### PR TITLE
Use $GTK2_RC_FILES for GTK2 config if set

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1412,8 +1412,8 @@ getstyle () {
 
         # Check for gtk2 theme
         if [ -z "$gtk2theme" ]; then
-            if [ -f "$HOME/.gtkrc-2.0" ]; then
-                gtk2theme=$(grep "^[^#]*$name" "$HOME/.gtkrc-2.0")
+            if [ -f "${GTK2_RC_FILES:-$HOME/.gtkrc-2.0}" ]; then
+                gtk2theme=$(grep "^[^#]*$name" "${GTK2_RC_FILES:-$HOME/.gtkrc-2.0}")
 
             elif [ -f "/usr/share/gtk-2.0/gtkrc" ]; then
                 gtk2theme=$(grep "^[^#]*$name" /usr/share/gtk-2.0/gtkrc)


### PR DESCRIPTION
I export GTK2_RC_FILES to $XDG_CONFIG_HOME/gtk-2.0/gtkrc (as specified in the [Arch wiki](https://wiki.archlinux.org/index.php/XDG_Base_Directory_support)) to help keep my home folder clean.

This way neofetch uses GTK2_RC_FILES if it is set, and the default location if it is not.