### PR TITLE
fixed cmus properly, now works regardless of output order

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1452,10 +1452,16 @@ getsong () {
         state=$(mpc | awk -F '\\[|\\]' '/\[/ {printf $2}' 2>/dev/null)
 
     elif [ -n "$(ps x | awk '!(/awk/) && /cmus/')" ]; then
-        song="$(cmus-remote -Q | grep "tag artist \|title" 2>/dev/null)"
-        artist="${song##*tag artist }"
-        title="${song##*tag title }"
-        title="${title%%tag artist*}"
+        song="$(cmus-remote -Q | grep "tag artist \|title" 2>/dev/null | tr -d '\012')"
+        if [ "$(printf "$song" | awk '{print $2}')" == "title" ]; then
+            artist="${song##*tag artist }"
+            title="${song##*tag title }"
+            title="${title%%tag artist*}"
+        else
+            artist="${song##tag artist }"
+            artist="${artist%%tag title*}"
+            title="${song##*tag title }"
+        fi
         song="$artist - $title"
         state=$(cmus-remote -Q | awk -F ' ' '/status/ {printf $2}' 2>/dev/null)
 

--- a/neofetch
+++ b/neofetch
@@ -1452,18 +1452,13 @@ getsong () {
         state=$(mpc | awk -F '\\[|\\]' '/\[/ {printf $2}' 2>/dev/null)
 
     elif [ -n "$(ps x | awk '!(/awk/) && /cmus/')" ]; then
-        song="$(cmus-remote -Q | grep "tag artist \|title" 2>/dev/null | tr -d '\012')"
-        if [ "$(printf "$song" | awk '{print $2}')" == "title" ]; then
-            artist="${song##*tag artist }"
-            title="${song##*tag title }"
-            title="${title%%tag artist*}"
-        else
-            artist="${song##tag artist }"
-            artist="${artist%%tag title*}"
-            title="${song##*tag title }"
-        fi
+        IFS=$'\n'
+        song=($(cmus-remote -Q | grep "tag artist \|title \|status" 2>/dev/null | sort))
+        artist=${song[1]/tag artist }
+        title=${song[2]/tag title }
+        state=${song[0]/status }
+
         song="$artist - $title"
-        state=$(cmus-remote -Q | awk -F ' ' '/status/ {printf $2}' 2>/dev/null)
 
     elif pgrep "mocp" >/dev/null 2>&1; then
         song="$(mocp -Q "%artist - %song" 2>/dev/null)"


### PR DESCRIPTION
Got it working in one call of `cmus-remote -Q` too :+1: