### PR TITLE
Fixed wallpaper error with nitrogen

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1796,7 +1796,7 @@ getwallpaper () {
                 img="$(awk -F\' '/feh/ {printf $2}' "$HOME/.fehbg")"
 
             elif type -p nitrogen >/dev/null 2>&1; then
-                img="$(awk -F'=' '/file/ {printf $2}' "$HOME/.config/nitrogen/bg-saved.cfg")"
+                img="$(awk -F'=' '/file/ {printf $2;exit;}' "$HOME/.config/nitrogen/bg-saved.cfg")"
 
             elif type -p gsettings >/dev/null 2>&1; then
                 case "$XDG_CURRENT_DESKTOP" in


### PR DESCRIPTION
Fixed the awk string to terminate after grabbing the first wallpaper found in nitrogen instead of mixing the two strings together and using the ascii art instead. In later revisions, there should be a way to check it's using the current monitor's wallpaper (I don't believe nitrogen orders them by usage, but rather by output).