### PR TITLE
Remove shuffledir in favor of '--image path/to/dir/'

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,13 +284,15 @@ alias fetch2="fetch \
 ## Usage
 
 
-    usage: fetch --option "value" --option "value"
+    usage: neofetch --option "value" --option "value"
+
+    NOTE: There's also a config option for each flag below.
 
     Info:
     --disable infoname          Allows you to disable an info line from appearing
                                 in the output.
                                 NOTE: You can supply multiple args. eg.
-                                'fetch --disable cpu gpu disk shell'
+                                'neofetch --disable cpu gpu disk shell'
     --osx_buildversion on/off   Hide/Show Mac OS X build version.
     --osx_codename on/off       Hide/Show Mac OS X codename.
     --os_arch on/off            Hide/Show Windows architecture.
@@ -337,8 +339,8 @@ alias fetch2="fetch \
     Progress Bars:
     --progress_char char        Character to use when drawing progress bars.
     --progress_length num       Length in spaces to make the progress bars.
-    --progress_colors num num   Colors to make the progress bar. Set in this order:
-                                elapsed, total
+    --progress_colors num num   Colors to make the progress bar.
+                                Set in this order: elapsed, total
     --cpu_display mode1 mode2   Which shorthand to use and how CPU usage should be printed
                                 mode1 takes: name, speed, tiny, on, off
                                 mode2 takes: info, bar, infobar, barinfo
@@ -352,11 +354,10 @@ alias fetch2="fetch \
 
     Image:
     --image type                Image source. Where and what image we display.
-                                Possible values: wall, shuffle, ascii,
-                                /path/to/img, off
+                                Possible values: wall, ascii,
+                                /path/to/img, /path/to/dir/, off
     --size 20px | --size 20%    Size to make the image, takes pixels or a percentage.
     --image_backend w3m/iterm2  Which program to use to draw images.
-    --shuffle_dir path/to/dir   Which directory to shuffle for an image.
     --image_position left/right Where to display the image: (Left/Right)
     --crop_mode mode            Which crop mode to use
                                 Takes the values: normal, fit, fill
@@ -378,11 +379,11 @@ alias fetch2="fetch \
     --ascii value               Where to get the ascii from, Possible values:
                                 distro, /path/to/ascii
     --ascii_colors x x x x x x  Colors to print the ascii art
-    --ascii_distro distro       Which Distro\'s ascii art to print
+    --ascii_distro distro       Which Distro's ascii art to print
 
 
     Stdout:
-    --stdout info info          Launch fetch in stdout mode which prints the info
+    --stdout info info          Launch neofetch in stdout mode which prints the info
                                 in a plain-text format that you can use with
                                 lemonbar etc.
     --stdout_separator string   String to use as a separator in stdout mode.
@@ -392,6 +393,7 @@ alias fetch2="fetch \
     --scrot /path/to/img        Take a screenshot, if path is left empty the screen-
                                 shot function will use \$scrot_dir and \$scrot_name.
     --scrot_cmd cmd             Screenshot program to launch
+
 
     Other:
     --config /path/to/config    Specify a path to a custom config file

--- a/config/config
+++ b/config/config
@@ -274,7 +274,7 @@ disk_display="off"
 
 
 # Image Source
-# --image wall, shuffle, ascii, /path/to/img, off
+# --image wall, ascii, /path/to/img, /path/to/dir/, off
 image="wall"
 
 # Thumbnail directory
@@ -293,9 +293,6 @@ w3m_img_path="/usr/lib/w3m/w3mimgdisplay"
 # Only works with the w3m backend
 # --image_position left/right
 image_position="left"
-
-# Shuffle dir
-shuffle_dir="$HOME/Pictures/wallpapers/wash"
 
 # Crop mode
 # --crop_mode normal/fit/fill

--- a/neofetch
+++ b/neofetch
@@ -295,7 +295,7 @@ disk_display="off"
 
 
 # Image Source
-# --image wall, shuffle, ascii, /path/to/img, off
+# --image wall, ascii, /path/to/img, /path/to/dir/, off
 image="wall"
 
 # Thumbnail directory
@@ -314,9 +314,6 @@ w3m_img_path="/usr/lib/w3m/w3mimgdisplay"
 # Only works with the w3m backend
 # --image_position left/right
 image_position="left"
-
-# Shuffle dir
-shuffle_dir="$HOME/Pictures/wallpapers/wash"
 
 # Crop mode
 # --crop_mode normal/fit/fill
@@ -1923,9 +1920,14 @@ getimage () {
 
     case "$image" in
         "wall") getwallpaper ;;
-        "shuffle") img="$(find "$shuffle_dir" -type f \( -name '*.jpg' -o -name '*.png' \) -print0 | shuf -n1 -z)" ;;
         "ascii") getascii; return ;;
-        *) img="$image" ;;
+        *)
+            if [ "${image: -1}" == "/" ]; then
+                img="$(find "$image" -type f \( -name '*.jpg' -o -name '*.png' \) -print0 | shuf -n1 -z)"
+            else
+                img="$image"
+            fi
+        ;;
     esac
 
     # Get terminal width and height
@@ -2553,11 +2555,10 @@ usage () { cat << EOF
 
     Image:
     --image type                Image source. Where and what image we display.
-                                Possible values: wall, shuffle, ascii,
-                                /path/to/img, off
+                                Possible values: wall, ascii,
+                                /path/to/img, /path/to/dir/, off
     --size 20px | --size 20%    Size to make the image, takes pixels or a percentage.
     --image_backend w3m/iterm2  Which program to use to draw images.
-    --shuffle_dir path/to/dir   Which directory to shuffle for an image.
     --image_position left/right Where to display the image: (Left/Right)
     --crop_mode mode            Which crop mode to use
                                 Takes the values: normal, fit, fill
@@ -2692,7 +2693,6 @@ while [ "$1" ]; do
 
         --size) image_size="$2" ;;
         --image_backend) image_backend="$2" ;;
-        --shuffle_dir) shuffle_dir="$2" ;;
         --image_position) image_position="$2" ;;
         --crop_mode) crop_mode="$2" ;;
         --crop_offset) crop_offset="$2" ;;

--- a/neofetch
+++ b/neofetch
@@ -1923,7 +1923,8 @@ getimage () {
         "ascii") getascii; return ;;
         *)
             if [ "${image: -1}" == "/" ]; then
-                img="$(find "$image" -type f \( -name '*.jpg' -o -name '*.png' \) -print0 | shuf -n1 -z)"
+                files=("$image"*.png "$image"*.jpg)
+                img="$(printf "%s" "${files[RANDOM % ${#files[@]}]}")"
             else
                 img="$image"
             fi

--- a/neofetch.1
+++ b/neofetch.1
@@ -158,16 +158,13 @@ Takes: bar, infobar, barinfo
 .B \--image 'type'
 Image source. Where and what image we display.
 .br
-Possible values: wall, shuffle, ascii, /path/to/img, off
+Possible values: wall, ascii, /path/to/img, /path/to/dir/, off
 .TP
 .B \--size 'size'
 Size to make the image, takes pixels or a percentage.
 .TP
 .B \--image_backend 'w3m/iterm2'
 Which program to use to draw images.
-.TP
-.B \--shuffle_dir 'path'
-Which directory to shuffle for an image.
 .TP
 .B \--image_position 'left/right'
 Where to display the image: (Left/Right)


### PR DESCRIPTION
This PR removes the shuffle mode and all the config options and flags that came with it and replaces it with `--image path/to/dir/` and `image="path/to/dir/"` instead. 

- This will hopefully clear up the confusion in issue **#169**.
- You can set the default shuffle dir in the config by changing `$image` to a directory path.
- The value **must** end in a `/`.

TODO

- [x] ~~Update the Man page~~
- [x] ~~Update the Readme~~

I'd like to get some confirmation that this works on other platforms before I merge this to master.

cc @misterch0c @iandrewt 