### PR TITLE
fixed wallpaper if using default GNOME wallpaper

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1869,6 +1869,11 @@ getwallpaper () {
                 # Strip quotes etc from the path.
                 img=${img/'file://'}
                 img=${img//\'}
+
+                # If image is the default GNOME wallpaper cycle, use the day image
+                if [[ $img == *adwaita-timed.xml ]]; then
+                    img=/usr/share/backgrounds/gnome/adwaita-day.jpg
+                fi
             fi
         ;;
 


### PR DESCRIPTION
By default in GNOME, the "wallpaper" is actually an XML file (unless you've changed the wallpaper). Now we check if the file is `adwaita-timed.xml` and if it is we use `/usr/share/backgrounds/gnome/adwaita-day.jpg` as the wallpaper image (figuring out which image from the set of 3 to use would make the wallpaper detection take a lot longer, with calls to `awk` and `time`)