### PR TITLE
Rewrite memory function to work on older linux kernel versions.

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1112,17 +1112,9 @@ getgpu () {
 getmemory () {
     case "$os" in
         "Linux")
-            # Read first 3 lines
-            mem=$(awk -F ':' '/MemTotal|MemAvailable/ {printf $2}' /proc/meminfo )
-
-            # Do some substitution on each line
-            memtotal=${mem/kB*/kB}
-            memavail=${mem/${memtotal}}
-            memtotal=${memtotal/kB*}
-            memavail=${memavail/kB*}
-
-            memused=$((memtotal - memavail))
-            memory="$((memused / 1024))MB / $((memtotal / 1024))MB"
+            mem=($(awk -F ':| kB' '/MemTotal|MemFree|Buffers|Cached/ {printf $2}' /proc/meminfo ))
+            memused=$((${mem[0]} - ${mem[1]} - ${mem[2]} - ${mem[3]}))
+            memory="$((memused / 1024))MB / $((${mem[0]} / 1024))MB"
         ;;
 
         "Mac OS X")


### PR DESCRIPTION
This rewrite makes the memory function work on old linux kernel versions while also reducing the size of the function to 3 lines.

- This fixes the issue inside  **#152**

cc @joshbenham 