### PR TITLE
fixed song output for cmus

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1446,9 +1446,10 @@ getsong () {
 
     elif [ -n "$(ps x | awk '!(/awk/) && /cmus/')" ]; then
         song="$(cmus-remote -Q | grep "tag artist \|title" 2>/dev/null)"
-        song=${song/tag artist }
-        song=${song/tag title/-}
-        song=${song//[[:space:]]/ }
+        artist="${song##*tag artist }"
+        title="${song##*tag title }"
+        title="${title%%tag artist*}"
+        song="$artist - $title"
         state=$(cmus-remote -Q | awk -F ' ' '/status/ {printf $2}' 2>/dev/null)
 
     elif pgrep "mocp" >/dev/null 2>&1; then


### PR DESCRIPTION
Previously would print ` - "song name" "song artist"`, now prints `"song artist" - "song name"`