### PR TITLE
Terminal Font Function

### DIFF
--- a/ascii/distro/windows
+++ b/ascii/distro/windows
@@ -3,7 +3,7 @@ ${c1}        ,.=:!!t3Z3z.,
        :tt:::tt333EE3
 ${c1}       Et:::ztt33EEEL${c2} @Ee.,      ..,
 ${c1}      ;tt:::tt333EE7${c2} ;EEEEEEttttt33#
-${c1}     :Et:::zt333EEQ.${c2} \$EEEEEttttt33QL
+${c1}     :Et:::zt333EEQ.${c2} $EEEEEttttt33QL
 ${c1}     it::::tt333EEF${c2} @EEEEEEttttt33F
 ${c1}    ;3=*^\`\`\`\"*4EEV${c2} :EEEEEEttttt33@.
 ${c3}    ,.=::::!t=., ${c1}\`${c2} @EEEEEEtttz33QF

--- a/config/config
+++ b/config/config
@@ -29,18 +29,20 @@ printinfo () {
     info "WM Theme" wmtheme
     info "Theme" theme
     info "Icons" icons
-    info "Font" font
+    info "Terminal Emulator" term
+    info "Terminal Font" termfont
     info "CPU" cpu
     info "GPU" gpu
     info "Memory" memory
 
     # info "Disk" disk
     # info "Battery" battery
+    # info "Font" font
+    # info "Song" song
     # info "Local IP" localip
     # info "Public IP" publicip
     # info "Users" users
     # info "Birthday" birthday
-    # info "Song" song
 
     info linebreak
     info cols

--- a/config/config
+++ b/config/config
@@ -29,7 +29,7 @@ printinfo () {
     info "WM Theme" wmtheme
     info "Theme" theme
     info "Icons" icons
-    info "Terminal Emulator" term
+    info "Terminal" term
     info "Terminal Font" termfont
     info "CPU" cpu
     info "GPU" gpu

--- a/neofetch
+++ b/neofetch
@@ -1789,18 +1789,6 @@ gettermfont () {
         "termite")
             termfont="$(awk -F '= ' '!/^($|#)/ && /font/ {printf $2; exit}' "${XDG_CONFIG_HOME}/termite/config")"
         ;;
-
-        # This only works on a global basis right now.
-        # We need to figure out a way to get the current
-        # profile in use.
-        "terminator")
-            termfont="$(awk -F '= ' '!/^($|#)/ && /font/ {printf $2; exit}' "${XDG_CONFIG_HOME}/terminator/config")"
-        ;;
-
-        "iTerm2")
-            termfile="$(/usr/libexec/plistbuddy -c Print ~/Library/Preferences/com.googlecode.iterm2.plist)"
-            termfont="$(awk -F '= ' '/Normal Font/ {printf $2; exit}' <<< "$termfile")"
-        ;;
     esac
 }
 

--- a/neofetch
+++ b/neofetch
@@ -3183,7 +3183,7 @@ while [ "$1" ]; do
             esac
         ;;
         --test)
-            info=(title underline distro kernel uptime packages shell resolution de wm wmtheme theme icons cpu gpu memory font disk battery song localip publicip users birthday)
+            info=(title underline distro kernel uptime packages shell resolution de wm wmtheme theme icons cpu gpu memory font disk battery song localip publicip users birthday term termfont)
 
             refresh_rate="on"
             shell_version="on"

--- a/neofetch
+++ b/neofetch
@@ -1760,12 +1760,9 @@ gettermfont () {
     [ -z "$term" ] && getterm
 
     case "$term" in
-        "urxvt"* | "xterm")
-            # Check for a different font line if the term is urxvt or xterm.
-            case "$term" in
-                "urxvt"*) termfont="$(awk -F ': ' '!/^($|!)/ && /t\*font/ {printf $2}' "$HOME/.Xresources")" ;;
-                "xterm")  termfont="$(awk -F ': ' '!/^($|!)/ && /m\*font/ {printf $2}' "$HOME/.Xresources")" ;;
-            esac
+        "urxvt" | "urxvtd" | "xterm")
+            termfont="$(grep -i "${term/d}\*font" "$HOME/.Xresources")"
+            termfont=${termfont/*font: }
 
             # Xresources has two different font syntax, this checks which
             # one is in use and formats it accordingly.

--- a/neofetch
+++ b/neofetch
@@ -1767,6 +1767,7 @@ getterm () {
 
         case "$name" in
             "${SHELL/*\/}" | *"sh" | "tmux" | "screen" | "systemd") getterm "$parent" ;;
+            "login" | "init") term="$(tty)"; term=${term/*\/} ;;
             *) term="$name" ;;
         esac
     fi

--- a/neofetch
+++ b/neofetch
@@ -1781,7 +1781,7 @@ gettermfont () {
 
     case "$term" in
         "urxvt" | "urxvtd" | "xterm")
-            termfont="$(grep -i "${term/d}\*font" "$HOME/.Xresources")"
+            termfont="$(grep -i "${term/d}\*font" <<< $(xrdb -query))"
             termfont=${termfont/*font: }
 
             # Xresources has two different font syntax, this checks which

--- a/neofetch
+++ b/neofetch
@@ -1770,7 +1770,7 @@ getterm () {
     case "${name// }" in
         "${SHELL/*\/}" | *"sh" | "tmux" | "screen") getterm "$parent" ;;
         "login" | "init") term="$(tty)"; term=${term/*\/} ;;
-        "ruby" | "1" | "systemd" | "sshd") unset term ;;
+        "ruby" | "1" | "systemd" | "sshd" | "python"*) unset term ;;
         "gnome-terminal-") term="gnome-terminal" ;;
         *) term="$name" ;;
     esac

--- a/neofetch
+++ b/neofetch
@@ -1771,6 +1771,7 @@ getterm () {
         "${SHELL/*\/}" | *"sh" | "tmux" | "screen") getterm "$parent" ;;
         "login" | "init") term="$(tty)"; term=${term/*\/} ;;
         "ruby" | "1" | "systemd" | "sshd") unset term ;;
+        "gnome-terminal-") term="gnome-terminal" ;;
         *) term="$name" ;;
     esac
 }

--- a/neofetch
+++ b/neofetch
@@ -1739,39 +1739,40 @@ getfont () {
 # Terminal Emulator {{{
 
 getterm () {
-    # Workaround for OS X systems that
-    # don't support the block below.
-    case "$TERM_PROGRAM" in
-        "iTerm.app") term="iTerm2" ;;
-        "Terminal.app") term="Apple Terminal" ;;
-        *) term="${TERM_PROGRAM/\.app}" ;;
+    # Check $PPID for terminal emulator.
+    case "$os" in
+        "Mac OS X")
+            # Workaround for OS X systems that
+            # don't support the block below.
+            case "$TERM_PROGRAM" in
+                "iTerm.app") term="iTerm2" ;;
+                "Terminal.app") term="Apple Terminal" ;;
+                *) term="${TERM_PROGRAM/\.app}" ;;
+            esac
+            return
+        ;;
+
+        "Windows")
+            parent="$(ps -p ${1:-$PPID} | awk '{printf $2}')"
+            parent=${parent/'PPID'}
+
+            name="$(ps -p $parent | awk '{printf $8}')"
+            name=${name/'COMMAND'}
+            name=${name/*\/}
+        ;;
+
+        *)
+            parent="$(ps -p ${1:-$PPID} -o ppid=)"
+            name="$(ps -p $parent -o comm=)"
+        ;;
     esac
 
-    # Check $PPID for terminal emulator.
-    if [ -z "$term" ]; then
-        case "$os" in
-            "Windows")
-                parent="$(ps -p ${1:-$PPID} | awk '{printf $2}')"
-                parent=${parent/'PPID'}
-
-                name="$(ps -p $parent | awk '{printf $8}')"
-                name=${name/'COMMAND'}
-                name=${name/*\/}
-            ;;
-
-            *)
-                parent="$(ps -p ${1:-$PPID} -o ppid=)"
-                name="$(ps -p $parent -o comm=)"
-            ;;
-        esac
-
-        case "${name// }" in
-            "${SHELL/*\/}" | *"sh" | "tmux" | "screen") getterm "$parent" ;;
-            "login" | "init") term="$(tty)"; term=${term/*\/} ;;
-            "ruby" | "1" | "systemd" | "sshd") unset term ;;
-            *) term="$name" ;;
-        esac
-    fi
+    case "${name// }" in
+        "${SHELL/*\/}" | *"sh" | "tmux" | "screen") getterm "$parent" ;;
+        "login" | "init") term="$(tty)"; term=${term/*\/} ;;
+        "ruby" | "1" | "systemd" | "sshd") unset term ;;
+        *) term="$name" ;;
+    esac
 }
 
 # }}}

--- a/neofetch
+++ b/neofetch
@@ -1738,7 +1738,13 @@ getfont () {
 # Terminal Emulator {{{
 
 getterm () {
-    [ -n "$ITERM_PROFILE" ] && term="iTerm2"
+    # Workaround for OS X systems that
+    # don't support the block below.
+    case "$TERM_PROGRAM" in
+        "iTerm.app") term="iTerm2" ;;
+        "Terminal.app") term="Apple Terminal" ;;
+        *) term="${TERM_PROGRAM/\.app}" ;;
+    esac
 
     # Check $PPID for terminal emulator.
     if [ -z "$term" ]; then

--- a/neofetch
+++ b/neofetch
@@ -1739,37 +1739,35 @@ getfont () {
 # Terminal Emulator {{{
 
 getterm () {
-    # Workaround for OS X systems that
-    # don't support the block below.
-    case "$TERM_PROGRAM" in
-        "iTerm.app") term="iTerm2" ;;
-        "Terminal.app") term="Apple Terminal" ;;
-        *) term="${TERM_PROGRAM/\.app}" ;;
+    # Check $PPID for terminal emulator.
+    case "$os" in
+        "Darwin")
+            case "$TERM_PROGRAM" in
+                "iTerm.app") term="iTerm2" ;;
+                "Terminal.app") term="Apple Terminal" ;;
+                *) term="${TERM_PROGRAM/\.app}" ;;
+            esac
+        ;;
+
+        "Windows")
+            parent="$(ps -p ${1:-$PPID} | awk '{printf $2}')"
+            parent=${parent/'PPID'}
+
+            name="$(ps -p $parent | awk '{printf $8}')"
+            name=${name/'COMMAND'}
+            name=${name/*\/}
+        ;;
+
+        *)
+            parent="$(ps -p ${1:-$PPID} -o ppid=)"
+            name="$(ps -p $parent -o comm=)"
+        ;;
     esac
 
-    # Check $PPID for terminal emulator.
-    if [ -z "$term" ]; then
-        case "$os" in
-            "Windows")
-                parent="$(ps -p ${1:-$PPID} | awk '{printf $2}')"
-                parent=${parent/'PPID'}
-
-                name="$(ps -p $parent | awk '{printf $8}')"
-                name=${name/'COMMAND'}
-                name=${name/*\/}
-            ;;
-
-            *)
-                parent="$(ps -p ${1:-$PPID} -o ppid=)"
-                name="$(ps -p $parent -o comm=)"
-            ;;
-        esac
-
-        case "$name" in
-            "${SHELL/*\/}" | *"sh" | "tmux" | "screen" | "systemd") getterm "$parent" ;;
-            *) term="$name" ;;
-        esac
-    fi
+    case "$name" in
+        "${SHELL/*\/}" | *"sh" | "tmux" | "screen" | "systemd") getterm "$parent" ;;
+        *) term="$name" ;;
+    esac
 }
 
 # }}}

--- a/neofetch
+++ b/neofetch
@@ -1760,18 +1760,22 @@ gettermfont () {
     [ -z "$term" ] && getterm
 
     case "$term" in
-        "urxvt"*)
-            termfont="$(awk -F ': ' '!/^($|!)/ && /\*font/ {printf $2}' "$HOME/.Xresources")"
+        "urxvt"* | "xterm")
+            # Check for a different font line if the term is urxvt or xterm.
+            case "$term" in
+                "urxvt"*) termfont="$(awk -F ': ' '!/^($|!)/ && /t\*font/ {printf $2}' "$HOME/.Xresources")" ;;
+                "xterm")  termfont="$(awk -F ': ' '!/^($|!)/ && /m\*font/ {printf $2}' "$HOME/.Xresources")" ;;
+            esac
 
+            # Xresources has two different font syntax, this checks which
+            # one is in use and formats it accordingly.
             case "$termfont" in
                 "xft:"*)
                     termfont=${termfont/xft:}
                     termfont=${termfont/:*}
                 ;;
 
-                "-"*)
-                    termfont="$(awk -F '\\-' '{printf $3}' <<< "$termfont")"
-                ;;
+                "-"*) termfont="$(awk -F '\\-' '{printf $3}' <<< "$termfont")" ;;
             esac
         ;;
 

--- a/neofetch
+++ b/neofetch
@@ -1752,7 +1752,7 @@ getterm () {
         name="$(ps -p $parent -o comm=)"
 
         case "$name" in
-            "${SHELL/*\/}" | *"sh" | "tmux" | "systemd") getterm "$parent" ;;
+            "${SHELL/*\/}" | *"sh" | "tmux" | "screen" | "systemd") getterm "$parent" ;;
             *) term="$name" ;;
         esac
     fi

--- a/neofetch
+++ b/neofetch
@@ -56,7 +56,7 @@ printinfo () {
     info "WM Theme" wmtheme
     info "Theme" theme
     info "Icons" icons
-    info "Terminal Emulator" term
+    info "Terminal" term
     info "Terminal Font" termfont
     info "CPU" cpu
     info "GPU" gpu

--- a/neofetch
+++ b/neofetch
@@ -1739,35 +1739,37 @@ getfont () {
 # Terminal Emulator {{{
 
 getterm () {
+    # Workaround for OS X systems that
+    # don't support the block below.
+    case "$TERM_PROGRAM" in
+        "iTerm.app") term="iTerm2" ;;
+        "Terminal.app") term="Apple Terminal" ;;
+        *) term="${TERM_PROGRAM/\.app}" ;;
+    esac
+
     # Check $PPID for terminal emulator.
-    case "$os" in
-        "Mac OS X")
-            case "$TERM_PROGRAM" in
-                "iTerm.app") term="iTerm2" ;;
-                "Terminal.app") term="Apple Terminal" ;;
-                *) term="${TERM_PROGRAM/\.app}" ;;
-            esac
-        ;;
+    if [ -z "$term" ]; then
+        case "$os" in
+            "Windows")
+                parent="$(ps -p ${1:-$PPID} | awk '{printf $2}')"
+                parent=${parent/'PPID'}
 
-        "Windows")
-            parent="$(ps -p ${1:-$PPID} | awk '{printf $2}')"
-            parent=${parent/'PPID'}
+                name="$(ps -p $parent | awk '{printf $8}')"
+                name=${name/'COMMAND'}
+                name=${name/*\/}
+            ;;
 
-            name="$(ps -p $parent | awk '{printf $8}')"
-            name=${name/'COMMAND'}
-            name=${name/*\/}
-        ;;
+            *)
+                parent="$(ps -p ${1:-$PPID} -o ppid=)"
+                name="$(ps -p $parent -o comm=)"
+            ;;
+        esac
 
-        *)
-            parent="$(ps -p ${1:-$PPID} -o ppid=)"
-            name="$(ps -p $parent -o comm=)"
-        ;;
-    esac
-
-    case "$name" in
-        "${SHELL/*\/}" | *"sh" | "tmux" | "screen" | "systemd") getterm "$parent" ;;
-        *) term="$name" ;;
-    esac
+        case "$name" in
+            "${SHELL/*\/}" | *"sh" | "tmux" | "screen" | "systemd") getterm "$parent" ;;
+            *) term="$name" ;;
+        esac
+    fi
 }
 
 # }}}

--- a/neofetch
+++ b/neofetch
@@ -64,6 +64,7 @@ printinfo () {
 
     # info "Disk" disk
     # info "Battery" battery
+    # info "Font" font
     # info "Song" song
     # info "Local IP" localip
     # info "Public IP" publicip

--- a/neofetch
+++ b/neofetch
@@ -2204,16 +2204,13 @@ getascii () {
     # Turn the file into a variable and strip escape codes.
     ascii_strip=$(<"$ascii")
     ascii_strip=${ascii_strip//\$\{??\}}
-    ascii_strip=${ascii_strip//\\\\/ }
-    ascii_strip=${ascii_strip//\\}
+    ascii_strip=${ascii_strip//'\\'}
+    ascii_strip=${ascii_strip//'\'}
 
     # Get length of longest line
-    # Get lines/columns of the ascii file in pure bash.
-    while read -r line 2>/dev/null; do
-        [ ${#line} -gt ${ascii_length:-0} ] && ascii_length=${#line}
-        lines=$((lines+=1))
-    done <<< "$ascii_strip"
-    lines=$((lines+=1))
+    ascii_size="$(awk 'END {printf NR " "}length>max{max=length}END{printf max}' <<< "$ascii_strip")"
+    lines=${ascii_size/ *}
+    ascii_length=${ascii_size/$lines}
 
     padding="\033[$((ascii_length + gap))C"
     printf "%b%s" "$print"

--- a/neofetch
+++ b/neofetch
@@ -2208,10 +2208,10 @@ getascii () {
     # Turn the file into a variable and strip escape codes.
     ascii_strip=$(<"$ascii")
     ascii_strip=${ascii_strip//\$\{??\}}
-    ascii_strip=${ascii_strip//'\\'}
+    ascii_strip=${ascii_strip//'\\'/ }
     ascii_strip=${ascii_strip//'\'}
 
-    # Get length of longest line
+    # Get ascii file size in rows/cols
     ascii_size="$(awk 'END {printf NR " "}length>max{max=length}END{printf max}' <<< "$ascii_strip")"
     lines=${ascii_size/ *}
     ascii_length=${ascii_size/$lines}

--- a/neofetch
+++ b/neofetch
@@ -1765,7 +1765,7 @@ getterm () {
             ;;
         esac
 
-        case "$name" in
+        case "${name// }" in
             "${SHELL/*\/}" | *"sh" | "tmux" | "screen" | "systemd") getterm "$parent" ;;
             "login" | "init") term="$(tty)"; term=${term/*\/} ;;
             *) term="$name" ;;

--- a/neofetch
+++ b/neofetch
@@ -1766,7 +1766,7 @@ getterm () {
         esac
 
         case "${name// }" in
-            "${SHELL/*\/}" | *"sh" | "tmux" | "screen" | "systemd") getterm "$parent" ;;
+            "${SHELL/*\/}" | *"sh" | "tmux" | "screen" | "systemd" | "sshd" | "ruby") getterm "$parent" ;;
             "login" | "init") term="$(tty)"; term=${term/*\/} ;;
             *) term="$name" ;;
         esac

--- a/neofetch
+++ b/neofetch
@@ -1799,8 +1799,7 @@ gettermfont () {
 
         "iTerm2")
             termfile="$(/usr/libexec/plistbuddy -c Print ~/Library/Preferences/com.googlecode.iterm2.plist)"
-            termfont="$(awk -v pattern="Name = $ITERM_PROFILE" -F '= ' '$0 ~ pattern {printf $2 " "} /Normal Font/ {printf $2 " "}' <<< "$termfile")"
-            termfont=${termfont/ $ITERM_PROFILE*}
+            termfont="$(awk -F '= ' '/Normal Font/ {printf $2; exit}' <<< "$termfile")"
         ;;
     esac
 }

--- a/neofetch
+++ b/neofetch
@@ -1746,7 +1746,7 @@ getterm () {
         name="$(ps -p $parent -o comm=)"
 
         case "$name" in
-            "${SHELL/*\/}" | *"sh" | "tmux") getterm "$parent" ;;
+            "${SHELL/*\/}" | *"sh" | "tmux" | "systemd") getterm "$parent" ;;
             *) term="$name" ;;
         esac
     fi
@@ -1761,22 +1761,33 @@ gettermfont () {
 
     case "$term" in
         "urxvt"*)
-            # Need to figure out how to best parse the Xresources file.
+            termfont="$(awk -F ': ' '!/^($|!)/ && /\*font/ {printf $2}' "$HOME/.Xresources")"
+
+            case "$termfont" in
+                "xft:"*)
+                    termfont=${termfont/xft:}
+                    termfont=${termfont/:*}
+                ;;
+
+                "-"*)
+                    termfont="$(awk -F '\\-' '{printf $3}' <<< "$termfont")"
+                ;;
+            esac
         ;;
 
         "xfce4-terminal")
-            termfont="$(awk -F '=' '/FontName/ {printf $2}' "${XDG_CONFIG_HOME}/xfce4/terminal/terminalrc")"
+            termfont="$(awk -F '=' '!/^($|\/\/)/ && /FontName/ {printf $2}' "${XDG_CONFIG_HOME}/xfce4/terminal/terminalrc")"
         ;;
 
         "termite")
-            termfont="$(awk -F '= ' '/font/ {printf $2; exit}' "${XDG_CONFIG_HOME}/termite/config")"
+            termfont="$(awk -F '= ' '!/^($|#)/ && /font/ {printf $2; exit}' "${XDG_CONFIG_HOME}/termite/config")"
         ;;
 
         "terminator")
             # This only works on a global basis right now.
             # We need to figure out a way to get the current
             # profile in use.
-            termfont="$(awk -F '= ' '/font/ {printf $2; exit}' "${XDG_CONFIG_HOME}/terminator/config")"
+            termfont="$(awk -F '= ' '!/^($|#)/ && /font/ {printf $2; exit}' "${XDG_CONFIG_HOME}/terminator/config")"
         ;;
     esac
 }

--- a/neofetch
+++ b/neofetch
@@ -1749,8 +1749,21 @@ getterm () {
 
     # Check $PPID for terminal emulator.
     if [ -z "$term" ]; then
-        parent="$(ps -p ${1:-$PPID} -o ppid=)"
-        name="$(ps -p $parent -o comm=)"
+        case "$os" in
+            "Windows")
+                parent="$(ps -p ${1:-$PPID} | awk '{printf $2}')"
+                parent=${parent/'PPID'}
+
+                name="$(ps -p $parent | awk '{printf $8}')"
+                name=${name/'COMMAND'}
+                name=${name/*\/}
+            ;;
+
+            *)
+                parent="$(ps -p ${1:-$PPID} -o ppid=)"
+                name="$(ps -p $parent -o comm=)"
+            ;;
+        esac
 
         case "$name" in
             "${SHELL/*\/}" | *"sh" | "tmux" | "screen" | "systemd") getterm "$parent" ;;

--- a/neofetch
+++ b/neofetch
@@ -1799,7 +1799,8 @@ gettermfont () {
 
         "iTerm2")
             termfile="$(/usr/libexec/plistbuddy -c Print ~/Library/Preferences/com.googlecode.iterm2.plist)"
-            termfont="$(awk -F '= ' '/Normal Font/ {printf $2; exit}' <<< "$termfile")"
+            termfont="$(awk -v pattern="Name = $ITERM_PROFILE" -F '= ' '$0 ~ pattern {printf $2 " "} /Normal Font/ {printf $2 " "}' <<< "$termfile")"
+            termfont=${termfont/ $ITERM_PROFILE*}
         ;;
     esac
 }

--- a/neofetch
+++ b/neofetch
@@ -1766,6 +1766,13 @@ gettermfont () {
         "termite")
             termfont="$(awk -F '= ' '/font/ {printf $2; exit}' "${XDG_CONFIG_HOME}/termite/config")"
         ;;
+
+        "terminator")
+            # This only works on a global basis right now.
+            # We need to figure out a way to get the current
+            # profile in use.
+            termfont="$(awk -F '= ' '/font/ {printf $2; exit}' "${XDG_CONFIG_HOME}/terminator/config")"
+        ;;
     esac
 }
 

--- a/neofetch
+++ b/neofetch
@@ -1766,8 +1766,9 @@ getterm () {
         esac
 
         case "${name// }" in
-            "${SHELL/*\/}" | *"sh" | "tmux" | "screen" | "systemd" | "sshd" | "ruby") getterm "$parent" ;;
+            "${SHELL/*\/}" | *"sh" | "tmux" | "screen") getterm "$parent" ;;
             "login" | "init") term="$(tty)"; term=${term/*\/} ;;
+            "ruby" | "1" | "systemd" | "sshd") unset term ;;
             *) term="$name" ;;
         esac
     fi

--- a/neofetch
+++ b/neofetch
@@ -56,7 +56,8 @@ printinfo () {
     info "WM Theme" wmtheme
     info "Theme" theme
     info "Icons" icons
-    info "Font" font
+    info "Terminal Emulator" term
+    info "Terminal Font" termfont
     info "CPU" cpu
     info "GPU" gpu
     info "Memory" memory
@@ -1730,6 +1731,38 @@ geticons () {
 getfont () {
     getstyle font
     font="$theme"
+}
+
+# }}}
+
+# Terminal Emulator {{{
+
+getterm () {
+    parent="$(ps -p ${1:-$PPID} -o ppid=)"
+    name="$(ps -p $parent -o comm=)"
+
+    case "$name" in
+        "${SHELL/*\/}" | *"sh") getterm "$parent" ;;
+        *) term="$name" ;;
+    esac
+}
+
+# }}}
+
+# Terminal Emulator Font {{{
+
+gettermfont () {
+    [ -z "$term" ] && getterm
+
+    case "$term" in
+        "urxvt"*)
+            # Need to figure out how to best parse the Xresources file.
+        ;;
+
+        "xfce4-terminal")
+            termfont="$(awk -F '=' '/FontName/ {printf $2}' "${XDG_CONFIG_HOME}/xfce4/terminal/terminalrc")"
+        ;;
+    esac
 }
 
 # }}}

--- a/neofetch
+++ b/neofetch
@@ -1741,7 +1741,7 @@ getfont () {
 getterm () {
     # Check $PPID for terminal emulator.
     case "$os" in
-        "Darwin")
+        "Mac OS X")
             case "$TERM_PROGRAM" in
                 "iTerm.app") term="iTerm2" ;;
                 "Terminal.app") term="Apple Terminal" ;;

--- a/neofetch
+++ b/neofetch
@@ -1790,11 +1790,16 @@ gettermfont () {
             termfont="$(awk -F '= ' '!/^($|#)/ && /font/ {printf $2; exit}' "${XDG_CONFIG_HOME}/termite/config")"
         ;;
 
+        # This only works on a global basis right now.
+        # We need to figure out a way to get the current
+        # profile in use.
         "terminator")
-            # This only works on a global basis right now.
-            # We need to figure out a way to get the current
-            # profile in use.
             termfont="$(awk -F '= ' '!/^($|#)/ && /font/ {printf $2; exit}' "${XDG_CONFIG_HOME}/terminator/config")"
+        ;;
+
+        "iTerm2")
+            termfile="$(/usr/libexec/plistbuddy -c Print ~/Library/Preferences/com.googlecode.iterm2.plist)"
+            termfont="$(awk -F '= ' '/Normal Font/ {printf $2; exit}' <<< "$termfile")"
         ;;
     esac
 }

--- a/neofetch
+++ b/neofetch
@@ -1803,6 +1803,10 @@ gettermfont () {
         "termite")
             termfont="$(awk -F '= ' '!/^($|#)/ && /font/ {printf $2; exit}' "${XDG_CONFIG_HOME}/termite/config")"
         ;;
+
+        "mintty")
+            termfont="$(awk -F '=' '!/^($|#)/ && /Font/ {printf $2; exit}' "${HOME}/.minttyrc")"
+        ;;
     esac
 }
 

--- a/neofetch
+++ b/neofetch
@@ -1762,6 +1762,10 @@ gettermfont () {
         "xfce4-terminal")
             termfont="$(awk -F '=' '/FontName/ {printf $2}' "${XDG_CONFIG_HOME}/xfce4/terminal/terminalrc")"
         ;;
+
+        "termite")
+            termfont="$(awk -F '= ' '/font/ {printf $2; exit}' "${XDG_CONFIG_HOME}/termite/config")"
+        ;;
     esac
 }
 


### PR DESCRIPTION
This PR introduces two new functions,

`term` - Get the current terminal emulator.
`termfont` - Get the terminal font.

This closes #251.

#### TODO

- [ ] Add `termfont` support for popular terminal emulators.

**Regular Configs:**

- [x] **URxvt and Xterm**
- [x] **Termite**
- [x] **Xfce4-terminal**
- [x] **Terminal.app**
- [x] **Mintty**

**Profile Based Configs:**

We need to figure out how to get the font on a per profile basis. 

- [ ] **Gnome-terminal**
- [ ] **Terminator**
- [ ] **Konsole**
- [ ] **iTerm2**

**No Configs:**

Font support can't be added as these terminals are configured at compile time.
 
- [ ] **st**
        
#### Issues

- [ ] `term` doesn't work when run from inside a tmux session.
    - This is because the `$PPID` of `tmux` is `systemd` for some odd reason.
- [x] `term` doesn't work on Windows.
    - This is because CYGWIN's `ps` command is missing the `-o` flag.
    - This has been fixed with an ugly solution imo.

#### Testing this PR

To test this PR just checkout this branch and run neofetch with 
`neofetch --config off`.