### PR TITLE
Implement Window Manager Theme

### DIFF
--- a/1.6.md
+++ b/1.6.md
@@ -85,6 +85,9 @@ This is much faster than the default method.
 **Theme**<br \>
 - Use `$GTK2_RC_FILES` if the envar is set. **[@onespaceman](https://github.com/onespaceman)**
 
+**Desktop Environment**<br \>
+- Added OS X detection.
+
 **Song**<br \>
 - [ MPD ] Fixed function when mpd is running on another PC and not your own.
 - Song now displays `Not Playing` instead of `Unknown` when no music player is found.

--- a/1.6.md
+++ b/1.6.md
@@ -25,6 +25,7 @@ appearing in the output.
 allow us to speed up the script by caching info that won't change for a<br \>
 long period of time like the CPU/GPU. \[1\]
 - Fixed a locale issue when `LC_ALL` is unset on the user's system.
+- Change all usage of `$HOME/.config` to `$XDG_CONFIG_HOME` with a fallback to `$HOME/.config`.
 
 \[1\] You can clear the cache with `--clean`.
 
@@ -49,6 +50,9 @@ the color white, it's now based on your foreground color.
 ### Info
 
 - Functions now no longer print `Unknown` when they fail, they now don't appear at all.
+
+**Window Manager Theme**<br \>
+- Added new `WM Theme` function to print window manager themes.
 
 **OS**<br \>
 - [ CRUX ] Also print the CRUX version. **[@onodera-punpun](https://github.com/onodera-punpun)**

--- a/config/config
+++ b/config/config
@@ -25,8 +25,9 @@ printinfo () {
     info "Packages" packages
     info "Shell" shell
     info "Resolution" resolution
-    info "Desktop Environment" de
-    info "Window Manager" wm
+    info "DE" de
+    info "WM" wm
+    info "WM Theme" wmtheme
     info "Theme" theme
     info "Icons" icons
     info "CPU" cpu

--- a/config/config
+++ b/config/config
@@ -7,7 +7,6 @@
 # Speed up script by not using unicode
 export LC_ALL=C
 export LANG=C
-export LANGUAGE=C
 
 # Info Options {{{
 
@@ -395,7 +394,7 @@ config="on"
 
 # Path to custom config file location
 # --config path/to/config
-config_file="$HOME/.config/neofetch/config"
+config_file="${XDG_CONFIG_HOME:-${HOME}/.config}/neofetch/config"
 
 
 # }}}

--- a/neofetch
+++ b/neofetch
@@ -854,6 +854,11 @@ getwmtheme () {
                 wmtheme="Graphite"
             fi
         ;;
+
+        'Fluxbox')
+            [ -f $HOME/.fluxbox/init ] && \
+                wmtheme="$(awk -F "/" '/styleFile/ {print $NF}' "$HOME/.fluxbox/init")"
+        ;;
     esac
     wmtheme="${wmtheme//\'}"
 }

--- a/neofetch
+++ b/neofetch
@@ -820,14 +820,6 @@ getwmtheme () {
             wmtheme="$(gsettings get org.cinnamon.desktop.wm.preferences theme)"
             wmtheme="${detheme} (${wmtheme})"
         ;;
-        'Quartz Compositor')
-            wmtheme=$(/usr/libexec/PlistBuddy -c "Print AppleAquaColorVariant" ~/Library/Preferences/.GlobalPreferences.plist)
-            if [ -z "$wmtheme" ] || [ "$wmtheme" == "1" ]; then
-                wmtheme="Blue"
-            else
-                wmtheme="Graphite"
-            fi
-        ;;
 
         'Compiz' | 'Mutter'* | 'GNOME Shell' | 'Gala')
             if type -p gsettings >/dev/null 2>&1; then
@@ -851,6 +843,15 @@ getwmtheme () {
                 wmtheme="$(eet -d $HOME/.e/e/config/standard/e.cfg config | awk '/value \"file\" string.*.edj/ {print $4}')"
                 wmtheme=${wmtheme##*/}
                 wmtheme=${wmtheme%.*}
+            fi
+        ;;
+
+        'Quartz Compositor')
+            wmtheme=$(/usr/libexec/PlistBuddy -c "Print AppleAquaColorVariant" ~/Library/Preferences/.GlobalPreferences.plist)
+            if [ -z "$wmtheme" ] || [ "$wmtheme" == "1" ]; then
+                wmtheme="Blue"
+            else
+                wmtheme="Graphite"
             fi
         ;;
     esac

--- a/neofetch
+++ b/neofetch
@@ -49,8 +49,9 @@ printinfo () {
     info "Packages" packages
     info "Shell" shell
     info "Resolution" resolution
-    info "Desktop Environment" de
-    info "Window Manager" wm
+    info "DE" de
+    info "WM" wm
+    info "WM Theme" wmtheme
     info "Theme" theme
     info "Icons" icons
     info "CPU" cpu
@@ -802,6 +803,14 @@ getwm () {
             "Windows") wm="Explorer" ;;
         esac
     fi
+}
+
+# }}}
+
+# Window Manager Theme {{{
+
+getwmtheme () {
+    echo "TODO"
 }
 
 # }}}

--- a/neofetch
+++ b/neofetch
@@ -822,7 +822,7 @@ getwmtheme () {
         'Cinnamon' | 'Muffin')
             detheme="$(gsettings get org.cinnamon.theme name)"
             wmtheme="$(gsettings get org.cinnamon.desktop.wm.preferences theme)"
-            wmtheme="${detheme} (${wmtheme})"
+            wmtheme="$detheme (${wmtheme})"
         ;;
 
         'Compiz' | 'Mutter'* | 'GNOME Shell' | 'Gala')
@@ -871,6 +871,18 @@ getwmtheme () {
         'Xfwm4')
             [ -f "${HOME}/.config/xfce4/xfconf/xfce-perchannel-xml/xfwm4.xml" ] && \
                 wmtheme="$(xfconf-query -c xfwm4 -p /general/theme)"
+        ;;
+
+        'KWin'*)
+            kdeconfigdir
+            kde_config_dir=${kde_config_dir%/}
+
+            if [ -f "$kde_config_dir/share/config/kwinrc" ]; then
+                wmtheme="$(awk '/PluginLib=kwin3_/{gsub(/PluginLib=kwin3_/,"",$0); print $0; exit}' "$kde_config_dir/share/config/kwinrc")"
+
+            elif [ -f "$KDE_CONFIG_DIR/share/config/kdebugrc" ]; then
+                wmtheme="$(awk '/(decoration)/ {gsub(/\[/,"",$1); print $1; exit}' "$kde_config_dir/share/config/kdebugrc")"
+            fi
         ;;
 
         'Quartz Compositor')
@@ -1390,15 +1402,7 @@ getstyle () {
         # Current DE
         case "$XDG_CURRENT_DESKTOP" in
             "KDE"*)
-                if type -p kde5-config >/dev/null 2>&1; then
-                    kde_config_dir=$(kde5-config --localprefix)
-
-                elif type -p kde4-config >/dev/null 2>&1; then
-                    kde_config_dir=$(kde4-config --localprefix)
-
-                elif type -p kde-config >/dev/null 2>&1; then
-                    kde_config_dir=$(kde-config --localprefix)
-                fi
+                kdeconfigdir
 
                 if [ -f "${kde_config_dir}/share/config/kdeglobals" ]; then
                     kde_config_file="${kde_config_dir}/share/config/kdeglobals"
@@ -2551,6 +2555,23 @@ cache () {
 }
 
 # }}}
+
+# KDE Config directory {{{
+
+kdeconfigdir () {
+    if type -p kde5-config >/dev/null 2>&1; then
+        kde_config_dir=$(kde5-config --localprefix)
+
+    elif type -p kde4-config >/dev/null 2>&1; then
+        kde_config_dir=$(kde4-config --localprefix)
+
+    elif type -p kde-config >/dev/null 2>&1; then
+        kde_config_dir=$(kde-config --localprefix)
+    fi
+}
+
+# }}}
+
 
 # }}}
 

--- a/neofetch
+++ b/neofetch
@@ -836,6 +836,15 @@ getwmtheme () {
         ;;
 
         'E16') wmtheme="$(awk -F"= " '/theme.name/ {print $2}' "$HOME/.e16/e_config--0.0.cfg")";;
+
+        'E17'|'Enlightenment')
+            # TODO: Reduce the size of this.
+            if type -p eet >/dev/null 2>&1; then
+                wmtheme="$(eet -d $HOME/.e/e/config/standard/e.cfg config | awk '/value \"file\" string.*.edj/ {print $4}')"
+                wmtheme=${wmtheme##*/}
+                wmtheme=${wmtheme%.*}
+            fi
+        ;;
     esac
     wmtheme="${wmtheme//\'}"
 }

--- a/neofetch
+++ b/neofetch
@@ -816,7 +816,7 @@ getwmtheme () {
         'BudgieWM') wmtheme="$(gsettings get org.gnome.desktop.wm.preferences theme)" ;;
         'E16') wmtheme="$(awk -F"= " '/theme.name/ {print $2}' "$HOME/.e16/e_config--0.0.cfg")";;
         'Marco') wmtheme="$(gsettings get org.mate.Marco.general theme)" ;;
-        'Metacity') wmtheme="$(gconftool-2 -g /apps/metacity/general/theme 2>/dev/null)" ;;
+        'Metacity'*) wmtheme="$(gconftool-2 -g /apps/metacity/general/theme 2>/dev/null)" ;;
         'Sawfish') wmtheme="$(awk -F ")" '/\(quote default-frame-style/ {print $2}' "$HOME/.sawfish/custom")" ;;
 
         'Cinnamon' | 'Muffin')
@@ -853,7 +853,7 @@ getwmtheme () {
                 wmtheme="$(awk -F "/" '/styleFile/ {print $NF}' "$HOME/.fluxbox/init")"
         ;;
 
-        'IceWM')
+        'IceWM'*)
             [ -f $HOME/.icewm/theme ] && \
                 wmtheme="$(awk -F "[\",/]" '!/#/ {print $2}' "$HOME/.icewm/theme")"
         ;;

--- a/neofetch
+++ b/neofetch
@@ -843,7 +843,6 @@ getwmtheme () {
         ;;
 
         'E17' | 'Enlightenment')
-            # TODO: Reduce the size of this.
             if type -p eet >/dev/null 2>&1; then
                 wmtheme="$(eet -d $HOME/.e/e/config/standard/e.cfg config | awk '/value \"file\" string.*.edj/ {print $4}')"
                 wmtheme=${wmtheme##*/}

--- a/neofetch
+++ b/neofetch
@@ -816,7 +816,6 @@ getwmtheme () {
     case "$wm"  in
         'BudgieWM') wmtheme="$(gsettings get org.gnome.desktop.wm.preferences theme)" ;;
         'E16') wmtheme="$(awk -F"= " '/theme.name/ {print $2}' "$HOME/.e16/e_config--0.0.cfg")";;
-        'Metacity'*) wmtheme="$(gconftool-2 -g /apps/metacity/general/theme 2>/dev/null)" ;;
         'Sawfish') wmtheme="$(awk -F ")" '/\(quote default-frame-style/ {print $2}' "$HOME/.sawfish/custom")" ;;
 
         'Cinnamon' | 'Muffin' | 'Mutter (Muffin)')
@@ -834,9 +833,13 @@ getwmtheme () {
             fi
         ;;
 
-        'Deepin WM')
-            type -p gsettings >/dev/null 2>&1 && \
-                wmtheme="$(gsettings get com.deepin.wrap.gnome.desktop.wm.preferences theme)"
+        'Metacity'*)
+            if [ "$de" == "Deepin" ]; then
+                wmtheme="$(gsettings get com.deepin.wrap.gnome.desktop.wm.preferences theme 2>/dev/null)"
+
+            else
+                wmtheme="$(gconftool-2 -g /apps/metacity/general/theme 2>/dev/null)"
+            fi
         ;;
 
         'E17' | 'Enlightenment')

--- a/neofetch
+++ b/neofetch
@@ -810,7 +810,19 @@ getwm () {
 # Window Manager Theme {{{
 
 getwmtheme () {
-    echo "TODO"
+    case "$os"  in
+        "Linux" | *"BSD")
+
+        ;;
+
+        "Mac OS X")
+
+        ;;
+
+        "Windows")
+
+        ;;
+    esac
 }
 
 # }}}

--- a/neofetch
+++ b/neofetch
@@ -22,8 +22,9 @@
 # Created by Dylan Araps
 # https://github.com/dylanaraps/
 
-version=${BASH_VERSION/.*}
+version="${BASH_VERSION/.*}"
 SYS_LOCALE="${LANG:-C}"
+XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-${HOME}/.config}"
 
 # Speed up script by not using unicode
 export LC_ALL=C
@@ -420,7 +421,7 @@ config="on"
 
 # Path to custom config file location
 # --config path/to/config
-config_file="$HOME/.config/neofetch/config"
+config_file="${XDG_CONFIG_HOME:-${HOME}/.config}/neofetch/config"
 
 
 # }}}
@@ -860,7 +861,7 @@ getwmtheme () {
 
         'Openbox')
             [ -f "${HOME}/.config/openbox/rc.xml" ] && \
-                wmtheme="$(awk -F "[<,>]" '/<theme/ {getline; print $3}' "$HOME/.config/openbox/rc.xml")";
+                wmtheme="$(awk -F "[<,>]" '/<theme/ {getline; print $3}' "$XDG_CONFIG_HOME/openbox/rc.xml")";
         ;;
 
         'PekWM')
@@ -1472,8 +1473,8 @@ getstyle () {
 
         # Check for gtk3 theme
         if [ -z "$gtk3theme" ]; then
-            if [ -f "$HOME/.config/gtk-3.0/settings.ini" ]; then
-                gtk3theme=$(grep "^[^#]*$name" "$HOME/.config/gtk-3.0/settings.ini")
+            if [ -f "$XDG_CONFIG_HOME/gtk-3.0/settings.ini" ]; then
+                gtk3theme=$(grep "^[^#]*$name" "$XDG_CONFIG_HOME/gtk-3.0/settings.ini")
 
             elif type -p gsettings >/dev/null 2>&1; then
                 gtk3theme="$(gsettings get org.gnome.desktop.interface $gsettings)"
@@ -1843,7 +1844,7 @@ getwallpaper () {
                 img="$(awk -F\' '/feh/ {printf $2}' "$HOME/.fehbg")"
 
             elif type -p nitrogen >/dev/null 2>&1; then
-                img="$(awk -F'=' '/file/ {printf $2;exit;}' "$HOME/.config/nitrogen/bg-saved.cfg")"
+                img="$(awk -F'=' '/file/ {printf $2;exit;}' "$XDG_CONFIG_HOME/nitrogen/bg-saved.cfg")"
 
             elif type -p gsettings >/dev/null 2>&1; then
                 case "$XDG_CURRENT_DESKTOP" in
@@ -2492,26 +2493,26 @@ getconfig () {
         source "$config_file"
         return
     fi
-    mkdir -p "$HOME/.config/neofetch/"
+    mkdir -p "$XDG_CONFIG_HOME/neofetch/"
 
-    # Check $HOME/.config/neofetch and create the
+    # Check $XDG_CONFIG_HOME/neofetch and create the
     # dir/files if they don't exist.
-    if [ -f "$HOME/.config/neofetch/config" ]; then
-        source "$HOME/.config/neofetch/config"
+    if [ -f "$XDG_CONFIG_HOME/neofetch/config" ]; then
+        source "$XDG_CONFIG_HOME/neofetch/config"
 
     elif [ -f "/usr/share/neofetch/config" ]; then
-        cp "/usr/share/neofetch/config" "$HOME/.config/neofetch"
-        source "$HOME/.config/neofetch/config"
+        cp "/usr/share/neofetch/config" "$XDG_CONFIG_HOME/neofetch"
+        source "$XDG_CONFIG_HOME/neofetch/config"
 
     elif [ -f "/usr/local/share/neofetch/config" ]; then
-        cp "/usr/local/share/neofetch/config" "$HOME/.config/neofetch"
-        source "$HOME/.config/neofetch/config"
+        cp "/usr/local/share/neofetch/config" "$XDG_CONFIG_HOME/neofetch"
+        source "$XDG_CONFIG_HOME/neofetch/config"
 
     else
         getscriptdir
 
-        cp "$script_dir/config/config" "$HOME/.config/neofetch"
-        source "$HOME/.config/neofetch/config"
+        cp "$script_dir/config/config" "$XDG_CONFIG_HOME/neofetch"
+        source "$XDG_CONFIG_HOME/neofetch/config"
     fi
 }
 

--- a/neofetch
+++ b/neofetch
@@ -813,11 +813,15 @@ getwmtheme () {
     [ -z "$wm" ] && getwm
 
     case "$wm"  in
-        '2bwm')
+        'BudgieWM') wmtheme="$(gsettings get org.gnome.desktop.wm.preferences theme)" ;;
 
+        'Cinnamon' | 'Muffin')
+            de_theme="$(gsettings get org.cinnamon.theme name)"
+            win_theme="$(gsettings get org.cinnamon.desktop.wm.preferences theme)"
+            Win_theme="${de_theme} (${win_theme})"
         ;;
-
     esac
+    wmtheme="${wmtheme//\'}"
 }
 
 # }}}

--- a/neofetch
+++ b/neofetch
@@ -810,18 +810,13 @@ getwm () {
 # Window Manager Theme {{{
 
 getwmtheme () {
-    case "$os"  in
-        "Linux" | *"BSD")
+    [ -z "$wm" ] && getwm
+
+    case "$wm"  in
+        '2bwm')
 
         ;;
 
-        "Mac OS X")
-
-        ;;
-
-        "Windows")
-
-        ;;
     esac
 }
 

--- a/neofetch
+++ b/neofetch
@@ -2734,7 +2734,7 @@ while [ "$1" ]; do
 
         # Stdout
         --stdout)
-            unset info_color colors cpu_display bar prin
+            unset info_color prin clear bar
             stdout_mode="on"
             config="off"
             case "$2" in

--- a/neofetch
+++ b/neofetch
@@ -829,6 +829,11 @@ getwmtheme () {
                 wmtheme="$(gconftool-2 -g /apps/metacity/general/theme)"
             fi
         ;;
+
+        'Deepin WM')
+            type -p gsettings >/dev/null 2>&1 && \
+                wmtheme="$(gsettings get com.deepin.wrap.gnome.desktop.wm.preferences theme)"
+        ;;
     esac
     wmtheme="${wmtheme//\'}"
 }

--- a/neofetch
+++ b/neofetch
@@ -881,7 +881,7 @@ getwmtheme () {
             if [ -f "$kde_config_dir/share/config/kwinrc" ]; then
                 wmtheme="$(awk '/PluginLib=kwin3_/{gsub(/PluginLib=kwin3_/,"",$0); print $0; exit}' "$kde_config_dir/share/config/kwinrc")"
 
-            elif [ -f "$KDE_CONFIG_DIR/share/config/kdebugrc" ]; then
+            elif [ -f "$kde_config_dir/share/config/kdebugrc" ]; then
                 wmtheme="$(awk '/(decoration)/ {gsub(/\[/,"",$1); print $1; exit}' "$kde_config_dir/share/config/kdebugrc")"
             fi
         ;;
@@ -2557,7 +2557,10 @@ cache () {
 # KDE Config directory {{{
 
 kdeconfigdir () {
-    if type -p kde5-config >/dev/null 2>&1; then
+    if [ -n "$KDE_CONFIG_DIR" ]; then
+        kde_config_dir="$KDE_CONFIG_DIR"
+
+    elif type -p kde5-config >/dev/null 2>&1; then
         kde_config_dir=$(kde5-config --localprefix)
 
     elif type -p kde4-config >/dev/null 2>&1; then

--- a/neofetch
+++ b/neofetch
@@ -814,6 +814,10 @@ getwmtheme () {
 
     case "$wm"  in
         'BudgieWM') wmtheme="$(gsettings get org.gnome.desktop.wm.preferences theme)" ;;
+        'E16') wmtheme="$(awk -F"= " '/theme.name/ {print $2}' "$HOME/.e16/e_config--0.0.cfg")";;
+        'Marco') wmtheme="$(gsettings get org.mate.Marco.general theme)" ;;
+        'Metacity') wmtheme="$(gconftool-2 -g /apps/metacity/general/theme 2>/dev/null)" ;;
+        'Sawfish') wmtheme="$(awk -F ")" '/\(quote default-frame-style/ {print $2}' "$HOME/.sawfish/custom")" ;;
 
         'Cinnamon' | 'Muffin')
             detheme="$(gsettings get org.cinnamon.theme name)"
@@ -835,8 +839,6 @@ getwmtheme () {
                 wmtheme="$(gsettings get com.deepin.wrap.gnome.desktop.wm.preferences theme)"
         ;;
 
-        'E16') wmtheme="$(awk -F"= " '/theme.name/ {print $2}' "$HOME/.e16/e_config--0.0.cfg")";;
-
         'E17'|'Enlightenment')
             # TODO: Reduce the size of this.
             if type -p eet >/dev/null 2>&1; then
@@ -844,6 +846,31 @@ getwmtheme () {
                 wmtheme=${wmtheme##*/}
                 wmtheme=${wmtheme%.*}
             fi
+        ;;
+
+        'Fluxbox')
+            [ -f $HOME/.fluxbox/init ] && \
+                wmtheme="$(awk -F "/" '/styleFile/ {print $NF}' "$HOME/.fluxbox/init")"
+        ;;
+
+        'IceWM')
+            [ -f $HOME/.icewm/theme ] && \
+                wmtheme="$(awk -F "[\",/]" '!/#/ {print $2}' "$HOME/.icewm/theme")"
+        ;;
+
+        'Openbox')
+            [ -f "${HOME}/.config/openbox/rc.xml" ] && \
+                wmtheme="$(awk -F "[<,>]" '/<theme/ {getline; print $3}' "$HOME/.config/openbox/rc.xml")";
+        ;;
+
+        'PekWM')
+            [ -f $HOME/.pekwm/config ] && \
+                wmtheme="$(awk -F "/" '/Theme/ {gsub(/\"/,""); print $NF}' "$HOME/.pekwm/config")"
+        ;;
+
+        'Xfwm4')
+            [ -f "${HOME}/.config/xfce4/xfconf/xfce-perchannel-xml/xfwm4.xml" ] && \
+                wmtheme="$(xfconf-query -c xfwm4 -p /general/theme)"
         ;;
 
         'Quartz Compositor')
@@ -855,12 +882,10 @@ getwmtheme () {
             fi
         ;;
 
-        'Fluxbox')
-            [ -f $HOME/.fluxbox/init ] && \
-                wmtheme="$(awk -F "/" '/styleFile/ {print $NF}' "$HOME/.fluxbox/init")"
-        ;;
     esac
+
     wmtheme="${wmtheme//\'}"
+    [ "$version" -ge 4 ] && wmtheme=${wmtheme^}
 }
 
 # }}}

--- a/neofetch
+++ b/neofetch
@@ -769,9 +769,11 @@ getshell () {
 # }}}
 
 # Desktop Environment {{{
-
 getde () {
-    de="${XDG_CURRENT_DESKTOP/i3}"
+    case "$os" in
+        "Mac OS X") de="Aqua" ;;
+        *) de="${XDG_CURRENT_DESKTOP/i3}" ;;
+    esac
 }
 
 # }}}

--- a/neofetch
+++ b/neofetch
@@ -816,9 +816,18 @@ getwmtheme () {
         'BudgieWM') wmtheme="$(gsettings get org.gnome.desktop.wm.preferences theme)" ;;
 
         'Cinnamon' | 'Muffin')
-            de_theme="$(gsettings get org.cinnamon.theme name)"
-            win_theme="$(gsettings get org.cinnamon.desktop.wm.preferences theme)"
-            Win_theme="${de_theme} (${win_theme})"
+            detheme="$(gsettings get org.cinnamon.theme name)"
+            wmtheme="$(gsettings get org.cinnamon.desktop.wm.preferences theme)"
+            wmtheme="${detheme} (${wmtheme})"
+        ;;
+
+        'Compiz' | 'Mutter'* | 'GNOME Shell' | 'Gala')
+            if type -p gsettings >/dev/null 2>&1; then
+                wmtheme="$(gsettings get org.gnome.desktop.wm.preferences theme)"
+
+            elif type -p gconftool-2 >/dev/null 2>&1; then
+                wmtheme="$(gconftool-2 -g /apps/metacity/general/theme)"
+            fi
         ;;
     esac
     wmtheme="${wmtheme//\'}"

--- a/neofetch
+++ b/neofetch
@@ -894,6 +894,16 @@ getwmtheme () {
             fi
         ;;
 
+        'Explorer')
+            path="/proc/registry/HKEY_CURRENT_USER/Software/Microsoft"
+            path+="/Windows/CurrentVersion/Themes/CurrentTheme"
+
+            wmtheme="$(head -n1 "$path" 2>/dev/null)"
+            wmtheme="${wmtheme##*\\}"
+            wmtheme="${wmtheme%.*}"
+            wmtheme="${wmtheme^}"
+        ;;
+
     esac
 
     wmtheme="${wmtheme//\'}"
@@ -1377,8 +1387,6 @@ getstyle () {
             gconf="gtk_theme"
             xfconf="ThemeName"
             kde="widgetStyle"
-            path="/proc/registry/HKEY_CURRENT_USER/Software/Microsoft"
-            path+="/Windows/CurrentVersion/Themes/CurrentTheme"
         ;;
 
         icons)
@@ -1517,17 +1525,6 @@ getstyle () {
             theme=${theme/ '[GTK3]'}
             theme=${theme/ '[GTK2/3]'}
         fi
-    else
-        case "$os" in
-            "Windows")
-                [ -z "$path" ] && return
-                theme="$(head -n1 "$path" 2>/dev/null)"
-                theme="${theme##*\\}"
-                theme="${theme%.*}"
-                theme="${theme^}"
-            ;;
-
-        esac
     fi
 }
 

--- a/neofetch
+++ b/neofetch
@@ -834,6 +834,8 @@ getwmtheme () {
             type -p gsettings >/dev/null 2>&1 && \
                 wmtheme="$(gsettings get com.deepin.wrap.gnome.desktop.wm.preferences theme)"
         ;;
+
+        'E16') wmtheme="$(awk -F"= " '/theme.name/ {print $2}' "$HOME/.e16/e_config--0.0.cfg")";;
     esac
     wmtheme="${wmtheme//\'}"
 }

--- a/neofetch
+++ b/neofetch
@@ -860,8 +860,14 @@ getwmtheme () {
         ;;
 
         'Openbox')
-            [ -f "${HOME}/.config/openbox/rc.xml" ] && \
-                wmtheme="$(awk -F "[<,>]" '/<theme/ {getline; print $3}' "$XDG_CONFIG_HOME/openbox/rc.xml")";
+            if [ "$de" == "LXDE" ] && [ -f "${HOME}/.config/openbox/lxde-rc.xml" ]; then
+                ob_file="lxde-rc"
+
+            elif [ -f "${HOME}/.config/openbox/rc.xml" ]; then
+                ob_file="rc"
+            fi
+
+            wmtheme="$(awk -F "[<,>]" '/<theme/ {getline; print $3}' "$XDG_CONFIG_HOME/openbox/${ob_file}.xml")";
         ;;
 
         'PekWM')

--- a/neofetch
+++ b/neofetch
@@ -816,7 +816,6 @@ getwmtheme () {
     case "$wm"  in
         'BudgieWM') wmtheme="$(gsettings get org.gnome.desktop.wm.preferences theme)" ;;
         'E16') wmtheme="$(awk -F"= " '/theme.name/ {print $2}' "$HOME/.e16/e_config--0.0.cfg")";;
-        'Marco') wmtheme="$(gsettings get org.mate.Marco.general theme)" ;;
         'Metacity'*) wmtheme="$(gconftool-2 -g /apps/metacity/general/theme 2>/dev/null)" ;;
         'Sawfish') wmtheme="$(awk -F ")" '/\(quote default-frame-style/ {print $2}' "$HOME/.sawfish/custom")" ;;
 
@@ -840,7 +839,7 @@ getwmtheme () {
                 wmtheme="$(gsettings get com.deepin.wrap.gnome.desktop.wm.preferences theme)"
         ;;
 
-        'E17'|'Enlightenment')
+        'E17' | 'Enlightenment')
             # TODO: Reduce the size of this.
             if type -p eet >/dev/null 2>&1; then
                 wmtheme="$(eet -d $HOME/.e/e/config/standard/e.cfg config | awk '/value \"file\" string.*.edj/ {print $4}')"

--- a/neofetch
+++ b/neofetch
@@ -819,7 +819,7 @@ getwmtheme () {
         'Metacity'*) wmtheme="$(gconftool-2 -g /apps/metacity/general/theme 2>/dev/null)" ;;
         'Sawfish') wmtheme="$(awk -F ")" '/\(quote default-frame-style/ {print $2}' "$HOME/.sawfish/custom")" ;;
 
-        'Cinnamon' | 'Muffin')
+        'Cinnamon' | 'Muffin' | 'Mutter (Muffin)')
             detheme="$(gsettings get org.cinnamon.theme name)"
             wmtheme="$(gsettings get org.cinnamon.desktop.wm.preferences theme)"
             wmtheme="$detheme (${wmtheme})"


### PR DESCRIPTION
Implement WM Theme

Features:

- Implements Window manager theme support.
- Changes all usage of `$HOME/.config` to `XDG_CONFIG_HOME` with a fallback to `$HOME/.config`

Changes:

- Moved Windows theme detection to WM Theme instead of getstyle.

TODO:

- [x] ~~Everything~~
- [x] ~~Testing~~
    - [x] ~~Budgie WM (Budgie DE)~~
    - [x] ~~E16~~
    - [x] ~~Marco WM~~
    - [x] ~~Metacity~~
    - [x] ~~Sawfish WM~~
    - [x] ~~Cinnamon / Muffin~~
    - [x] ~~Compiz / Mutter / GNOME Shell / Gala~~
    - [x] ~~Deepin WM~~
    - [x] ~~E17 / Enlightenment~~
    - [x] ~~Fluxbox~~
    - [x] ~~IceWM~~ (I might swap to this WM)
    - [x] ~~Openbox / LXDE~~
    - [x] ~~PekWM~~
    - [x] ~~Xfwm4~~
    - [x] ~~Kwin~~
    - [x] ~~Quartz Compositor (OS X)~~
    - [x] ~~Explorer (Windows)~~