### PR TITLE
[Linux / Windows] Memory: Use memavail when available.

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1212,8 +1212,14 @@ getgpu () {
 getmemory () {
     case "$os" in
         "Linux" | "Windows")
-            mem=($(awk -F ':| kB' '/MemTotal|MemFree|Buffers|Cached/ {printf $2}' /proc/meminfo) 0 0)
-            memused=$((mem[0] - mem[1] - mem[2] - mem[3]))
+            if [ ! -z "$(grep -F "MemAvail" /proc/meminfo)" ]; then
+                mem=($(awk -F ':| kB' '/MemTotal|MemAvail/ {printf $2}' /proc/meminfo))
+                memused=$((mem[0] - mem[1]))
+            else
+                mem=($(awk -F ':| kB' '/MemTotal|MemFree|Buffers|Cached/ {printf $2}' /proc/meminfo) 0 0)
+                memused=$((mem[0] - mem[1] - mem[2] - mem[3]))
+            fi
+
             memused=$((memused / 1024))
             memtotal=$((mem[0] / 1024))
         ;;


### PR DESCRIPTION
This makes the memory function use `memavail` when available.

This is a better replacement (imo) to #233 and #234.

TODO:

- [x] Testing