### PR TITLE
fixed if statement for linux resolution

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1285,7 +1285,7 @@ getresolution () {
                 esac 
                 resolution=${resolution//\*}
 
-            elif type -p xdpyinfo >/dev/null 2>&1 && \
+            elif type -p xdpyinfo >/dev/null 2>&1; then
                 resolution=$(xdpyinfo 2>/dev/null | awk '/dimensions:/ {printf $2}')
             fi
         ;;


### PR DESCRIPTION
the `&& \` method doesn't work with `elif`s it seems. breaks the script on OS X even though that block of code never fires.