### PR TITLE
fixed output of disk bar when gigabytes are used of a terabyte disk

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1507,13 +1507,11 @@ getdisk () {
     disk_used=${disk_used/G}
     disk_total=${disk_total/G}
 
-    if [[ "$disk_used" == *"T" ]]; then
+    [[ "$disk_used" == *"T" ]] && \
         disk_used=$(printf "%s\n" "${disk_used/T} * 1000" | bc)
-    fi
 
-    if [[ "$disk_total" == *"T" ]]; then
+    [[ "$disk_total" == *"T" ]] && \
         disk_total=$(printf "%s\n" "${disk_total/T} * 1000" | bc)
-    fi
 
     case "$disk_display" in
         "bar") disk="$(bar "${disk_used/'.'*}" "${disk_total/'.'*}")" ;;

--- a/neofetch
+++ b/neofetch
@@ -1508,14 +1508,12 @@ getdisk () {
     disk_total=${disk_total/G}
 
     if [[ "$disk_used" == *"T" ]]; then
-        disk_used=${disk_used/T}
-        disk_used=$(echo "${disk_used} * 1000" | bc)
+        disk_used=$(echo "${disk_used/T} * 1000" | bc)
         disk_used=${disk_used/'.'*}
     fi
 
     if [[ "$disk_total" == *"T" ]]; then
-        disk_total=${disk_total/T}
-        disk_total=$(echo "${disk_total} * 1000" | bc)
+        disk_total=$(echo "${disk_total/T} * 1000" | bc)
         disk_total=${disk_total/'.'*}
     fi
 

--- a/neofetch
+++ b/neofetch
@@ -1509,18 +1509,16 @@ getdisk () {
 
     if [[ "$disk_used" == *"T" ]]; then
         disk_used=$(printf "%s\n" "${disk_used/T} * 1000" | bc)
-        disk_used=${disk_used/'.'*}
     fi
 
     if [[ "$disk_total" == *"T" ]]; then
         disk_total=$(printf "%s\n" "${disk_total/T} * 1000" | bc)
-        disk_total=${disk_total/'.'*}
     fi
 
     case "$disk_display" in
-        "bar") disk="$(bar "${disk_used/'.'}" "${disk_total/'.'}")" ;;
-        "infobar") disk+=" $(bar "${disk_used/'.'}" "${disk_total/'.'}")" ;;
-        "barinfo") disk="$(bar "${disk_used/'.'}" "${disk_total/'.'}") $disk" ;;
+        "bar") disk="$(bar "${disk_used/'.'*}" "${disk_total/'.'*}")" ;;
+        "infobar") disk+=" $(bar "${disk_used/'.'*}" "${disk_total/'.'*}")" ;;
+        "barinfo") disk="$(bar "${disk_used/'.'*}" "${disk_total/'.'*}") $disk" ;;
     esac
 }
 

--- a/neofetch
+++ b/neofetch
@@ -1508,14 +1508,12 @@ getdisk () {
     disk_total=${disk_total/G}
 
     if [[ "$disk_used" == *"T" ]]; then
-        touch "terabyte_used"
         disk_used=${disk_used/T}
         disk_used=$(echo "${disk_used} * 1000" | bc)
         disk_used=${disk_used/'.'*}
     fi
 
     if [[ "$disk_total" == *"T" ]]; then
-        touch "terabyte_total"
         disk_total=${disk_total/T}
         disk_total=$(echo "${disk_total} * 1000" | bc)
         disk_total=${disk_total/'.'*}

--- a/neofetch
+++ b/neofetch
@@ -1505,9 +1505,21 @@ getdisk () {
 
     # Add info bar
     disk_used=${disk_used/G}
-    disk_used=${disk_used/T}
     disk_total=${disk_total/G}
-    disk_total=${disk_total/T}
+
+    if [[ "$disk_used" == *"T" ]]; then
+        touch "terabyte_used"
+        disk_used=${disk_used/T}
+        disk_used=$(echo "${disk_used} * 1000" | bc)
+        disk_used=${disk_used/'.'*}
+    fi
+
+    if [[ "$disk_total" == *"T" ]]; then
+        touch "terabyte_total"
+        disk_total=${disk_total/T}
+        disk_total=$(echo "${disk_total} * 1000" | bc)
+        disk_total=${disk_total/'.'*}
+    fi
 
     case "$disk_display" in
         "bar") disk="$(bar "${disk_used/'.'}" "${disk_total/'.'}")" ;;

--- a/neofetch
+++ b/neofetch
@@ -1508,12 +1508,12 @@ getdisk () {
     disk_total=${disk_total/G}
 
     if [[ "$disk_used" == *"T" ]]; then
-        disk_used=$(echo "${disk_used/T} * 1000" | bc)
+        disk_used=$(printf "%s\n" "${disk_used/T} * 1000" | bc)
         disk_used=${disk_used/'.'*}
     fi
 
     if [[ "$disk_total" == *"T" ]]; then
-        disk_total=$(echo "${disk_total/T} * 1000" | bc)
+        disk_total=$(printf "%s\n" "${disk_total/T} * 1000" | bc)
         disk_total=${disk_total/'.'*}
     fi
 


### PR DESCRIPTION
apparently bar doesn't like it when the first variable is bigger than the second, it went really haywyre.

to see old behaviour, set `disk_used` to `63` and `disk_total` to `3.1` (that's what my disk usage and disk total is, in gigabytes and terabytes respectively)