### PR TITLE
Error msg

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -16,7 +16,7 @@
 
 **Neofetch 1.7**
 
-2. Run `neofetch --verbose 2> neofetchlog`
+2. Run `neofetch -vv 2> neofetchlog`
 3. Upload the contents of `neofetchlog` to pastebin, gist or equivalent.
 
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -6,7 +6,7 @@
 
 #### Operating system
 
-## Image (If relevant)
+## Screenshot (If relevant)
 
 ## Verbose log
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -6,6 +6,8 @@
 
 #### Operating system
 
+## Image (If relevant)
+
 ## Verbose log
 
 **Neofetch 1.6**

--- a/1.7.md
+++ b/1.7.md
@@ -11,10 +11,19 @@ Thanks to the following people for contributing this release.
 ### General
 
 - Made it easier to get verbose logs.
-- Added `--verbose` to print a verbose log to stdout. \[1\]
 - Added issue template for github.
 
-\[1\] Use `neofetch --verbose 2> file` to save a verbose log for bug reporting.
+### Error Messages
+
+Neofetch now supports displaying error messages and saving a verbose log for<br \>
+troubleshooting.
+
+![log](https://ipfs.pics/ipfs/QmeTWGKozY79zcxbrgXueyTRfQcTUe7ZmDqLv4ASgJB4G4)
+
+- Added `-v` to print error messages to stdout.
+- Added `-vv` to print a verbose log to stdout. \[1\]
+
+\[1\] Use `neofetch -vv 2> file` to save a verbose log for bug reporting.
 
 ### Info
 

--- a/neofetch
+++ b/neofetch
@@ -1891,8 +1891,8 @@ getwallpaper () {
     # If img is an xml file don't use it.
     [ "${img/*\./}" == "xml" ] && img=""
 
-    [ -z "$img" ] && \
-        err "Wallpaper detection failed, falling back to ascii mode."
+    # Error msg
+    [ -z "$img" ] && err "Wallpaper detection failed, falling back to ascii mode."
 }
 
 # }}}

--- a/neofetch
+++ b/neofetch
@@ -1890,6 +1890,9 @@ getwallpaper () {
 
     # If img is an xml file don't use it.
     [ "${img/*\./}" == "xml" ] && img=""
+
+    [ -z "$img" ] && \
+        err "Wallpaper detection failed, falling back to ascii mode."
 }
 
 # }}}
@@ -1898,6 +1901,9 @@ getwallpaper () {
 
 getascii () {
     if [ ! -f "$ascii" ] || [ "$ascii" == "distro" ]; then
+        # Error message
+        [ ! -f "$ascii" ] && err "Ascii file not found, using distro ascii"
+
         # Lowercase the distro name
         if [ "$version" -le 3 ]; then
             ascii=$(tr '[:upper:]' '[:lower:]' <<< "$ascii_distro")
@@ -1921,6 +1927,7 @@ getascii () {
             if [ ! -f "$script_dir/ascii/distro/${ascii/ *}" ]; then
                 padding="\033[0C"
                 image="off"
+                err "Ascii file not found, falling back to text mode."
                 return
             fi
 
@@ -2008,6 +2015,11 @@ getimage () {
     if [ ! -f "$img" ] || [ ${#term_size} -le 5 ]; then
         image="ascii"
         getascii
+
+        # Error messages
+        [ ! -f "$img" ] && err "\$img, isn't a file, falling back to ascii mode."
+        [ ${#term_size} -le 5 ] && err "Your terminal doesn't support \\\033[14t, falling back to ascii mode."
+
         return
     fi
 
@@ -2141,6 +2153,7 @@ getw3m_img_path () {
 
     else
         image="ascii"
+        err "w3m-img wasn't found on your system, falling back to ascii mode."
     fi
 }
 
@@ -2582,6 +2595,9 @@ kdeconfigdir () {
 
 # }}}
 
+err () {
+    err+="$(color 1)[!]$(color fg) $1 \n"
+}
 
 # }}}
 
@@ -2891,7 +2907,8 @@ while [ "$1" ]; do
             }
         ;;
 
-        --verbose) set -x ;;
+        -v) verbose="on" ;;
+        -vv) set -x; verbose="on" ;;
         --help) usage ;;
     esac
 
@@ -2982,5 +2999,8 @@ fi
 if [ "$scrot" == "on" ]; then
     takescrot
 fi
+
+# Show error messages
+[ "$verbose" == "on" ] && printf "$err"
 
 # }}}

--- a/neofetch
+++ b/neofetch
@@ -3002,6 +3002,8 @@ if [ "$scrot" == "on" ]; then
 fi
 
 # Show error messages
-[ "$verbose" == "on" ] && printf "$err"
+if [ "$verbose" == "on" ]; then
+    printf "$err"
+fi
 
 # }}}

--- a/neofetch
+++ b/neofetch
@@ -1902,6 +1902,7 @@ getwallpaper () {
 getascii () {
     if [ ! -f "$ascii" ] || [ "$ascii" == "distro" ]; then
         # Error message
+        [ "$ascii" != "distro" ] && \
         [ ! -f "$ascii" ] && err "Ascii file not found, using distro ascii"
 
         # Lowercase the distro name


### PR DESCRIPTION
### Error Messages

Neofetch now supports displaying error messages and saving a verbose log for
troubleshooting.

![log](https://ipfs.pics/ipfs/QmeTWGKozY79zcxbrgXueyTRfQcTUe7ZmDqLv4ASgJB4G4)

- Added `-v` to print error messages to stdout.
- Added `-vv` to print a verbose log to stdout. \[1\]

\[1\] Use `neofetch -vv 2> file` to save a verbose log for bug reporting.