### PR TITLE
added tiny option to --gpu_shorthand

### DIFF
--- a/1.5.md
+++ b/1.5.md
@@ -11,10 +11,6 @@
 **Disk Usage**<br \>
 - Only display usage of local disks.
 
-**GPU**</br>
-- Add `tiny` option to shorten output of GPU even further.
-- Removes words 'Graphics', 'GeForce' and 'Radeon'
-
 ### Ascii
 
 - Kaos: Update ascii logo to the new logo.

--- a/1.5.md
+++ b/1.5.md
@@ -11,6 +11,10 @@
 **Disk Usage**<br \>
 - Only display usage of local disks.
 
+**GPU**</br>
+- Add `tiny` option to shorten output of GPU even further.
+- Removes words 'Graphics', 'GeForce' and 'Radeon'
+
 ### Ascii
 
 - Kaos: Update ascii logo to the new logo.

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ alias fetch2="fetch \
                                 NOTE: This only support Linux with cpufreq.
     --kernel_shorthand on/off   Shorten the output of kernel
     --uptime_shorthand on/off   Shorten the output of uptime (tiny, on, off)
-    --gpu_shorthand on/off      Shorten the output of GPU
+    --gpu_shorthand on/off      Shorten the output of GPU (tiny, on, off)
     --gtk_shorthand on/off      Shorten output of gtk theme/icons
     --gtk2 on/off               Enable/Disable gtk2 theme/icons output
     --gtk3 on/off               Enable/Disable gtk3 theme/icons output

--- a/config/config
+++ b/config/config
@@ -97,7 +97,7 @@ speed_type="max"
 # GPU
 
 # Shorten output of the getgpu funcion
-# --gpu_shorthand on/off
+# --gpu_shorthand on/off/tiny
 gpu_shorthand="on"
 
 

--- a/neofetch
+++ b/neofetch
@@ -117,7 +117,7 @@ speed_type="max"
 # GPU
 
 # Shorten output of the getgpu funcion
-# --gpu_shorthand on/off
+# --gpu_shorthand on/off/tiny
 gpu_shorthand="on"
 
 
@@ -972,17 +972,27 @@ getgpu () {
         ;;
     esac
 
-    if [ "$gpu_shorthand" == "on" ]; then
-        gpu=${gpu// Rev\. ?}
-        gpu=${gpu//AMD*\/ATI\]/AMD}
-        gpu=${gpu// Tahiti}
-        gpu=${gpu// PRO}
-        gpu=${gpu// OEM}
-        gpu=${gpu// Mars}
-        gpu=${gpu// Series}
-        gpu=${gpu// Controller}
-        gpu=${gpu/\/*}
-    fi
+    case "$gpu_shorthand" in
+        "on" | "tiny")
+            gpu=${gpu// Rev\. ?}
+            gpu=${gpu//AMD*\/ATI\]/AMD}
+            gpu=${gpu// Tahiti}
+            gpu=${gpu// PRO}
+            gpu=${gpu// OEM}
+            gpu=${gpu// Mars}
+            gpu=${gpu// Series}
+            gpu=${gpu// Controller}
+            gpu=${gpu/\/*}
+
+            case "$gpu_shorthand" in
+                "tiny")
+                    gpu=${gpu/Graphics }
+                    gpu=${gpu/GeForce }
+                    gpu=${gpu/Radeon }
+                ;;
+            esac
+        ;;
+    esac
 
     gpu="${gpu}${count}"
 }
@@ -2297,7 +2307,7 @@ usage () { cat << EOF
                                 NOTE: This only support Linux with cpufreq.
     --kernel_shorthand on/off   Shorten the output of kernel
     --uptime_shorthand on/off   Shorten the output of uptime (tiny, on, off)
-    --gpu_shorthand on/off      Shorten the output of GPU
+    --gpu_shorthand on/off      Shorten the output of GPU (tiny, on, off)
     --gtk_shorthand on/off      Shorten output of gtk theme/icons
     --gtk2 on/off               Enable/Disable gtk2 theme/icons output
     --gtk3 on/off               Enable/Disable gtk3 theme/icons output

--- a/neofetch.1
+++ b/neofetch.1
@@ -40,7 +40,7 @@ Shorten the output of kernel
 Shorten the output of uptime (tiny, on, off)
 .TP
 .B \--gpu_shorthand 'on/off'
-Shorten the output of GPU
+Shorten the output of GPU (tiny, on, off)
 .TP
 .B \--gtk_shorthand 'on/off'
 Shorten output of gtk theme/icons


### PR DESCRIPTION
removes 'Graphics', 'GeForce' and 'Radeon' from output

as I have intel and nvidia graphics in my system, i was finding the output was wrapping for me. this fixes it, thought i'd share it with `master`