### PR TITLE
Fix issues with users having more than one package manager installed.

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -687,25 +687,17 @@ getpackages () {
         ;;
 
         "Mac OS X")
-            if [ -d "/usr/local/bin" ]; then
-                local_packages=$(ls -l /usr/local/bin/ | grep -v "\(../Cellar/\|brew\)" | wc -l)
-                packages=$((local_packages - 1))
-            fi
+            [ -d "/usr/local/bin" ] && \
+                packages=$(($(ls -l /usr/local/bin/ | grep -v "\(../Cellar/\|brew\)" | wc -l) - 1))
 
-            if type -p port >/dev/null 2>&1; then
-                port_packages=$(port installed 2>/dev/null | wc -l)
-                packages=$((packages + port_packages - 1))
-            fi
+            type -p port >/dev/null 2>&1 && \
+                packages=$((packages + $(port installed 2>/dev/null | wc -l) - 1))
 
-            if type -p brew >/dev/null 2>&1; then
-                brew_packages=$(find /usr/local/Cellar -maxdepth 1 2>/dev/null | wc -l)
-                packages=$((packages + brew_packages - 1))
-            fi
+            type -p brew >/dev/null 2>&1 && \
+                packages=$((packages + $(find /usr/local/Cellar -maxdepth 1 2>/dev/null | wc -l) - 1))
 
-            if type -p pkgin >/dev/null 2>&1; then
-                pkgsrc_packages=$(pkgin list 2>/dev/null | wc -l)
-                packages=$((packages + pkgsrc_packages))
-            fi
+            type -p pkgin >/dev/null 2>&1 && \
+                packages=$((packages + $(pkgin list 2>/dev/null | wc -l)))
         ;;
 
         *"BSD")
@@ -721,10 +713,8 @@ getpackages () {
             packages=$(cygcheck -cd | wc -l)
 
             # Count chocolatey packages
-            if [ -d "/cygdrive/c/ProgramData/chocolatey/lib" ]; then
-                choco_packages=$(ls -1 /cygdrive/c/ProgramData/chocolatey/lib | wc -l)
-                packages=$((packages + choco_packages))
-            fi
+            [ -d "/cygdrive/c/ProgramData/chocolatey/lib" ] && \
+                packages=$((packages+=$(ls -1 /cygdrive/c/ProgramData/chocolatey/lib | wc -l)))
         ;;
     esac
     packages=${packages// }

--- a/neofetch
+++ b/neofetch
@@ -649,44 +649,41 @@ getpackages () {
             type -p pacman >/dev/null 2>&1 && \
                 packages="$(pacman -Qq --color never | wc -l)"
 
-            [ -z "$packages" ] && type -p dpkg >/dev/null 2>&1 && \
-                packages="$(dpkg --get-selections | grep -cv deinstall$)"
+            type -p dpkg >/dev/null 2>&1 && \
+                let packages+="$(dpkg --get-selections | grep -cv deinstall$)"
 
-            [ -z "$packages" ] && type -p /sbin/pkgtool >/dev/null 2>&1 && \
-                packages="$(ls -1 /var/log/packages | wc -l)"
+            type -p /sbin/pkgtool >/dev/null 2>&1 && \
+                let packages+="$(ls -1 /var/log/packages | wc -l)"
 
-            [ -z "$packages" ] && type -p rpm >/dev/null 2>&1 && \
-                packages="$(rpm -qa | wc -l)"
+            type -p rpm >/dev/null 2>&1 && \
+                let packages+="$(rpm -qa | wc -l)"
 
-            [ -z "$packages" ] && type -p xbps-query >/dev/null 2>&1 && \
-                packages="$(xbps-query -l | wc -l)"
+            type -p xbps-query >/dev/null 2>&1 && \
+                let packages+="$(xbps-query -l | wc -l)"
 
-            [ -z "$packages" ] && type -p pkginfo >/dev/null 2>&1 && \
-                packages="$(pkginfo -i | wc -l)"
+            type -p pkginfo >/dev/null 2>&1 && \
+                let packages+="$(pkginfo -i | wc -l)"
 
-            [ -z "$packages" ] && type -p pisi >/dev/null 2>&1 && \
-                packages="$(pisi list-installed | wc -l)"
+            type -p pisi >/dev/null 2>&1 && \
+                let packages+="$(pisi list-installed | wc -l)"
 
-            [ -z "$packages" ] && type -p pkg >/dev/null 2>&1 && \
-                packages="$(ls -1 /var/db/pkg | wc -l)"
+            type -p pkg >/dev/null 2>&1 && \
+                let packages+="$(ls -1 /var/db/pkg | wc -l)"
 
-            [ -z "$packages" ] && type -p emerge >/dev/null 2>&1 && \
-                packages="$(ls -d /var/db/pkg/*/* | wc -l)"
+            type -p emerge >/dev/null 2>&1 && \
+                let packages+="$(ls -d /var/db/pkg/*/* | wc -l)"
 
-            [ -z "$packages" ] && type -p nix-env >/dev/null 2>&1 && \
-                packages="$(ls -d -1 /nix/store/*/ | wc -l)"
+            type -p nix-env >/dev/null 2>&1 && \
+                let packages+="$(ls -d -1 /nix/store/*/ | wc -l)"
 
-            [ -z "$packages" ] && type -p apk >/dev/null 2>&1 && \
-                packages="$(apk info | wc -l)"
+            type -p apk >/dev/null 2>&1 && \
+                let packages+="$(apk info | wc -l)"
 
-            [ -z "$packages" ] && type -p pacman-g2 >/dev/null 2>&1 && \
-                packages="$(pacman-g2 -Q | wc -l)"
+            type -p pacman-g2 >/dev/null 2>&1 && \
+                let packages+="$(pacman-g2 -Q | wc -l)"
 
-            if [ -z "$packages" ] && type -p cave >/dev/null 2>&1; then
-                cross_packages=$(ls -d -1 /var/db/paludis/repositories/cross-installed/*/data/* | wc -l)
-                packages=$(ls -d -1 /var/db/paludis/repositories/installed/data/* | wc -l)
-                packages=$((packages + cross_packages))
-            fi
+            type -p cave >/dev/null 2>&1 && \
+                let packages+=$(ls -d -1 /var/db/paludis/repositories/cross-installed/*/data/* /var/db/paludis/repositories/installed/data/* | wc -l)
         ;;
 
         "Mac OS X")

--- a/neofetch
+++ b/neofetch
@@ -650,40 +650,40 @@ getpackages () {
                 packages="$(pacman -Qq --color never | wc -l)"
 
             type -p dpkg >/dev/null 2>&1 && \
-                let packages+="$(dpkg --get-selections | grep -cv deinstall$)"
+                packages=$((packages+=$(dpkg --get-selections | grep -cv deinstall$)))
 
             type -p /sbin/pkgtool >/dev/null 2>&1 && \
-                let packages+="$(ls -1 /var/log/packages | wc -l)"
+                packages=$((packages+=$(ls -1 /var/log/packages | wc -l)))
 
             type -p rpm >/dev/null 2>&1 && \
-                let packages+="$(rpm -qa | wc -l)"
+                packages=$((packages+=$(rpm -qa | wc -l)))
 
             type -p xbps-query >/dev/null 2>&1 && \
-                let packages+="$(xbps-query -l | wc -l)"
+                packages=$((packages+=$(xbps-query -l | wc -l)))
 
             type -p pkginfo >/dev/null 2>&1 && \
-                let packages+="$(pkginfo -i | wc -l)"
+                packages=$((packages+=$(pkginfo -i | wc -l)))
 
             type -p pisi >/dev/null 2>&1 && \
-                let packages+="$(pisi list-installed | wc -l)"
+                packages=$((packages+=$(pisi list-installed | wc -l)))
 
             type -p pkg >/dev/null 2>&1 && \
-                let packages+="$(ls -1 /var/db/pkg | wc -l)"
+                packages=$((packages+=$(ls -1 /var/db/pkg | wc -l)))
 
             type -p emerge >/dev/null 2>&1 && \
-                let packages+="$(ls -d /var/db/pkg/*/* | wc -l)"
+                packages=$((packages+=$(ls -d /var/db/pkg/*/* | wc -l)))
 
             type -p nix-env >/dev/null 2>&1 && \
-                let packages+="$(ls -d -1 /nix/store/*/ | wc -l)"
+                packages=$((packages+=$(ls -d -1 /nix/store/*/ | wc -l)))
 
             type -p apk >/dev/null 2>&1 && \
-                let packages+="$(apk info | wc -l)"
+                packages=$((packages+=$(apk info | wc -l)))
 
             type -p pacman-g2 >/dev/null 2>&1 && \
-                let packages+="$(pacman-g2 -Q | wc -l)"
+                packages=$((packages+=$(pacman-g2 -Q | wc -l)))
 
             type -p cave >/dev/null 2>&1 && \
-                let packages+=$(ls -d -1 /var/db/paludis/repositories/cross-installed/*/data/* /var/db/paludis/repositories/installed/data/* | wc -l)
+                packages=$((packages+=$(ls -d -1 /var/db/paludis/repositories/cross-installed/*/data/* /var/db/paludis/repositories/installed/data/* | wc -l)))
         ;;
 
         "Mac OS X")

--- a/neofetch
+++ b/neofetch
@@ -646,43 +646,43 @@ getuptime () {
 getpackages () {
     case "$os" in
         "Linux")
-            if type -p pacman >/dev/null 2>&1; then
+            type -p pacman >/dev/null 2>&1 && \
                 packages="$(pacman -Qq --color never | wc -l)"
 
-            elif type -p dpkg >/dev/null 2>&1; then
+            [ -z "$packages" ] && type -p dpkg >/dev/null 2>&1 && \
                 packages="$(dpkg --get-selections | grep -cv deinstall$)"
 
-            elif type -p /sbin/pkgtool >/dev/null 2>&1; then
+            [ -z "$packages" ] && type -p /sbin/pkgtool >/dev/null 2>&1 && \
                 packages="$(ls -1 /var/log/packages | wc -l)"
 
-            elif type -p rpm >/dev/null 2>&1; then
+            [ -z "$packages" ] && type -p rpm >/dev/null 2>&1 && \
                 packages="$(rpm -qa | wc -l)"
 
-            elif type -p xbps-query >/dev/null 2>&1; then
+            [ -z "$packages" ] && type -p xbps-query >/dev/null 2>&1 && \
                 packages="$(xbps-query -l | wc -l)"
 
-            elif type -p pkginfo >/dev/null 2>&1; then
+            [ -z "$packages" ] && type -p pkginfo >/dev/null 2>&1 && \
                 packages="$(pkginfo -i | wc -l)"
 
-            elif type -p pisi >/dev/null 2>&1; then
+            [ -z "$packages" ] && type -p pisi >/dev/null 2>&1 && \
                 packages="$(pisi list-installed | wc -l)"
 
-            elif type -p pkg >/dev/null 2>&1; then
+            [ -z "$packages" ] && type -p pkg >/dev/null 2>&1 && \
                 packages="$(ls -1 /var/db/pkg | wc -l)"
 
-            elif type -p emerge >/dev/null 2>&1; then
+            [ -z "$packages" ] && type -p emerge >/dev/null 2>&1 && \
                 packages="$(ls -d /var/db/pkg/*/* | wc -l)"
 
-            elif type -p nix-env >/dev/null 2>&1; then
+            [ -z "$packages" ] && type -p nix-env >/dev/null 2>&1 && \
                 packages="$(ls -d -1 /nix/store/*/ | wc -l)"
 
-            elif type -p apk >/dev/null 2>&1; then
+            [ -z "$packages" ] && type -p apk >/dev/null 2>&1 && \
                 packages="$(apk info | wc -l)"
 
-            elif type -p pacman-g2 >/dev/null 2>&1; then
+            [ -z "$packages" ] && type -p pacman-g2 >/dev/null 2>&1 && \
                 packages="$(pacman-g2 -Q | wc -l)"
 
-            elif type -p cave >/dev/null 2>&1; then
+            if [ -z "$packages" ] && type -p cave >/dev/null 2>&1; then
                 cross_packages=$(ls -d -1 /var/db/paludis/repositories/cross-installed/*/data/* | wc -l)
                 packages=$(ls -d -1 /var/db/paludis/repositories/installed/data/* | wc -l)
                 packages=$((packages + cross_packages))


### PR DESCRIPTION
This breaks up the package `if` block into individual blocks which will allow 
the package count to work with multiple package managers. This will also 
help out with adding bedrock linux support!

TODO

- ~~Add up the result from each package manager.~~
- ~~Testing~~

Fixes **#228**.