### PR TITLE
Use extglob to reduce large blocks of substitutions to single lines.

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -505,10 +505,8 @@ case "$os" in
         distro="$(wmic os get Caption /value)"
 
         # Strip crap from the output of wmic
-        distro=${distro/Caption'='}
+        distro=${distro//*(Caption'='|  |Microsoft )}
         distro=${distro//[[:space:]]/ }
-        distro=${distro//  }
-        distro=${distro/Microsoft }
 
         # Change bits to xx-bit for Windows
         x64="64-bit"
@@ -574,8 +572,7 @@ getuptime () {
         "Mac OS X" | *"BSD")
             # Get boot time in seconds
             boot="$(sysctl -n kern.boottime)"
-            boot="${boot/'{ sec = '}"
-            boot=${boot/,*}
+            boot="${boot/*('{ sec = '|,*)}"
 
             # Get current date in seconds
             now=$(date +%s)
@@ -612,24 +609,18 @@ getuptime () {
     # Make the output of uptime smaller.
     case "$uptime_shorthand" in
         "on")
-            uptime=${uptime/up}
+            uptime=${uptime/up }
             uptime=${uptime/minutes/mins}
             uptime=${uptime/minute/min}
             uptime=${uptime/seconds/secs}
-            uptime=${uptime# }
         ;;
 
         "tiny")
-            uptime=${uptime/up}
-            uptime=${uptime/ days/d}
-            uptime=${uptime/ day/d}
-            uptime=${uptime/ hours/h}
-            uptime=${uptime/ hour/h}
-            uptime=${uptime/ minutes/m}
-            uptime=${uptime/ minute/m}
-            uptime=${uptime/ seconds/s}
-            uptime=${uptime/,}
-            uptime=${uptime# }
+            uptime=${uptime//*(up |,)}
+            uptime=${uptime// day[s]/d}
+            uptime=${uptime// hour[s]/h}
+            uptime=${uptime// minute[s]/m}
+            uptime=${uptime// seconds/s}
         ;;
     esac
     uptime=${uptime//+( )/ }

--- a/neofetch
+++ b/neofetch
@@ -880,7 +880,9 @@ getcpu () {
     esac
 
     # Remove uneeded patterns from cpu output
-    cpu=${cpu//*('(tm)'|'(r)'|CPU|Processor|Six-Core|Eight-Core|with Radeon HD Graphics)}
+    cpu=${cpu//*(CPU|Processor|Six-Core|Eight-Core|with Radeon HD Graphics)}
+    cpu=${cpu/'(r)'}
+    cpu=${cpu/'(tm)'}
 
     # Add cpu cores to output
     [ "$cpu_cores" == "on" ] && [ ! -z "$cores" ] && \

--- a/neofetch
+++ b/neofetch
@@ -892,7 +892,8 @@ getcpu () {
         "speed") cpu=${cpu#*@ } ;;
 
         "on" | "tiny")
-            cpu=${cpu//*(Intel |Core |Core? Duo |AMD )}
+            cpu=${cpu//*(Intel |Core |AMD )}
+            cpu=${cpu/Core? Duo}
 
             case "$cpu_shorthand" in
                 "tiny") cpu=${cpu/@*} ;;

--- a/neofetch
+++ b/neofetch
@@ -572,7 +572,8 @@ getuptime () {
         "Mac OS X" | *"BSD")
             # Get boot time in seconds
             boot="$(sysctl -n kern.boottime)"
-            boot="${boot/*('{ sec = '|,*)}"
+            boot=${boot/'{ sec = '}
+            boot=${boot/,*}
 
             # Get current date in seconds
             now=$(date +%s)

--- a/neofetch
+++ b/neofetch
@@ -29,6 +29,9 @@ SYS_LOCALE="$LANG"
 export LC_ALL=C
 export LANG=C
 
+# Set no case match and extended globbing.
+shopt -s extglob nocasematch
+
 
 # Config Options {{{
 
@@ -432,11 +435,6 @@ config_file="$HOME/.config/neofetch/config"
 
 
 # Gather Info {{{
-
-
-# Set no case match and extended globbing.
-shopt -s nocasematch
-shopt -s extglob
 
 
 # Operating System {{{
@@ -908,13 +906,8 @@ getcpu () {
 
     # Make the output of cpu shorter
     case "$cpu_shorthand" in
-        "name")
-            cpu=${cpu/@*}
-        ;;
-
-        "speed")
-            cpu=${cpu#*@ }
-        ;;
+        "name") cpu=${cpu/@*} ;;
+        "speed") cpu=${cpu#*@ } ;;
 
         "on" | "tiny")
             cpu=${cpu/Intel }
@@ -952,8 +945,8 @@ getcpu () {
 # GPU {{{
 
 getgpu () {
-   case "$os" in
-       "Linux")
+    case "$os" in
+        "Linux")
             gpu="$(PATH="/sbin:$PATH" lspci | grep -F "3D")"
 
             # If a GPU with a prefix of '3D' doesn't exist
@@ -984,43 +977,19 @@ getgpu () {
 
             case "$gpu" in
                 intel*)
-                    gpu=${gpu/Intel Corporation }
-                    gpu=${gpu/Haswell-??? }
-                    gpu=${gpu/?th Gen }
-                    gpu=${gpu/Core }
-                    gpu=${gpu/Processor }
-                    gpu=${gpu/ Mobile}
-                    gpu=${gpu/ Express}
-                    gpu=${gpu/ Controller}
-                    gpu=${gpu/Sky }
-                    gpu=${gpu/Lake }
-
+                    gpu=${gpu//*(Intel Corporation |Haswell-??? |?th Gen |Core |Processor |\
+                                Mobile |Express |Controller |Sky |Lake )}
                     brand="Intel "
                 ;;
 
                 advanced*)
-                    gpu=${gpu/Advanced Micro Devices, Inc\. }
-                    gpu=${gpu/'[AMD/ATI]' }
-                    gpu=${gpu/Tahiti PRO}
-                    gpu=${gpu/Seymour}
-                    gpu=${gpu/Richland}
-                    gpu=${gpu/Pitcairn}
-                    gpu=${gpu/Hawaii}
-                    gpu=${gpu/ OEM}
-                    gpu=${gpu/ Cape Verde}
-                    gpu=${gpu/ \[}
-                    gpu=${gpu/\]}
-
+                    gpu=${gpu//*(Advanced Micro Devices, Inc.|'[AMD/ATI]'|Tahiti PRO|Seymour|\
+                                Richland|Pitcairn|Hawaii| OEM| Cape Verde)}
                     brand="AMD "
                 ;;
 
                 nvidia*)
-                    gpu=${gpu/NVIDIA Corporation }
-                    gpu=${gpu/G????M }
-                    gpu=${gpu/G???? }
-                    gpu=${gpu/\[}
-                    gpu=${gpu/\] }
-
+                    gpu=${gpu//*(NVIDIA Corporation |G????M |G???? )}
                     brand="NVIDIA "
                 ;;
 
@@ -1059,22 +1028,11 @@ getgpu () {
 
     case "$gpu_shorthand" in
         "on" | "tiny")
-            gpu=${gpu// Rev\. ?}
+            gpu=${gpu//*( Rev . ?| PRO| OEM| Mars| Series| Controller|\/*|\[|\])}
             gpu=${gpu//AMD*\/ATI\]/AMD}
-            gpu=${gpu// Tahiti}
-            gpu=${gpu// PRO}
-            gpu=${gpu// OEM}
-            gpu=${gpu// Mars}
-            gpu=${gpu// Series}
-            gpu=${gpu// Controller}
-            gpu=${gpu/\/*}
 
             case "$gpu_shorthand" in
-                "tiny")
-                    gpu=${gpu/Graphics }
-                    gpu=${gpu/GeForce }
-                    gpu=${gpu/Radeon }
-                ;;
+                "tiny") gpu=${gpu//*(Graphics |Geforce |Radeon )} ;;
             esac
         ;;
     esac

--- a/neofetch
+++ b/neofetch
@@ -750,8 +750,7 @@ getshell () {
 
             *"tcsh"* | *"csh"*)
                 shell+="$("$SHELL" --version)"
-                shell=${shell/tcsh}
-                shell=${shell/\(*}
+                shell=${shell//*(tcsh|\(*)}
             ;;
         esac
 
@@ -880,16 +879,7 @@ getcpu () {
     esac
 
     # Remove uneeded patterns from cpu output
-    # This is faster than sed/gsub
-    cpu=${cpu//(tm)}
-    cpu=${cpu//(TM)}
-    cpu=${cpu//(r)}
-    cpu=${cpu//(R)}
-    cpu=${cpu//CPU}
-    cpu=${cpu//Processor}
-    cpu=${cpu//Six-Core}
-    cpu=${cpu//Eight-Core}
-    cpu=${cpu//with Radeon HD Graphics}
+    cpu=${cpu//*('(tm)'|'(r)'|CPU|Processor|Six-Core|Eight-Core|with Radeon HD Graphics)}
 
     # Add cpu cores to output
     [ "$cpu_cores" == "on" ] && [ ! -z "$cores" ] && \
@@ -901,10 +891,7 @@ getcpu () {
         "speed") cpu=${cpu#*@ } ;;
 
         "on" | "tiny")
-            cpu=${cpu/Intel }
-            cpu=${cpu/Core }
-            cpu=${cpu/Core? Duo }
-            cpu=${cpu/AMD }
+            cpu=${cpu//*(Intel |Core |Core? Duo |AMD )}
 
             case "$cpu_shorthand" in
                 "tiny") cpu=${cpu/@*} ;;
@@ -1203,12 +1190,10 @@ getresolution () {
 
         "Windows")
             width=$(wmic desktopmonitor get screenwidth /value 2>/dev/null)
-            width=${width/ScreenWidth'='/}
-            width=${width//[[:space:]]}
+            width=${width//*(ScreenWidth'='|[[:space:]])}
 
             height=$(wmic desktopmonitor get screenheight /value 2>/dev/null)
-            height=${height/ScreenHeight'='/}
-            height=${height//[[:space:]]}
+            height=${height//*(ScreenHeight'='|[[:space:]])}
 
             [ ! -z "$width" ] && \
                 resolution="${width}x${height}"
@@ -1374,15 +1359,11 @@ getstyle () {
 
         # Final string
         theme="${gtk2theme}${gtk3theme}"
-        theme=${theme//\"}
-        theme=${theme//\'}
+        theme=${theme//*(\"|\')}
 
         # Make the output shorter by removing "[GTKX]" from the string
-        if [ "$gtk_shorthand" == "on" ]; then
-            theme=${theme/ '[GTK2]'}
-            theme=${theme/ '[GTK3]'}
-            theme=${theme/ '[GTK2/3]'}
-        fi
+        [ "$gtk_shorthand" == "on" ] && \
+            theme=${theme//*( \[GTK[23]\]|\[GTK2\/3])}
     else
         case "$os" in
             "Windows")
@@ -1540,8 +1521,7 @@ getbattery () {
         "Windows")
             battery="$(wmic Path Win32_Battery get EstimatedChargeRemaining /value)"
             battery=${battery/EstimatedChargeRemaining'='}
-            battery=${battery//[[:space:]]/ }
-            battery=${battery// }
+            battery=${battery//[[:space:]]}
             [ ! -z "$battery" ] && \
                 battery+="%"
         ;;
@@ -1719,8 +1699,7 @@ getwallpaper () {
                 esac
 
                 # Strip quotes etc from the path.
-                img=${img/'file://'}
-                img=${img//\'}
+                img=${img//*('file://'|\')}
             fi
         ;;
 
@@ -1799,8 +1778,7 @@ getascii () {
 
     # Turn the file into a variable and strip escape codes.
     ascii_strip=$(<"$ascii")
-    ascii_strip=${ascii_strip//\$\{??\}}
-    ascii_strip=${ascii_strip//\\}
+    ascii_strip=${ascii_strip//*(\$\{??\}|\\)}
 
     # Get length of longest line
     length="$(wc -L 2>/dev/null <<< "$ascii_strip")"

--- a/neofetch
+++ b/neofetch
@@ -1778,7 +1778,8 @@ getascii () {
 
     # Turn the file into a variable and strip escape codes.
     ascii_strip=$(<"$ascii")
-    ascii_strip=${ascii_strip//*(\$\{??\}|\\)}
+    ascii_strip=${ascii_strip//\$\{??\}}
+    ascii_strip=${ascii_strip//\\}
 
     # Get length of longest line
     length="$(wc -L 2>/dev/null <<< "$ascii_strip")"


### PR DESCRIPTION
TODO

- [ ] Get this working on bash 3. 
    - Not sure why it isn't working since extglob was introduced in bash 2.

- [ ] Test this on Windows, OSX and BSD