### PR TITLE
Remove Image position

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,7 +424,6 @@ alias fetch2="fetch \
                                 /path/to/img, /path/to/dir/, off
     --size 00px | --size 00%    How to size the image.
                                 Possible values: auto, 00px, 00%, none
-    --image_position left/right Where to display the image: (Left/Right)
     --crop_mode mode            Which crop mode to use
                                 Takes the values: normal, fit, fill
     --crop_offset value         Change the crop offset for normal mode.

--- a/neofetch
+++ b/neofetch
@@ -330,11 +330,6 @@ thumbnail_dir="$HOME/.cache/thumbnails/neofetch"
 # builtin detection doesn't work.
 w3m_img_path="/usr/lib/w3m/w3mimgdisplay"
 
-# Image position
-# Only works with the w3m backend
-# --image_position left/right
-image_position="left"
-
 # Crop mode
 # --crop_mode normal/fit/fill
 crop_mode="normal"
@@ -2335,18 +2330,8 @@ getimage () {
     width="${width:-$image_size}"
     height="${height:-$image_size}"
 
-    # Where to draw the image
-    case "$image_position" in
-        "left")
-            # Padding is half the terminal width + gap
-            padding="\033[$((width / font_width + gap + xoffset/font_width))C"
-        ;;
-
-        "right")
-            padding="\033[0C"
-            xoffset="$((columns * font_width / 2 - gap))"
-        ;;
-    esac
+    # Padding is half the terminal width + gap
+    padding="\033[$((width / font_width + gap + xoffset/font_width))C"
 
     # Make the directory if it doesn't exist
     mkdir -p "$thumbnail_dir"
@@ -3018,7 +3003,6 @@ usage () { cat << EOF
                                 /path/to/img, /path/to/dir/, off
     --size 00px | --size 00%    How to size the image.
                                 Possible values: auto, 00px, 00%, none
-    --image_position left/right Where to display the image: (Left/Right)
     --crop_mode mode            Which crop mode to use
                                 Takes the values: normal, fit, fill
     --crop_offset value         Change the crop offset for normal mode.
@@ -3164,7 +3148,6 @@ while [ "$1" ]; do
         ;;
 
         --size) image_size="$2" ;;
-        --image_position) image_position="$2" ;;
         --crop_mode) crop_mode="$2" ;;
         --crop_offset) crop_offset="$2" ;;
         --xoffset) xoffset="$2" ;;

--- a/neofetch.1
+++ b/neofetch.1
@@ -179,9 +179,6 @@ How to size the image.
 .br
 Possible values: auto, 00px, 00%, none
 .TP
-.B \--image_position 'left/right'
-Where to display the image: (Left/Right)
-.TP
 .B \--crop_mode 'mode'
 Which crop mode to use
 .br


### PR DESCRIPTION
This PR removes `image_position`.

This option only worked with `w3m-img` and had rendering issues.

I'll consider re-adding this if we can support `iTerm` and `Terminology`.