### PR TITLE
Fix 0 package count in Slackware

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -574,7 +574,7 @@ getpackages () {
             elif type -p pacman >/dev/null 2>&1; then
                 packages="$(pacman -Qq --color never | wc -l)"
 
-            elif type -p pkgtool >/dev/null 2>&1; then
+            elif type -p /sbin/pkgtool >/dev/null 2>&1; then
                 packages="$(ls -1 /var/log/packages | wc -l)"
 
             elif type -p rpm >/dev/null 2>&1; then


### PR DESCRIPTION
Fixes #112.

Rationale:
- By default in Slackware, /sbin and /usr/sbin aren't part of the user's
  PATH. (It's been this way since I started using it in 2004, version
  9.1)
- `type -p /path/to/binary` works just like it was used with a bare
  binary name.