### PR TITLE
Fix for terminology support: does not fallback on ascii when no wallpaper is found

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2307,7 +2307,7 @@ getimage () {
 
     # If $img isn't a file or the terminal doesn't support xterm escape sequences,
     # fallback to ascii mode.
-    if [ ! -f "$img" ] || [ ${#term_size} -le 5 ] && [ "$image_backend" != "tycat" ]; then
+    if [ ! -f "$img" ] || ([ ${#term_size} -le 5 ] && [ "$image_backend" != "tycat" ]); then
         image="ascii"
         getascii
 


### PR DESCRIPTION
Ok, first, sorry guys, I was so focused on how to deal with images in terminology that I totally missed this issue until now.

When no image is set and there is no background image (or a `.xml` is detected) and the image option is set to `wall` (default), neofetch does not fallback on ascii mode.
The issue comes from the line 2310:

    if [ ! -f "$img" ] || [ ${#term_size} -le 5 ] && [ "$image_backend" != "tycat" ]; then

as `||` and `&&` have the same priority, bash does not evaluate `[ ${#term_size} -le 5 ] && [ "$image_backend" != "tycat" ]` first.
Solution is simply this

    if [ ! -f "$img" ] || ([ ${#term_size} -le 5 ] && [ "$image_backend" != "tycat" ]); then

Once again, really sorry about that... (shame on me)
![93418](https://cloud.githubusercontent.com/assets/2317394/15968533/7d90f072-2f2c-11e6-97d3-ef57131072bb.jpg)
