### PR TITLE
Add Fish version and fix BC scale.

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -770,6 +770,10 @@ getshell () {
                 shell=${shell/tcsh}
                 shell=${shell/\(*}
             ;;
+
+            *"fish"*)
+                shell+="$("$SHELL" -c 'printf "%s" "$FISH_VERSION"')"
+            ;;
         esac
 
         shell="${shell/\(*\)}"

--- a/neofetch
+++ b/neofetch
@@ -1408,7 +1408,7 @@ getmemory () {
         ;;
 
         "Mac OS X" | "iPhone OS")
-            memtotal=$(printf "%s\n" "$(sysctl -n hw.memsize)"/1024^2 | bc)
+            memtotal=$(printf "scale=0; %s\n" "$(sysctl -n hw.memsize)"/1024^2 | bc)
             memwired=$(vm_stat | awk '/wired/ { print $4 }')
             memactive=$(vm_stat | awk '/active / { printf $3 }')
             memcompressed=$(vm_stat | awk '/occupied/ { printf $5 }')


### PR DESCRIPTION
I added support for displaying the fish shell version.

I also have a `.bcrc` file that set the `scale` option, so all divides using `bc` have decimal places displayed. That makes for some ugly output. I added "scale=0" before doing the `bc` memory calculation, and it's much cleaner now.