### PR TITLE
Info function cleanup

### DIFF
--- a/1.6.md
+++ b/1.6.md
@@ -14,8 +14,11 @@ Thanks to the following people for contributing this release.
 - Fixed buggy colors in older versions of \*BSD, OS X and Linux.
 - Added Travis CI support.
 - Added `--test` which prints all functions.
+- Cleanup of Distro, Uptime and CPU functions.
 
 ### Info
+
+- Functions now no longer print `Unknown` when they fail, they now don't appear at all.
 
 **OS**<br \>
 - [ CRUX ] Also print the CRUX version. **[@onodera-punpun](https://github.com/onodera-punpun)**
@@ -23,6 +26,7 @@ Thanks to the following people for contributing this release.
 **CPU**<br \>
 - [ Windows ] Don't print CPU cores if detection fails.
 - [ BSD ] Fixed extremely long output.
+- Fixed broken CPU speed when source is `/proc/cpuinfo`.
 
 **GPU**<br \>
 - Don't show GPU output on unsupported OS.
@@ -40,10 +44,12 @@ Thanks to the following people for contributing this release.
 
 **Song**<br \>
 - [ MPD ] Fixed function when mpd is running on another PC and not your own.
+- Song now displays `Not Playing` instead of `Unknown` when no music player is found.
 - Added support for Google Play Music Desktop Player (adds optional dependency of [`gpmdp-bash`](https://github.com/iandrewt/gpmdp-bash)) **[@iandrewt](https://github.com/iandrewt)**
 
 **Disk**<br \>
 - Added new display option `perc` to display just the percentage with the progress bar.
+- Fixed disk usage not working on FreeBSD.
 
 **Memory**<br \>
 - [ OpenBSD ] Fixed completely broken memory output on OpenBSD.
@@ -67,6 +73,7 @@ Thanks to the following people for contributing this release.
 - Added ascii art for Qubes OS.
 - Added ascii art for Travis CI.
 - Revamped Alpine Linux's ascii art.
+- Fixed missing ascii colors for Puppy Linux.
 - [ OSX ] Fixed incorrect text colors.
 
 

--- a/neofetch
+++ b/neofetch
@@ -2329,6 +2329,11 @@ colors () {
             setcolors 4 7 1
         ;;
 
+        "Puppy"* | "Quirky Werewolf"* | "Precise Puppy"*)
+            setcolors 4
+            ascii_distro="puppy"
+        ;;
+
         "Scientific"*)
             setcolors 4 1 7
         ;;

--- a/neofetch
+++ b/neofetch
@@ -840,7 +840,7 @@ getcpu () {
 
         "Mac OS X")
             cpu="$(sysctl -n machdep.cpu.brand_string)"
-            cpu=${cpu//    }
+            cpu=${cpu//  }
             cores=$(sysctl -n hw.ncpu)
         ;;
 

--- a/neofetch
+++ b/neofetch
@@ -840,7 +840,6 @@ getcpu () {
         "Mac OS X")
             cpu="$(sysctl -n machdep.cpu.brand_string)"
             cpu=${cpu//  }
-            cpu=${cpu/  @ / @ }
             cores=$(sysctl -n hw.ncpu)
         ;;
 

--- a/neofetch
+++ b/neofetch
@@ -1574,8 +1574,6 @@ getbattery () {
                     fi
                     battery="${batteries[0]}%"
                 fi
-            else
-                battery="None"
             fi
         ;;
 

--- a/neofetch
+++ b/neofetch
@@ -819,11 +819,7 @@ getcpu () {
     case "$os" in
         "Linux")
             # Get cpu name
-            cpu="$(grep -F 'model name' /proc/cpuinfo)"
-            cpu=${cpu/model name*: }
-            cpu=${cpu/ @*}
-            cpu=${cpu//  }
-            cpu=${cpu%% }
+            cpu="$(awk -F ': | @' '/model name/ {printf $2; exit}' /proc/cpuinfo)"
 
             # Get cpu speed
             if [ -d "/sys/devices/system/cpu/cpu0/cpufreq" ]; then
@@ -841,8 +837,7 @@ getcpu () {
                     /sys/devices/system/cpu/cpu0/cpufreq/${speed_type}
 
             else
-                speed=$(awk -F ': ' '/cpu MHz/ {printf $2; exit}' /proc/cpuinfo)
-                speed=${speed/\.}
+                speed=$(awk -F ': |\\.' '/cpu MHz/ {printf $2; exit}' /proc/cpuinfo)
             fi
 
             # Convert mhz to ghz without bc

--- a/neofetch
+++ b/neofetch
@@ -839,7 +839,7 @@ getcpu () {
 
         "Mac OS X")
             cpu="$(sysctl -n machdep.cpu.brand_string)"
-            cpu=${cpu//  }
+            cpu=${cpu/    }
             cores=$(sysctl -n hw.ncpu)
         ;;
 

--- a/neofetch
+++ b/neofetch
@@ -456,21 +456,18 @@ x32="x86"
 case "$os" in
     "Linux" )
         if type -p lsb_release >/dev/null 2>&1; then
-            distro="$(lsb_release -d 2>/dev/null | awk -F':' '/Description/ {printf $2}')"
+            distro="$(lsb_release -d 2>/dev/null | awk -F ':' '/Description/ {printf $2}')"
             distro=${distro/[[:space:]]}
 
         elif type -p crux >/dev/null 2>&1; then
             distro="$(crux)"
 
         else
-            distro="$(grep -h '^NAME=' /etc/*ease)"
+            distro="$(awk -F 'NAME="|"' '/^NAME=/ {printf $2}' /etc/*ease)"
 
             # Workaround for distros that store the value differently.
-            [ -z "$distro" ] && distro="$(grep -h 'TAILS_PRODUCT_NAME' /etc/*ease)"
+            [ -z "$distro" ] && distro="$(awk -F 'TAILS_PRODUCT_NAME="|"' '/^TAILS_PRODUCT_NAME=/ {printf $2}' /etc/*ease)"
             [ -z "$distro" ] && distro="$(awk '/BLAG/ {print $1; exit}' /etc/*ease)"
-
-            distro=${distro/*NAME\=}
-            distro=${distro//\"}
         fi
     ;;
 

--- a/neofetch
+++ b/neofetch
@@ -826,12 +826,11 @@ getcpu () {
                 read -r speed < \
                     /sys/devices/system/cpu/cpu0/cpufreq/${speed_type}
 
+                speed=$((speed / 100000))
             else
                 speed=$(awk -F ': |\\.' '/cpu MHz/ {printf $2; exit}' /proc/cpuinfo)
+                speed=$((speed / 100))
             fi
-
-            # Convert mhz to ghz without bc
-            speed=$((speed / 100000))
             speed=${speed:0:1}.${speed:1}
 
             cpu="$cpu @ ${speed}GHz"
@@ -903,7 +902,7 @@ getcpu () {
 
     # Add cpu cores to output
     [ "$cpu_cores" == "on" ] && [ ! -z "$cores" ] && \
-        cpu=${cpu/ @/ \(${cores}\) @}
+        cpu=${cpu/@/\(${cores}\) @}
 
     # Make the output of cpu shorter
     case "$cpu_shorthand" in

--- a/neofetch
+++ b/neofetch
@@ -839,6 +839,7 @@ getcpu () {
 
         "Mac OS X")
             cpu="$(sysctl -n machdep.cpu.brand_string)"
+            echo "$cpu"
             cpu=${cpu/    }
             cores=$(sysctl -n hw.ncpu)
         ;;

--- a/neofetch
+++ b/neofetch
@@ -511,10 +511,6 @@ case "$os" in
         x64="64-bit"
         x32="32-bit"
     ;;
-
-    *)
-        distro="Unknown"
-    ;;
 esac
 ascii_distro="$distro"
 
@@ -608,10 +604,6 @@ getuptime () {
             fi
 
             uptime="up $uptime"
-        ;;
-
-        *)
-            uptime="Unknown"
         ;;
     esac
 
@@ -732,8 +724,6 @@ getpackages () {
         ;;
     esac
     packages=${packages// }
-
-    [ -z "$packages" ] && packages="Unknown"
 }
 
 # }}}
@@ -897,10 +887,6 @@ getcpu () {
             speed=${speed:0:1}.${speed:1}
             cpu="$cpu @ ${speed}GHz"
         ;;
-
-        *)
-            cpu="Unknown"
-        ;;
     esac
 
     # Remove uneeded patterns from cpu output
@@ -969,7 +955,8 @@ getgpu () {
             # If a GPU with a prefix of '3D' doesn't exist
             # fallback to looking for a prefix of 'VGA'
             [ -z "$gpu" ] && \
-            gpu="$(PATH="/sbin:$PATH" lspci | grep -F "VGA")"
+                gpu="$(PATH="/sbin:$PATH" lspci | grep -F "VGA")"
+
             gpu=${gpu//??':'??'.'?}
 
             # Count the number of GPUs
@@ -1166,10 +1153,6 @@ getmemory () {
             memory="$((${memused%% *} / 1024))MB / "
             memory+="$((${memtotal%% *} / 1024))MB"
         ;;
-
-        *)
-            memory="Unknown"
-        ;;
     esac
 
     # Progress bars
@@ -1230,7 +1213,7 @@ getsong () {
         state="$(osascript -e 'tell application "iTunes" to player state as string')"
 
     else
-        song="Unknown"
+        song="Not Playing"
     fi
 
     case "$state" in
@@ -1301,10 +1284,6 @@ getresolution () {
 
             [ ! -z "$width" ] && \
                 resolution="${width}x${height}"
-        ;;
-
-        "*")
-            resolution="Unknown"
         ;;
     esac
 
@@ -1515,9 +1494,8 @@ getdisk () {
         "Mac OS X") df_flags="-H / -l" ;;
 
         *"BSD")
-            case "$os" in
-                "FreeBSD") df_flags="-h -c -l" ;;
-                *) disk="Unknown"; return ;;
+            case "$distro" in
+                "FreeBSD"*) df_flags="-h -c -l" ;;
             esac
         ;;
     esac
@@ -1673,10 +1651,6 @@ getlocalip () {
         "Windows")
             localip="$(ipconfig | awk -F ': ' '/IPv4 Address/ {printf $2}')"
         ;;
-
-        *)
-            localip="Unknown"
-        ;;
     esac
 }
 
@@ -1689,9 +1663,6 @@ getpublicip () {
 
     elif type -p wget >/dev/null 2>&1; then
         publicip="$(wget -qO- "$public_ip_host"; printf "%s")"
-
-    else
-        publicip="Unknown"
     fi
 }
 
@@ -1751,10 +1722,6 @@ getbirthday () {
                     birthday="$(ls -alctT /etc/defaults/rc.conf | awk '{printf $6 " " $7 " " $9 " " $8}')"
                     birthday_shorthand="on"
                 ;;
-
-                *)
-                    birthday="Unknown"
-                ;;
             esac
         ;;
 
@@ -1762,11 +1729,6 @@ getbirthday () {
             birthday="$(ls -alct --full-time /cygdrive/c/Windows/explorer.exe | awk '{printf $8 " " $9}')"
             date_cmd="$(date -d"$birthday" +"$birthday_format")"
         ;;
-
-        *)
-            birthday="Unknown"
-        ;;
-
     esac
 
     # Strip seconds from time output

--- a/neofetch
+++ b/neofetch
@@ -554,9 +554,9 @@ getkernel() {
 
 getuptime () {
     case "$os" in
-        "Linux")
+        "Linux" | "Windows")
             case "$distro" in
-                "Puppy Linux"* | "Quirky Werewolf"* | "Precise Puppy"* | "Alpine Linux"*)
+                *"Puppy"* | "Quirky Werewolf"* | "Alpine Linux"* | "Windows"*)
                     uptime=$(uptime | awk -F ':[0-9]{2}+ |(, ){1}+' '{printf $2}')
                     uptime=${uptime/  / }
                 ;;
@@ -608,11 +608,6 @@ getuptime () {
             fi
 
             uptime="up $uptime"
-        ;;
-
-        "Windows")
-            uptime=$(uptime | awk -F ':[0-9]{2}+ |(, ){1}+' '{printf $2}')
-            uptime=${uptime/  / }
         ;;
 
         *)

--- a/neofetch
+++ b/neofetch
@@ -839,8 +839,8 @@ getcpu () {
 
         "Mac OS X")
             cpu="$(sysctl -n machdep.cpu.brand_string)"
-            echo "$cpu"
-            cpu=${cpu/    }
+            cpu=${cpu//  }
+            cpu=${cpu/  @ / @ }
             cores=$(sysctl -n hw.ncpu)
         ;;
 

--- a/neofetch
+++ b/neofetch
@@ -903,7 +903,7 @@ getcpu () {
 
     # Add cpu cores to output
     [ "$cpu_cores" == "on" ] && [ ! -z "$cores" ] && \
-        cpu=${cpu/@/\(${cores}\) @}
+        cpu=${cpu/ @/ \(${cores}\) @}
 
     # Make the output of cpu shorter
     case "$cpu_shorthand" in

--- a/neofetch
+++ b/neofetch
@@ -840,7 +840,7 @@ getcpu () {
 
         "Mac OS X")
             cpu="$(sysctl -n machdep.cpu.brand_string)"
-            cpu=${cpu/    }
+            cpu=${cpu//    }
             cores=$(sysctl -n hw.ncpu)
         ;;
 


### PR DESCRIPTION
This PR aims to cleanup all of the info functions, reduce the amount of space they take up and hopefully speed things up as a bonus.

Functions cleaned up so far:

- Distro
- Uptime
- CPU

Issues fixed:

- Missing ascii colors for `Puppy Linux`.
- Fixed disk usage not working on `FreeBSD`.
- Fixed broken CPU speed when using `/proc/cpuinfo` instead of `/sys/`.

Changes: 

- Functions now no longer print `Unknown` when they fail, they now don't print anything.
- `Song` now displays `Not Playing` instead of `Unknown` when no music player is found.
