### PR TITLE
fix for mpc detection

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1192,7 +1192,7 @@ getmemory () {
 # Song {{{
 
 getsong () {
-    if pgrep "mpd" >/dev/null 2>&1; then
+    if hash "mpc" >/dev/null 2>&1; then
         song="$(mpc current 2>/dev/null)"
         state=$(mpc | awk -F '\\[|\\]' '/\[/ {printf $2}' 2>/dev/null)
 

--- a/neofetch
+++ b/neofetch
@@ -1192,7 +1192,7 @@ getmemory () {
 # Song {{{
 
 getsong () {
-    if hash "mpc" >/dev/null 2>&1; then
+    if mpc version >/dev/null 2>&1; then
         song="$(mpc current 2>/dev/null)"
         state=$(mpc | awk -F '\\[|\\]' '/\[/ {printf $2}' 2>/dev/null)
 


### PR DESCRIPTION
In my case your `if pgrep "mpd" >/dev/null 2>&1` is not working because i'm using mpd on server and mpc on my laptop, so i don't have mpd on it and `pgrep` is failing. I think it is better to search for mpc than for mpd in this `if`