### PR TITLE
Add '--size none' to disable cropping / resizing the images.

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,8 @@ alias fetch2="fetch \
     --image type                Image source. Where and what image we display.
                                 Possible values: wall, ascii,
                                 /path/to/img, /path/to/dir/, off
-    --size 20px | --size 20%    Size to make the image, takes pixels or a percentage.
+    --size 00px | --size 00%    How to size the image.
+                                Possible values: auto, 00px, 00%, none
     --image_position left/right Where to display the image: (Left/Right)
     --crop_mode mode            Which crop mode to use
                                 Takes the values: normal, fit, fill

--- a/config/config
+++ b/config/config
@@ -317,7 +317,7 @@ crop_offset="center"
 
 # Image size
 # The image is half the terminal width by default.
-# --size auto, 00px, 00%
+# --size auto, 00px, 00%, none
 image_size="auto"
 
 # Right gap between image and text

--- a/neofetch
+++ b/neofetch
@@ -2208,10 +2208,10 @@ getimage () {
 
     # Calculate font size
     if [ "$os" == "Mac OS X" ]; then
-        font_width=$((term_width / columns))
+        font_width=$((term_width / columns / 2))
     else
         # Fixes padding issues in iTerm2.
-        font_width=$((term_width / columns / 2))
+        font_width=$((term_width / columns))
     fi
 
     # Image size is half of the terminal

--- a/neofetch
+++ b/neofetch
@@ -2208,9 +2208,9 @@ getimage () {
 
     # Calculate font size
     if [ "$os" == "Mac OS X" ]; then
+        # Fixes padding issues in iTerm2.
         font_width=$((term_width / columns / 2))
     else
-        # Fixes padding issues in iTerm2.
         font_width=$((term_width / columns))
     fi
 

--- a/neofetch
+++ b/neofetch
@@ -2207,12 +2207,12 @@ getimage () {
     columns=$(tput cols)
 
     # Calculate font size
-    if [ "$os" == "Mac OS X" ]; then
-        # Fixes padding issues in iTerm2.
-        font_width=$((term_width / columns / 2))
-    else
-        font_width=$((term_width / columns))
-    fi
+    # if [ "$os" == "Mac OS X" ]; then
+    #     # Fixes padding issues in iTerm2.
+    #     font_width=$((term_width / columns / 2))
+    # else
+    font_width=$((term_width / columns))
+    # fi
 
     # Image size is half of the terminal
     case "$image_size" in

--- a/neofetch
+++ b/neofetch
@@ -2207,12 +2207,7 @@ getimage () {
     columns=$(tput cols)
 
     # Calculate font size
-    # if [ "$os" == "Mac OS X" ]; then
-    #     # Fixes padding issues in iTerm2.
-    #     font_width=$((term_width / columns / 2))
-    # else
     font_width=$((term_width / columns))
-    # fi
 
     # Image size is half of the terminal
     case "$image_size" in

--- a/neofetch
+++ b/neofetch
@@ -2277,12 +2277,12 @@ getimage () {
             size=$(identify -format "%w %h" "$img")
             og_width=${size%% *}
             og_height=${size##* }
-        fi
 
-        # This checks to see if height is geater than width
-        # so we can do a better crop of portrait images.
-        size=$og_height
-        [ "$og_height" -gt "$og_width" ] && size=$og_width
+            # This checks to see if height is geater than width
+            # so we can do a better crop of portrait images.
+            size=$og_height
+            [ "$og_height" -gt "$og_width" ] && size=$og_width
+        fi
 
         case "$crop_mode" in
             fit)

--- a/neofetch
+++ b/neofetch
@@ -2229,7 +2229,9 @@ getimage () {
 
         "none")
             # Get image size so that we can do a better crop
-            getimgsize "$img"
+            size=$(identify -format "%w %h" "$img")
+            width=${size%% *}
+            height=${size##* }
             crop_mode="none"
         ;;
 
@@ -2259,19 +2261,23 @@ getimage () {
     # Check to see if the image has a file extension, if it doesn't
     # then add one.
     case "${img##*/}" in
-        *"."*) imgname="$crop_mode-$crop_offset-$image_size-${img##*/}" ;;
-        *) imgname="$crop_mode-$crop_offset-$image_size-${img##*/}.jpg" ;;
+        *"."*) imgname="$crop_mode-$crop_offset-$width-$height-${img##*/}" ;;
+        *) imgname="$crop_mode-$crop_offset-$width-$height-${img##*/}.jpg" ;;
     esac
 
     # Check to see if the thumbnail exists before we do any cropping.
     if [ ! -f "$thumbnail_dir/$imgname" ]; then
         # Get image size so that we can do a better crop
-        getimgsize "$img"
+        if [ -z "$size" ]; then
+            size=$(identify -format "%w %h" "$img")
+            og_width=${size%% *}
+            og_height=${size##* }
+        fi
 
         # This checks to see if height is geater than width
         # so we can do a better crop of portrait images.
-        size=$height
-        [ "$height" -gt "$width" ] && size=$width
+        size=$og_height
+        [ "$og_height" -gt "$og_width" ] && size=$og_width
 
         case "$crop_mode" in
             fit)
@@ -2344,16 +2350,6 @@ getw3m_img_path () {
         image="ascii"
         err "w3m-img wasn't found on your system, falling back to ascii mode."
     fi
-}
-
-# }}}
-
-# Get Image Size {{{
-
-getimgsize () {
-    size=$(identify -format "%w %h" "$1")
-    width=${size%% *}
-    height=${size##* }
 }
 
 # }}}

--- a/neofetch
+++ b/neofetch
@@ -2207,7 +2207,12 @@ getimage () {
     columns=$(tput cols)
 
     # Calculate font size
-    font_width=$((term_width / columns))
+    if [ "$os" == "Mac OS X" ]; then
+        font_width=$((term_width / columns))
+    else
+        # Fixes padding issues in iTerm2.
+        font_width=$((term_width / columns / 2))
+    fi
 
     # Image size is half of the terminal
     case "$image_size" in

--- a/neofetch
+++ b/neofetch
@@ -2202,10 +2202,8 @@ getimage () {
         return
     fi
 
-    # Get terminal lines
+    # Get terminal lines and columns
     lines=$(tput lines)
-
-    # Get terminal columns
     columns=$(tput cols)
 
     # Calculate font size
@@ -2229,14 +2227,24 @@ getimage () {
                 image_size=$((percent * term_height / 100))
         ;;
 
+        "none")
+            # Get image size so that we can do a better crop
+            getimgsize "$img"
+            crop_mode="none"
+        ;;
+
         *) image_size=${image_size/px} ;;
     esac
+
+    # Fallback if width / height are empty.
+    width=${width:-$image_size}
+    height=${height:-$image_size}
 
     # Where to draw the image
     case "$image_position" in
         "left")
             # Padding is half the terminal width + gap
-            padding="\033[$((image_size / font_width + gap + xoffset/font_width))C"
+            padding="\033[$((width / font_width + gap + xoffset/font_width))C"
         ;;
 
         "right")
@@ -2258,9 +2266,7 @@ getimage () {
     # Check to see if the thumbnail exists before we do any cropping.
     if [ ! -f "$thumbnail_dir/$imgname" ]; then
         # Get image size so that we can do a better crop
-        size=$(identify -format "%w %h" "$img")
-        width=${size%% *}
-        height=${size##* }
+        getimgsize "$img"
 
         # This checks to see if height is geater than width
         # so we can do a better crop of portrait images.
@@ -2279,7 +2285,7 @@ getimage () {
                     -gravity south \
                     -background "$c" \
                     -extent "$size"x"$size" \
-                    -scale "$image_size"x"$image_size" \
+                    -scale "$width"x"$height" \
                     "$thumbnail_dir/$imgname"
             ;;
 
@@ -2287,18 +2293,19 @@ getimage () {
                 convert \
                     "$img" \
                     -trim +repage \
-                    -scale "$image_size"x"$image_size"^ \
-                    -extent "$image_size"x"$image_size" \
+                    -scale "$width"x"$height"^ \
+                    -extent "$width"x"$height" \
                     "$thumbnail_dir/$imgname"
             ;;
 
+            none) cp "$img" "$thumbnail_dir/$imgname" ;;
             *)
                 convert \
                     "$img" \
                     -gravity $crop_offset \
                     -crop "$size"x"$size"+0+0 \
                     -quality 95 \
-                    -scale "$image_size"x"$image_size" \
+                    -scale "$width"x"$height" \
                     "$thumbnail_dir/$imgname"
             ;;
         esac
@@ -2337,6 +2344,16 @@ getw3m_img_path () {
         image="ascii"
         err "w3m-img wasn't found on your system, falling back to ascii mode."
     fi
+}
+
+# }}}
+
+# Get Image Size {{{
+
+getimgsize () {
+    size=$(identify -format "%w %h" "$1")
+    width=${size%% *}
+    height=${size##* }
 }
 
 # }}}
@@ -3186,12 +3203,12 @@ fi
 if [ "$image" != "off" ] && [ "$image" != "ascii" ]; then
     case "$image_backend" in
         "w3m")
-            printf "%b%s\n" "0;1;$xoffset;$yoffset;$image_size;$image_size;;;;;$img\n4;\n3;" |\
+            printf "%b%s\n" "0;1;$xoffset;$yoffset;$width;$height;;;;;$img\n4;\n3;" |\
             $w3m_img_path 2>/dev/null || padding="\033[0C"
         ;;
 
         "iterm2")
-            printf "%b%s\a\n" "\033]1337;File=width=${image_size}px;height=${image_size}px;inline=1:$(base64 < "$img")"
+            printf "%b%s\a\n" "\033]1337;File=width=${width}px;height=${height}px;inline=1:$(base64 < "$img")"
         ;;
     esac
 fi

--- a/neofetch
+++ b/neofetch
@@ -344,7 +344,7 @@ crop_offset="center"
 
 # Image size
 # The image is half the terminal width by default.
-# --size auto, 00px, 00%
+# --size auto, 00px, 00%, none
 image_size="auto"
 
 # Right gap between image and text
@@ -2905,7 +2905,8 @@ usage () { cat << EOF
     --image type                Image source. Where and what image we display.
                                 Possible values: wall, ascii,
                                 /path/to/img, /path/to/dir/, off
-    --size 20px | --size 20%    Size to make the image, takes pixels or a percentage.
+    --size 00px | --size 00%    How to size the image.
+                                Possible values: auto, 00px, 00%, none
     --image_position left/right Where to display the image: (Left/Right)
     --crop_mode mode            Which crop mode to use
                                 Takes the values: normal, fit, fill

--- a/neofetch.1
+++ b/neofetch.1
@@ -172,7 +172,9 @@ Image source. Where and what image we display.
 Possible values: wall, ascii, /path/to/img, /path/to/dir/, off
 .TP
 .B \--size 'size'
-Size to make the image, takes pixels or a percentage.
+How to size the image.
+.br
+Possible values: auto, 00px, 00%, none
 .TP
 .B \--image_position 'left/right'
 Where to display the image: (Left/Right)


### PR DESCRIPTION
This adds a new option to `--size` called `none` which disables cropping/resizing the images.

Features:

- `--size none` / `size=none`: Disable cropping and resizing.
- `--crop_mode none` / `crop_mode=none`: Disable cropping.

Issues: 

- [x] This causes sizing issues on the first load when `size` is `auto`.

This fixes #261 

