### PR TITLE
Update CRUX distro name

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -457,7 +457,7 @@ case "$os" in
             distro=${distro/[[:space:]]}
 
         elif type -p crux >/dev/null 2>&1; then
-            distro="CRUX"
+            distro="$(crux)"
 
         else
             distro="$(grep -h '^NAME=' /etc/*ease)"


### PR DESCRIPTION
CRUX has a binary called crux that print the distro name and the version (CRUX version 3.2 for example).