### PR TITLE
Add terminology image support 2

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2283,15 +2283,11 @@ getimage () {
 
     else
         printf "%b%s" "\033[14t\033[c"
+        read_flags="-d c"
     fi
 
     # The escape code above prints the output AFTER the prompt so this
-    # loop below reads it as input. wtf xterm / terminology
-    if [ "$image_backend" == "tycat" ]; then
-        read -t 1 -s -r term_size
-    else
-        read -t 1 -d c -s -r term_size
-    fi
+    read -t 1 ${read_flags} -s -r term_size
     stty echo
 
     # Split the string

--- a/neofetch
+++ b/neofetch
@@ -2290,16 +2290,15 @@ getimage () {
     read -t 1 ${read_flags} -s -r term_size
     stty echo
 
+
+    # 83;28;8;15
+
     # Split the string
     if [ "$image_backend" == "tycat" ]; then
-        lines=${term_size%%';'*}
-        columns=${term_size%';'*';'*}
-        columns=${columns#*';'}
-        font_height=${term_size##*';'}
-        font_weight=${term_size#*';'*';'}
-        font_weight=${font_weight%';'*}
-        term_height=$((font_height * columns))
-        term_width=$((font_weight * lines))
+        term_size=(${term_size//;/ })
+        term_width=$((term_size[2] * term_size[0]))
+        term_height=$((term_size[3] * term_size[1]))
+
     else
         term_size=${term_size//'['}
         term_size=${term_size/';'}
@@ -2311,7 +2310,7 @@ getimage () {
 
     # If $img isn't a file or the terminal doesn't support xterm escape sequences,
     # fallback to ascii mode.
-    if [ ! -f "$img" ] || [ ${#term_size} -le 5 ]; then
+    if [ ! -f "$img" ] || [ ${#term_size} -le 5 ] && [ "$image_backend" != "tycat" ]; then
         image="ascii"
         getascii
 

--- a/neofetch
+++ b/neofetch
@@ -2277,23 +2277,41 @@ getimage () {
     stty -echo
     if [ -n "$TMUX" ]; then
         printf "%b%s" "\033Ptmux;\033\033[14t\033\033[c\033\\"
+
+    elif [ "$image_backend" == "tycat" ]; then
+        printf "%b%s" "\033}qs\000"
+
     else
         printf "%b%s" "\033[14t\033[c"
     fi
 
     # The escape code above prints the output AFTER the prompt so this
-    # loop below reads it as input. wtf xterm
-    read -t 1 -d c -s -r term_size
+    # loop below reads it as input. wtf xterm / terminology
+    if [ "$image_backend" == "tycat" ]; then
+        read -t 1 -s -r term_size
+    else
+        read -t 1 -d c -s -r term_size
+    fi
     stty echo
 
     # Split the string
-    term_size=${term_size//'['}
-    term_size=${term_size/';'}
-    term_size=${term_size/$'\E4'}
-    term_size=${term_size/t*}
-    term_height=${term_size/';'*}
-    term_width=${term_size/*';'}
-
+    if [ "$image_backend" == "tycat" ]; then
+        lines=${term_size%%';'*}
+        columns=${term_size%';'*';'*}
+        columns=${columns#*';'}
+        font_height=${term_size##*';'}
+        font_weight=${term_size#*';'*';'}
+        font_weight=${font_weight%';'*}
+        term_height=$((font_height * columns))
+        term_width=$((font_weight * lines))
+    else
+        term_size=${term_size//'['}
+        term_size=${term_size/';'}
+        term_size=${term_size/$'\E4'}
+        term_size=${term_size/t*}
+        term_height=${term_size/';'*}
+        term_width=${term_size/*';'}
+    fi
 
     # If $img isn't a file or the terminal doesn't support xterm escape sequences,
     # fallback to ascii mode.
@@ -3287,6 +3305,10 @@ if [ "$image" != "off" ]; then
     # If iterm2 is detected use iterm2 backend.
     if [ -n "$ITERM_PROFILE" ]; then
         image_backend="iterm2"
+
+    elif [ ! -z "$(tycat 2>/dev/null)" ]; then
+        image_backend="tycat"
+
     else
         image_backend="w3m"
     fi
@@ -3310,6 +3332,10 @@ if [ "$image" != "off" ] && [ "$image" != "ascii" ]; then
 
         "iterm2")
             printf "%b%s\a\n" "\033]1337;File=width=${width}px;height=${height}px;inline=1:$(base64 < "$img")"
+        ;;
+
+        "tycat")
+            tycat "$img"
         ;;
     esac
 fi

--- a/neofetch
+++ b/neofetch
@@ -2290,9 +2290,6 @@ getimage () {
     read -t 1 ${read_flags} -s -r term_size
     stty echo
 
-
-    # 83;28;8;15
-
     # Split the string
     if [ "$image_backend" == "tycat" ]; then
         term_size=(${term_size//;/ })


### PR DESCRIPTION
Original PR by @aranega at #272.

This is my version of his PR with some changes made.

Changes:

- Fixed some indentation.
- Changed the spacing of parts.
- We now check for `terminology` by seeing if `tycat` outputs any info. (The output of `tycat` is blank outside of terminology) I changed this because running the `term` function is a little excessive tbh.
- Removed the `read` if block and swapped it out for a variable.
- Reduced size of the formatting block below.

TODO:

- [x] Remove the read `if` block.
- [x] Reduce the size of this:

```sh
if [ "$image_backend" == "tycat" ]; then
    lines=${term_size%%';'*}
    columns=${term_size%';'*';'*}
    columns=${columns#*';'}
    font_height=${term_size##*';'}
    font_weight=${term_size#*';'*';'}
    font_weight=${font_weight%';'*}
    term_height=$((font_height * columns))
    term_width=$((font_weight * lines))
else
    term_size=${term_size//'['}
    term_size=${term_size/';'}
    term_size=${term_size/$'\E4'}
    term_size=${term_size/t*}
    term_height=${term_size/';'*}
    term_width=${term_size/*';'}
fi
```