### PR TITLE
prevent 'tag artistsort' from showing up in song title

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1441,7 +1441,7 @@ getsong () {
         state=$(mpc | awk -F '\\[|\\]' '/\[/ {printf $2}' 2>/dev/null)
 
     elif [ -n "$(ps x | awk '!(/awk/) && /cmus/')" ]; then
-        song="$(cmus-remote -Q | grep "tag artist\|title" 2>/dev/null)"
+        song="$(cmus-remote -Q | grep "tag artist \|title" 2>/dev/null)"
         song=${song/tag artist }
         song=${song/tag title/-}
         song=${song//[[:space:]]/ }


### PR DESCRIPTION
adding a space prevents cmus from showing the "tag artistsort" information in the song title.

this is my first PR ever, apologies if i'm doing it wrong :)