### PR TITLE
[WIP] Added better Ubuntu-GNOME ascii art

### DIFF
--- a/ascii/distro/ubuntu-gnome
+++ b/ascii/distro/ubuntu-gnome
@@ -1,22 +1,18 @@
 "\
-${c1}            .:/+oossssoo+/:.
-        \`:+ssssssssssssssssss+:\`
-      -+ssssssssssssssssssssssss+-
-    -ossssssssssss/osssssssssssssso.
-   /sssssssssss+-   -ossssssssssssss/
-  +ssssssssss/\`  -:\`  -osssssssssssss+
- +ssssssssss.  :ssos/\`  -ossssssssssss+
--ssssssssss/  :s+\` -os/\`  -osssssssssss-
-+ssssssssss+  \`os:\`  -os/\`  -osssssssss+
-ssssssssssss/   :ss:\`  -os/\`  -ossssssss
-ssssssssss//so-  \`:ss:\`  -os/\`  -ossssss
-+ssssssss:  \`/so-  \`:ss:\`  -os/./ssssss+
--ssssssssso-  \`/so-  \`+ss-  \`osssssssss-
- +sssssssssso-  \`/so:/ss:  .osssssssss+
-  +ssssssssssso-   -::-  \`+ssssssssss+
-   /sssssssssssso:.\`  \`-+sssssssssss/
-    .osssssssssssssssssssssssssssso.
-      -+ssssssssssssssssssssssss+-
-        \`:+ssssssssssssssssss+:\`
-            .:/+oossssoo+/:.
+${c3}          ./o.
+${c3}        .oooooooo
+${c3}      .oooo\`\`\`soooo
+${c3}    .oooo\`     \`soooo
+${c3}   .ooo\`   ${c4}.o.${c3}   \`\/ooo.
+${c3}   :ooo   ${c4}:oooo.${c3}   \`\/ooo.
+${c3}    sooo    ${c4}\`ooooo${c3}    \/oooo
+${c3}     \/ooo    ${c4}\`soooo${c3}    \`ooooo
+${c3}      \`soooo    ${c4}\`\/ooo${c3}    \`soooo
+${c4}./oo    ${c3}\`\/ooo    ${c4}\`/oooo.${c3}   \`/ooo
+${c4}\`\/ooo.   ${c3}\`/oooo.   ${c4}\`/oooo.${c3}   \`\`
+${c4}  \`\/ooo.    ${c3}/oooo     ${c4}/ooo\`${c3}
+${c4}     \`ooooo    ${c3}\`\`    ${c4}.oooo${c3}
+${c4}       \`soooo.     .oooo\`
+${c4}         \`\/oooooooooo\`
+${c4}            \`\`\/oo\`\`
 "

--- a/neofetch
+++ b/neofetch
@@ -2464,7 +2464,7 @@ colors () {
         ;;
 
         "CRUX"* | "Chakra"* | "gNewSense"* | "SailfishOS"* | "Alpine"* | "Ubuntu-GNOME"* | "Qubes"*)
-            setcolors 4 5 7
+            setcolors 4 5 7 6
         ;;
 
         "Chrom"*)


### PR DESCRIPTION
Everything's fine apart from the fact that the ASCII is getting too close to the output. I can see a variable called padding in the [source](https://github.com/dylanaraps/neofetch/blob/master/neofetch#L2138) but it doesn't seem like it's being used.

Also, I am trying to add an option for bold ASCII arts. I have a `hack` by changing: `[0-7]) printf "%b%s" "\033[0m\033[3${1}m"` to `[0-7]) printf "%b%s" "\033[1m\033[3${1}m"` on [line 2642](https://github.com/dylanaraps/neofetch/blob/master/neofetch#L2642). But that makes everything bold and hence will not honor settings of a user for not using bold.

**I wanted to ask how are you defining the colors for the ASCII?**

![2016-05-14_19-35-15_1366x768](https://cloud.githubusercontent.com/assets/10473142/15268870/04d5e056-1a0b-11e6-91a1-fb13f2614663.png)
