### PR TITLE
OSX and BSD uptime fixes.

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -590,11 +590,11 @@ getuptime () {
             hours=$((uptime / 3600%24))
             days=$((uptime / 86400))
 
-            days="$days days,"
-            hours="$hours hours,"
-            mins="$mins minutes"
+            days=" $days days,"
+            hours=" $hours hours,"
+            mins=" $mins minutes"
 
-            uptime="up ${days/0 days,} ${hours/0 hours,} ${mins/0 minutes}"
+            uptime="up${days/ 0 days,}${hours/ 0 hours,}${mins/ 0 minutes}"
         ;;
     esac
 

--- a/neofetch
+++ b/neofetch
@@ -590,6 +590,10 @@ getuptime () {
             hours=$((uptime / 3600%24))
             days=$((uptime / 86400))
 
+            echo "$mins"
+            echo "$hours"
+            echo "$days"
+
             # Format the output like Linux's "uptime -p" cmd.
             if [ "$mins" == 1 ]; then
                 uptime="$mins minute"

--- a/neofetch
+++ b/neofetch
@@ -590,20 +590,25 @@ getuptime () {
             hours=$((uptime / 3600%24))
             days=$((uptime / 86400))
 
-            days=" $days days"
-            hours=", $hours hours"
-            mins=", $mins minutes"
+            case "$mins" in
+                1) mins="1 minute" ;;
+                0) ;;
+                *) mins="$mins minutes" ;;
+            esac
 
-            days=${days/ 0 days}
-            days=${days/, 1 days/, 1 day}
+            case "$hours" in
+                1) hours="1 hour" ;;
+                0) ;;
+                *) hours="$hours hours" ;;
+            esac
 
-            hours=${hours/, 0 hours}
-            hours=${hours/, 1 hours/, 1 hour}
+            case "$days" in
+                1) days="1 day" ;;
+                0) ;;
+                *) days="$days days" ;;
+            esac
 
-            mins=${mins/, 0 minutes}
-            mins=${mins/, 1 minutes/, 1 minute}
-
-            uptime="up ${days}${hours}${mins}"
+            uptime="up $days, $hours, $minutes"
         ;;
     esac
 

--- a/neofetch
+++ b/neofetch
@@ -590,15 +590,11 @@ getuptime () {
             hours=$((uptime / 3600%24))
             days=$((uptime / 86400))
 
-            echo "$mins"
-            echo "$hours"
-            echo "$days"
-
             days="$days days,"
             hours="$hours hours,"
             mins="$mins minutes"
 
-            uptime="up ${days/0 days,} ${hours/ 0 hours,} ${mins/0 mins}"
+            uptime="up ${days/0 days,} ${hours/0 hours,} ${mins/0 mins}"
         ;;
     esac
 

--- a/neofetch
+++ b/neofetch
@@ -590,20 +590,20 @@ getuptime () {
             hours=$((uptime / 3600%24))
             days=$((uptime / 86400))
 
-            days=" $days days,"
-            hours=" $hours hours,"
-            mins=" $mins minutes"
+            days=" $days days"
+            hours=", $hours hours"
+            mins=", $mins minutes"
 
-            days=${days/ 0 days,}
-            days=${days/ 1 days/ 1 day}
+            days=${days/ 0 days}
+            days=${days/, 1 days/, 1 day}
 
-            hours=${hours/ 0 hours,}
-            hours=${hours/ 1 hours/ 1 hour}
+            hours=${hours/, 0 hours}
+            hours=${hours/, 1 hours/, 1 hour}
 
-            mins=${mins/ 0 minutes}
-            mins=${mins/ 1 minutes/ 1 minute}
+            mins=${mins/, 0 minutes}
+            mins=${mins/, 1 minutes/, 1 minute}
 
-            uptime="up${days}${hours}${mins}"
+            uptime="up ${days}${hours}${mins}"
         ;;
     esac
 

--- a/neofetch
+++ b/neofetch
@@ -591,22 +591,22 @@ getuptime () {
             days=$((uptime / 86400))
 
             # Format the output like Linux's "uptime -p" cmd.
-            if [ "$mins" == 1 ]; then
-                uptime="$mins minute"
-            elif [ "$mins" != 0 ]; then
+            if [ "$mins" != 0 ]; then
                 uptime="$mins minutes"
+            else
+                uptime="$mins minute"
             fi
 
-            if [ "$hours" == 1 ]; then
-                uptime="$hours hour, $uptime"
-            elif [ "$mins" != 0 ]; then
+            if [ "$mins" != 0 ]; then
                 uptime="$hours hours, $uptime"
+            else
+                uptime="$hours hour, $uptime"
             fi
 
-            if [ "$days" == 1 ]; then
-                uptime="$days day, $uptime"
-            elif [ "$days" != 0 ]; then
+            if [ "$days" != 0 ]; then
                 uptime="$days days, $uptime"
+            else
+                uptime="$days day, $uptime"
             fi
 
             uptime="up $uptime"

--- a/neofetch
+++ b/neofetch
@@ -594,26 +594,11 @@ getuptime () {
             echo "$hours"
             echo "$days"
 
-            # Format the output like Linux's "uptime -p" cmd.
-            if [ "$mins" == 1 ]; then
-                uptime="$mins minute"
-            elif [ "$mins" != 0 ]; then
-                uptime="$mins minutes"
-            fi
+            days="$days days,"
+            hours="$hours hours,"
+            mins="$mins minutes"
 
-            if [ "$hours" == 1 ]; then
-                uptime="$hours hour, $uptime"
-            elif [ "$mins" != 0 ]; then
-                uptime="$hours hours, $uptime"
-            fi
-
-            if [ "$days" == 1 ]; then
-                uptime="$days day, $uptime"
-            elif [ "$days" != 0 ]; then
-                uptime="$days days, $uptime"
-            fi
-
-            uptime="up $uptime"
+            uptime="up ${days/0 days,} ${hours/ 0 hours,} ${mins/0 mins}"
         ;;
     esac
 

--- a/neofetch
+++ b/neofetch
@@ -608,7 +608,7 @@ getuptime () {
                 *) days="$days days," ;;
             esac
 
-            uptime="up $days, $hours, $minutes"
+            uptime="up $days $hours $minutes"
         ;;
     esac
 

--- a/neofetch
+++ b/neofetch
@@ -597,16 +597,24 @@ getuptime () {
             esac
 
             case "$hours" in
-                1) hours="1 hour," ;;
+                1) hours="1 hour" ;;
                 0) unset hours ;;
-                *) hours="$hours hours," ;;
+                *) hours="$hours hours" ;;
             esac
 
             case "$days" in
-                1) days="1 day," ;;
-                0) unset days;;
-                *) days="$days days," ;;
+                1) days="1 day" ;;
+                0) unset days ;;
+                *) days="$days days" ;;
             esac
+
+            [ ! -z "$hours" ] && \
+            [ ! -z "$minutes" ] && \
+                hours+=","
+
+            [ ! -z "$days" ] && \
+            [ ! -z "$hours" ] && \
+                days+=","
 
             uptime="up $days $hours $minutes"
         ;;

--- a/neofetch
+++ b/neofetch
@@ -592,20 +592,20 @@ getuptime () {
 
             case "$minutes" in
                 1) minutes="1 minute" ;;
-                0) ;;
+                0) unset minutes ;;
                 *) minutes="$minutes minutes" ;;
             esac
 
             case "$hours" in
-                1) hours="1 hour" ;;
-                0) ;;
-                *) hours="$hours hours" ;;
+                1) hours="1 hour," ;;
+                0) unset hours ;;
+                *) hours="$hours hours," ;;
             esac
 
             case "$days" in
-                1) days="1 day" ;;
-                0) ;;
-                *) days="$days days" ;;
+                1) days="1 day," ;;
+                0) unset days;;
+                *) days="$days days," ;;
             esac
 
             uptime="up $days, $hours, $minutes"

--- a/neofetch
+++ b/neofetch
@@ -594,7 +594,16 @@ getuptime () {
             hours=" $hours hours,"
             mins=" $mins minutes"
 
-            uptime="up${days/ 0 days,}${hours/ 0 hours,}${mins/ 0 minutes}"
+            days=${days/ 0 days,}
+            days=${days/ 1 days/ 1 day}
+
+            hours=${hours/ 0 hours,}
+            hours=${hours/ 1 hours/ 1 hour}
+
+            mins=${mins/ 0 minutes}
+            mins=${mins/ 1 minutes/ 1 minute}
+
+            uptime="up${days}${hours}${mins}"
         ;;
     esac
 

--- a/neofetch
+++ b/neofetch
@@ -591,32 +591,24 @@ getuptime () {
             days=$((uptime / 86400))
 
             case "$minutes" in
-                1) minutes="1 minute" ;;
+                1) uptime="1 minute" ;;
                 0) unset minutes ;;
-                *) minutes="$minutes minutes" ;;
+                *) uptime="$minutes minutes" ;;
             esac
 
             case "$hours" in
-                1) hours="1 hour" ;;
+                1) uptime="1 hour, $uptime" ;;
                 0) unset hours ;;
-                *) hours="$hours hours" ;;
+                *) uptime="$hours hours, $uptime" ;;
             esac
 
             case "$days" in
-                1) days="1 day" ;;
+                1) uptime="1 day, $uptime" ;;
                 0) unset days ;;
-                *) days="$days days" ;;
+                *) uptime="$days days, $uptime" ;;
             esac
 
-            [ ! -z "$hours" ] && \
-            [ ! -z "$minutes" ] && \
-                hours+=","
-
-            [ ! -z "$days" ] && \
-            [ ! -z "$hours" ] && \
-                days+=","
-
-            uptime="up $days $hours $minutes"
+            uptime="up $uptime"
         ;;
     esac
 

--- a/neofetch
+++ b/neofetch
@@ -594,7 +594,7 @@ getuptime () {
             hours="$hours hours,"
             mins="$mins minutes"
 
-            uptime="up ${days/0 days,} ${days/1 days/1 day} ${hours/0 hours,} ${hours/1 hours/1 hour} ${mins/0 minutes} ${mins/1 minutes/1 minute}"
+            uptime="up ${days/0 days,} ${hours/0 hours,} ${mins/0 minutes}"
         ;;
     esac
 

--- a/neofetch
+++ b/neofetch
@@ -623,7 +623,7 @@ getuptime () {
     # Make the output of uptime smaller.
     case "$uptime_shorthand" in
         "on")
-            uptime=${uptime/up}
+            uptime=${uptime/up }
             uptime=${uptime/minutes/mins}
             uptime=${uptime/minute/min}
             uptime=${uptime/seconds/secs}
@@ -631,7 +631,7 @@ getuptime () {
         ;;
 
         "tiny")
-            uptime=${uptime/up}
+            uptime=${uptime/up }
             uptime=${uptime/ days/d}
             uptime=${uptime/ day/d}
             uptime=${uptime/ hours/h}

--- a/neofetch
+++ b/neofetch
@@ -586,14 +586,14 @@ getuptime () {
             uptime=$((now - boot))
 
             # Convert uptime to days/hours/mins
-            mins=$((uptime / 60%60))
+            minutes=$((uptime / 60%60))
             hours=$((uptime / 3600%24))
             days=$((uptime / 86400))
 
-            case "$mins" in
-                1) mins="1 minute" ;;
+            case "$minutes" in
+                1) minutes="1 minute" ;;
                 0) ;;
-                *) mins="$mins minutes" ;;
+                *) minutes="$minutes minutes" ;;
             esac
 
             case "$hours" in

--- a/neofetch
+++ b/neofetch
@@ -591,22 +591,22 @@ getuptime () {
             days=$((uptime / 86400))
 
             # Format the output like Linux's "uptime -p" cmd.
-            if [ "$mins" != 0 ]; then
-                uptime="$mins minutes"
-            else
+            if [ "$mins" == 1 ]; then
                 uptime="$mins minute"
+            elif [ "$mins" != 0 ]; then
+                uptime="$mins minutes"
             fi
 
-            if [ "$mins" != 0 ]; then
-                uptime="$hours hours, $uptime"
-            else
+            if [ "$hours" == 1 ]; then
                 uptime="$hours hour, $uptime"
+            elif [ "$mins" != 0 ]; then
+                uptime="$hours hours, $uptime"
             fi
 
-            if [ "$days" != 0 ]; then
-                uptime="$days days, $uptime"
-            else
+            if [ "$days" == 1 ]; then
                 uptime="$days day, $uptime"
+            elif [ "$days" != 0 ]; then
+                uptime="$days days, $uptime"
             fi
 
             uptime="up $uptime"

--- a/neofetch
+++ b/neofetch
@@ -591,24 +591,32 @@ getuptime () {
             days=$((uptime / 86400))
 
             case "$minutes" in
-                1) uptime="1 minute" ;;
+                1) minutes="1 minute" ;;
                 0) unset minutes ;;
-                *) uptime="$minutes minutes" ;;
+                *) minutes="$minutes minutes" ;;
             esac
 
             case "$hours" in
-                1) uptime="1 hour, $uptime" ;;
+                1) hours="1 hour" ;;
                 0) unset hours ;;
-                *) uptime="$hours hours, $uptime" ;;
+                *) hours="$hours hours" ;;
             esac
 
             case "$days" in
-                1) uptime="1 day, $uptime" ;;
+                1) days="1 day" ;;
                 0) unset days ;;
-                *) uptime="$days days, $uptime" ;;
+                *) days="$days days" ;;
             esac
 
-            uptime="up $uptime"
+            [ ! -z "$hours" ] && \
+            [ ! -z "$minutes" ] && \
+                hours+=","
+
+            [ ! -z "$days" ] && \
+            [ ! -z "$hours" ] && \
+                days+=","
+
+            uptime="up $days $hours $minutes"
         ;;
     esac
 

--- a/neofetch
+++ b/neofetch
@@ -594,7 +594,7 @@ getuptime () {
             hours="$hours hours,"
             mins="$mins minutes"
 
-            uptime="up ${days/0 days,} ${hours/0 hours,} ${mins/0 mins}"
+            uptime="up ${days/0 days,} ${days/1 days/1 day} ${hours/0 hours,} ${hours/1 hours/1 hour} ${mins/0 minutes} ${mins/1 minutes/1 minute}"
         ;;
     esac
 


### PR DESCRIPTION
This PR aims to fix issues with the OS X and BSD part of the uptime function.

Changes
- $mins is now $minutes
- Fixes format issues with uptime on OS X and BSD
- Fixes #230 

TODO
- Testing