### PR TITLE
Fix help message text

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2310,7 +2310,7 @@ usage () { cat << EOF
     --ascii value               Where to get the ascii from, Possible values:
                                 distro, /path/to/ascii
     --ascii_color num           Color to print the ascii art
-    --ascii_distro distro       Which Distro\'s ascii art to print
+    --ascii_distro distro       Which Distro's ascii art to print
 
 
     Stdout:


### PR DESCRIPTION
Fixes `Which Distro\'s ascii art to print` in output when running `--help`. (Notice the backslash-quote.)

Caused by a rogue backslash in the heredoc.

Aside: I don't think Github's syntax highlighting is doing a good job here.