### PR TITLE
display refresh rate after each monitor (optional)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ your distro's logo or any ascii art of your choice!
 
 - Wallpaper: `feh`, `nitrogen` or `gsettings`
 - Current Song: `mpc` or `cmus`
-- Resolution: `xorg-xdpyinfo`
+- Resolution: `xorg-xdpyinfo` or `xrandr`
 - Screenshot: `scrot` \[5\]
 
 

--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ alias fetch2="fetch \
     --kernel_shorthand on/off   Shorten the output of kernel
     --uptime_shorthand on/off   Shorten the output of uptime (tiny, on, off)
     --refresh_rate on/off       Whether to display the refresh rate of each monitor
+                                Unsupported on Windows
     --gpu_shorthand on/off      Shorten the output of GPU (tiny, on, off)
     --gtk_shorthand on/off      Shorten output of gtk theme/icons
     --gtk2 on/off               Enable/Disable gtk2 theme/icons output

--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ alias fetch2="fetch \
     --cpu_cores on/off          Whether or not to display the number of CPU cores
     --kernel_shorthand on/off   Shorten the output of kernel
     --uptime_shorthand on/off   Shorten the output of uptime (tiny, on, off)
+    --refresh_rate on/off       Whether to display the refresh rate of each monitor
     --gpu_shorthand on/off      Shorten the output of GPU (tiny, on, off)
     --gtk_shorthand on/off      Shorten output of gtk theme/icons
     --gtk2 on/off               Enable/Disable gtk2 theme/icons output

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ your distro's logo or any ascii art of your choice!
 
 - Wallpaper: `feh`, `nitrogen` or `gsettings`
 - Current Song: `mpc` or `cmus`
-- Resolution: `xorg-xdpyinfo` or `xrandr`
+- Resolution: `xorg-xdpyinfo`
 - Screenshot: `scrot` \[5\]
 
 

--- a/config/config
+++ b/config/config
@@ -115,6 +115,12 @@ cpu_cores="on"
 # --gpu_shorthand on/off/tiny
 gpu_shorthand="on"
 
+# Resolution
+
+# Display refresh rate next to each monitor
+# --refresh_rate on/off
+refresh_rate="off"
+
 
 # Gtk Theme / Icons
 

--- a/config/config
+++ b/config/config
@@ -118,6 +118,7 @@ gpu_shorthand="on"
 # Resolution
 
 # Display refresh rate next to each monitor
+# Unsupported on Windows
 # --refresh_rate on/off
 refresh_rate="off"
 

--- a/neofetch
+++ b/neofetch
@@ -136,6 +136,11 @@ cpu_cores="on"
 # --gpu_shorthand on/off/tiny
 gpu_shorthand="on"
 
+# Resolution
+
+# Display refresh rate next to each monitor
+# --refresh_rate on/off
+refresh_rate="off"
 
 # Gtk Theme / Icons
 
@@ -1273,8 +1278,16 @@ getresolution () {
         ;;
 
         "Mac OS X")
-            resolution=$(system_profiler SPDisplaysDataType |\
-                        awk '/Resolution:/ {printf $2"x"$4" "}')
+            case "$refresh_rate" in
+                "on")
+                    resolution=$(system_profiler SPDisplaysDataType |\
+                                awk '/Resolution:/ {printf $2"x"$4" @ "$6"Hz, "}')
+                ;;
+                "off")
+                    resolution=$(system_profiler SPDisplaysDataType |\
+                                awk '/Resolution:/ {printf $2"x"$4", "}')
+                ;;
+            esac
         ;;
 
         "Windows")
@@ -1293,6 +1306,8 @@ getresolution () {
             resolution="Unknown"
         ;;
     esac
+
+    resolution=${resolution%,*}
 }
 
 # }}}
@@ -2498,6 +2513,7 @@ usage () { cat << EOF
     --cpu_cores on/off          Whether or not to display the number of CPU cores
     --kernel_shorthand on/off   Shorten the output of kernel
     --uptime_shorthand on/off   Shorten the output of uptime (tiny, on, off)
+    --refresh_rate on/off       Whether to display the refresh rate of each monitor
     --gpu_shorthand on/off      Shorten the output of GPU (tiny, on, off)
     --gtk_shorthand on/off      Shorten output of gtk theme/icons
     --gtk2 on/off               Enable/Disable gtk2 theme/icons output
@@ -2617,6 +2633,7 @@ while [ "$1" ]; do
         --uptime_shorthand) uptime_shorthand="$2" ;;
         --cpu_shorthand) cpu_shorthand="$2" ;;
         --gpu_shorthand) gpu_shorthand="$2" ;;
+        --refresh_rate) refresh_rate="$2" ;;
         --gtk_shorthand) gtk_shorthand="$2" ;;
         --gtk2) gtk2="$2" ;;
         --gtk3) gtk3="$2" ;;

--- a/neofetch
+++ b/neofetch
@@ -139,6 +139,7 @@ gpu_shorthand="on"
 # Resolution
 
 # Display refresh rate next to each monitor
+# Unsupported on Windows
 # --refresh_rate on/off
 refresh_rate="off"
 
@@ -2522,6 +2523,7 @@ usage () { cat << EOF
     --kernel_shorthand on/off   Shorten the output of kernel
     --uptime_shorthand on/off   Shorten the output of uptime (tiny, on, off)
     --refresh_rate on/off       Whether to display the refresh rate of each monitor
+                                Unsupported on Windows
     --gpu_shorthand on/off      Shorten the output of GPU (tiny, on, off)
     --gtk_shorthand on/off      Shorten output of gtk theme/icons
     --gtk2 on/off               Enable/Disable gtk2 theme/icons output

--- a/neofetch
+++ b/neofetch
@@ -1273,8 +1273,11 @@ getsong () {
 getresolution () {
     case "$os" in
         "Linux" | *"BSD")
-            if type -p xrandr >/dev/null 2>&1 && [ "$refresh_rate" == "on" ]; then
-                resolution=$(xrandr --nograb --current | awk 'match($0,/[0-0]{2,3}.[0-9]{2}\*/) {printf $1 " @ " substr($0,RSTART,RLENGTH) "Hz, "}')
+            if type -p xrandr >/dev/null 2>&1; then
+                case "$refresh_rate" in
+                    "on") resolution=$(xrandr --nograb --current | awk 'match($0,/[0-0]{2,3}.[0-9]{2}\*/) {printf $1 " @ " substr($0,RSTART,RLENGTH) "Hz, "}') ;;
+                    "off") resolution=$(xrandr --nograb --current | awk '/*/ {printf $1 ", "}') ;;
+                esac 
                 resolution=${resolution//\*}
 
             elif type -p xdpyinfo >/dev/null 2>&1 && \

--- a/neofetch
+++ b/neofetch
@@ -1273,8 +1273,13 @@ getsong () {
 getresolution () {
     case "$os" in
         "Linux" | *"BSD")
-            type -p xdpyinfo >/dev/null 2>&1 && \
+            if type -p xrandr >/dev/null 2>&1; then
+                resolution=$(xrandr --nograb --current | awk 'match($0,/[0-0]{2,3}.[0-9]{2}\*/) {printf $1 " @ " substr($0,RSTART,RLENGTH) "Hz, "}')
+                resolution=${resolution//\*}
+
+            elif type -p xdpyinfo >/dev/null 2>&1 && \
                 resolution=$(xdpyinfo 2>/dev/null | awk '/dimensions:/ {printf $2}')
+            fi
         ;;
 
         "Mac OS X")

--- a/neofetch
+++ b/neofetch
@@ -1273,7 +1273,7 @@ getsong () {
 getresolution () {
     case "$os" in
         "Linux" | *"BSD")
-            if type -p xrandr >/dev/null 2>&1; then
+            if type -p xrandr >/dev/null 2>&1 && [ "$refresh_rate" == "on" ]; then
                 resolution=$(xrandr --nograb --current | awk 'match($0,/[0-0]{2,3}.[0-9]{2}\*/) {printf $1 " @ " substr($0,RSTART,RLENGTH) "Hz, "}')
                 resolution=${resolution//\*}
 

--- a/neofetch.1
+++ b/neofetch.1
@@ -52,6 +52,7 @@ Shorten the output of uptime (tiny, on, off)
 .TP
 .B \--refresh_rate 'on/off'
 Whether to display the refresh rate of each monitor
+Unsupported on Windows
 .TP
 .B \--gpu_shorthand 'on/off'
 Shorten the output of GPU (tiny, on, off)

--- a/neofetch.1
+++ b/neofetch.1
@@ -50,6 +50,9 @@ Shorten the output of kernel
 .B \--uptime_shorthand 'on/off'
 Shorten the output of uptime (tiny, on, off)
 .TP
+.B \--refresh_rate 'on/off'
+Whether to display the refresh rate of each monitor
+.TP
 .B \--gpu_shorthand 'on/off'
 Shorten the output of GPU (tiny, on, off)
 .TP


### PR DESCRIPTION
Display refresh rate with `--refresh_rate on`

TODO:

- [x] Linux/BSD support
- [ ] Windows support

This closes **#159**