### PR TITLE
Image directory randomization can go out of bounds

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2158,7 +2158,7 @@ getimage () {
         *)
             if [ "${image: -1}" == "/" ]; then
                 files=("$image"*.png "$image"*.jpg)
-                img="$(printf "%s" "${files[RANDOM % ${#files[@]}]}")"
+                img="$(printf "%s" "${files[RANDOM % (${#files[@]} - 1)]}")"
             else
                 img="$image"
             fi


### PR DESCRIPTION
Right now it does not subtract 1 from the total number of files in a directory, so that sometimes it will not find a file and have to fallback to ascii art.
This *should* always fix this.