### PR TITLE
Fix CPU Usage

### DIFF
--- a/1.8.md
+++ b/1.8.md
@@ -76,6 +76,12 @@ block will be.
 - [Cmus] The function now works on both OS X and Linux.
 - [iTunes] Fix song not displaying. **[@iandrewt](https://github.com/iandrewt)**
 
+**CPU Usage**<br \>
+
+- Fixed broken CPU usage output on BSD and Windows
+- Fixed misleading output on Linux / Mac OS X
+- Moved CPU Usage to its own dedicated function
+
 
 ### Image
 

--- a/README.md
+++ b/README.md
@@ -389,8 +389,6 @@ alias fetch2="fetch \
     --underline_char char       Character to use when underlining title
     --line_wrap on/off          Enable/Disable line wrapping
     --bold on/off               Enable/Disable bold text
-    --prompt_height num         Set this to your prompt height to fix issues with
-                                the text going off screen at the top
 
 
     Color Blocks:
@@ -407,9 +405,8 @@ alias fetch2="fetch \
     --progress_length num       Length in spaces to make the progress bars.
     --progress_colors num num   Colors to make the progress bar.
                                 Set in this order: elapsed, total
-    --cpu_display mode1 mode2   Which shorthand to use and how CPU usage should be printed
-                                mode1 takes: name, speed, tiny, on, off
-                                mode2 takes: info, bar, infobar, barinfo
+    --cpu_display mode          Which way should the cpu progress bar be added
+                                Takes bar, infobar, barinfo
     --memory_display mode       Which way should the memory progress bar be added
                                 Takes bar, infobar, barinfo
     --battery_display mode      Which way should the battery progress bar be added

--- a/README.md
+++ b/README.md
@@ -405,14 +405,14 @@ alias fetch2="fetch \
     --progress_length num       Length in spaces to make the progress bars.
     --progress_colors num num   Colors to make the progress bar.
                                 Set in this order: elapsed, total
-    --cpu_display mode          Which way should the cpu progress bar be added
-                                Takes bar, infobar, barinfo
-    --memory_display mode       Which way should the memory progress bar be added
-                                Takes bar, infobar, barinfo
-    --battery_display mode      Which way should the battery progress bar be added
-                                Takes bar, infobar, barinfo
-    --disk_display mode         Which way should the disk progress bar be added
-                                Takes bar, infobar, barinfo, perc
+    --cpu_display mode          Progress bar mode.
+                                Takes: bar, infobar, barinfo, off
+    --memory_display mode       Progress bar mode.
+                                Takes: bar, infobar, barinfo, off
+    --battery_display mode      Progress bar mode.
+                                Takes: bar, infobar, barinfo, off
+    --disk_display mode         Progress bar mode.
+                                Takes: bar, infobar, barinfo, off
 
 
     Image:

--- a/config/config
+++ b/config/config
@@ -115,7 +115,6 @@ cpu_display="off"
 cpu_cores="on"
 
 
-
 # GPU
 
 # Shorten output of the getgpu funcion

--- a/config/config
+++ b/config/config
@@ -99,16 +99,21 @@ shell_version="off"
 # scaling_current, scaling_min, scaling_max
 speed_type="max"
 
-# CPU Display
-# Set shorthand setting and progress bar setting
-# --cpu_display (name, speed, tiny, on, off) (bar, infobar, barinfo, off)
+# CPU Shorthand
+# Set shorthand setting
+# --cpu_shorthand name, speed, tiny, on, off
 cpu_shorthand="off"
+
+# CPU Usage display
+# Set CPU usage display setting
+# --cpu_display bar, infobar, barinfo, off
 cpu_display="off"
 
 # CPU Cores
 # Display CPU cores in output
 # --cpu_cores on/off
 cpu_cores="on"
+
 
 
 # GPU

--- a/config/config
+++ b/config/config
@@ -35,6 +35,7 @@ printinfo () {
     info "GPU" gpu
     info "Memory" memory
 
+    # info "CPU Usage" cpu_usage
     # info "Disk" disk
     # info "Battery" battery
     # info "Font" font

--- a/neofetch
+++ b/neofetch
@@ -117,11 +117,6 @@ speed_type="max"
 # --cpu_shorthand name, speed, tiny, on, off
 cpu_shorthand="off"
 
-# CPU Usage display
-# Set CPU usage display setting
-# --cpu_display bar, infobar, barinfo, off
-cpu_display="off"
-
 # CPU Cores
 # Display CPU cores in output
 # --cpu_cores on/off
@@ -294,9 +289,11 @@ progress_color_total="distro"
 # barinfo: The bar is displayed before the info.
 # off: Only the info is displayed.
 #
+# --cpu_display bar/infobar/barinfo/off
 # --memory_display bar/infobar/barinfo/off
 # --battery_display bar/infobar/barinfo/off
 # --disk_display bar/infobar/barinfo/off
+cpu_display="off"
 memory_display="off"
 battery_display="off"
 disk_display="off"

--- a/neofetch
+++ b/neofetch
@@ -47,6 +47,7 @@ printinfo () {
     info "GPU" gpu
     info "Memory" memory
 
+    info "CPU Usage" cpu_usage
     # info "Disk" disk
     # info "Battery" battery
     # info "Font" font
@@ -111,10 +112,14 @@ shell_version="off"
 # scaling_current, scaling_min, scaling_max
 speed_type="max"
 
-# CPU Display
-# Set shorthand setting and progress bar setting
-# --cpu_display (name, speed, tiny, on, off) (bar, infobar, barinfo, off)
+# CPU Shorthand
+# Set shorthand setting
+# --cpu_shorthand name, speed, tiny, on, off
 cpu_shorthand="off"
+
+# CPU Usage display
+# Set CPU usage display setting
+# --cpu_display bar, infobar, barinfo, off
 cpu_display="off"
 
 # CPU Cores
@@ -1147,18 +1152,46 @@ getcpu () {
 
     [ "$cpu" ] && prin "$subtitle" "$cpu"
 
-    if [ "$cpu_display" != "off" ]; then
-        cpu_usage="$(ps aux | awk 'BEGIN { sum = 0 }  { sum += $3 }; END { print sum }')"
-        cpu_usage=$((${cpu_usage/\.*} / cores))
-
-        case "$cpu_display" in
-            "info") prin "$subtitle Usage" "${cpu_usage}%" ;;
-            "bar") prin "$subtitle Usage" "$(bar "$cpu_usage" 100)" ;;
-            "infobar") prin "$subtitle Usage" "${cpu_usage}% $(bar $cpu_usage 100)" ;;
-            "barinfo") prin "$subtitle Usage" "$(bar $cpu_usage 100) ${cpu_usage}%" ;;
-        esac
-    fi
     [ "$stdout_mode" != "on" ] && unset cpu
+}
+
+# }}}
+
+# CPU Usage {{{
+
+getcpu_usage () {
+    case "$os" in
+        "Linux" | "Mac OS X" | "iPhone OS")
+            # Get cores if unset
+            if [ -z "$cores" ]; then
+                case "$os" in
+                    "Linux") cores="$(awk -F ': ' '/siblings/ {printf $2; exit}' /proc/cpuinfo)" ;;
+                    "Mac OS X") cores="$(sysctl -n hw.ncpu)" ;;
+                esac
+            fi
+
+            cpu_usage="$(ps aux | awk 'BEGIN { sum = 0 }  { sum += $3 }; END { print sum }')"
+            cpu_usage="$((${cpu_usage/\.*} / ${cores:-1}))"
+        ;;
+
+        "Windows")
+            cpu_usage="$(wmic cpu get loadpercentage /value)"
+            cpu_usage="${cpu_usage/LoadPercentage'='}"
+        ;;
+
+        "BSD")
+            # BSD support coming soon.
+            return
+        ;;
+    esac
+
+    # Print the bar
+    case "$cpu_display" in
+        "info") cpu_usage="${cpu_usage}%" ;;
+        "bar") cpu_usage="$(bar $cpu_usage 100)" ;;
+        "infobar") cpu_usage="${cpu_usage}% $(bar $cpu_usage 100)" ;;
+        "barinfo") cpu_usage="$(bar $cpu_usage 100) ${cpu_usage}%" ;;
+    esac
 }
 
 # }}}
@@ -2972,9 +3005,8 @@ usage () { cat << EOF
     --progress_length num       Length in spaces to make the progress bars.
     --progress_colors num num   Colors to make the progress bar.
                                 Set in this order: elapsed, total
-    --cpu_display mode1 mode2   Which shorthand to use and how CPU usage should be printed
-                                mode1 takes: name, speed, tiny, on, off
-                                mode2 takes: info, bar, infobar, barinfo
+    --cpu_display mode          Which way should the cpu progress bar be added
+                                Takes bar, infobar, barinfo
     --memory_display mode       Which way should the memory progress bar be added
                                 Takes bar, infobar, barinfo
     --battery_display mode      Which way should the battery progress bar be added
@@ -3119,10 +3151,7 @@ while [ "$1" ]; do
             progress_color_elapsed="$2"
             progress_color_total="$3"
         ;;
-        --cpu_display)
-            cpu_shorthand="$2"
-            cpu_display="$3"
-        ;;
+        --cpu_display) cpu_display="$2" ;;
         --memory_display) memory_display="$2" ;;
         --battery_display) battery_display="$2" ;;
         --disk_display) disk_display="$2" ;;

--- a/neofetch
+++ b/neofetch
@@ -3002,14 +3002,14 @@ usage () { cat << EOF
     --progress_length num       Length in spaces to make the progress bars.
     --progress_colors num num   Colors to make the progress bar.
                                 Set in this order: elapsed, total
-    --cpu_display mode          Which way should the cpu progress bar be added
-                                Takes bar, infobar, barinfo
-    --memory_display mode       Which way should the memory progress bar be added
-                                Takes bar, infobar, barinfo
-    --battery_display mode      Which way should the battery progress bar be added
-                                Takes bar, infobar, barinfo
-    --disk_display mode         Which way should the disk progress bar be added
-                                Takes bar, infobar, barinfo, perc
+    --cpu_display mode          Progress bar mode.
+                                Takes: bar, infobar, barinfo, off
+    --memory_display mode       Progress bar mode.
+                                Takes: bar, infobar, barinfo, off
+    --battery_display mode      Progress bar mode.
+                                Takes: bar, infobar, barinfo, off
+    --disk_display mode         Progress bar mode.
+                                Takes: bar, infobar, barinfo, off
 
 
     Image:

--- a/neofetch
+++ b/neofetch
@@ -1177,7 +1177,7 @@ getcpu_usage () {
         "Windows")
             cpu_usage="$(wmic cpu get loadpercentage /value)"
             cpu_usage="${cpu_usage/LoadPercentage'='}"
-            cpu_usage="${cpu_usage// }"
+            cpu_usage="${cpu_usage//[[:space:]]}"
         ;;
 
         "BSD")

--- a/neofetch
+++ b/neofetch
@@ -1173,7 +1173,7 @@ getcpu_usage () {
                 esac
             fi
 
-            cpu_usage="$(ps aux | awk 'BEGIN { sum = 0 }  { sum += $3 }; END { print sum }')"
+            cpu_usage="$(ps aux | awk 'BEGIN {sum=0} {sum+=$3 }; END {print sum}')"
             cpu_usage="$((${cpu_usage/\.*} / ${cores:-1}))"
         ;;
     esac

--- a/neofetch
+++ b/neofetch
@@ -47,7 +47,7 @@ printinfo () {
     info "GPU" gpu
     info "Memory" memory
 
-    info "CPU Usage" cpu_usage
+    # info "CPU Usage" cpu_usage
     # info "Disk" disk
     # info "Battery" battery
     # info "Font" font

--- a/neofetch
+++ b/neofetch
@@ -2799,12 +2799,9 @@ getlinebreak () {
 #
 # The 'set -f/+f' is here so that 'echo' doesn't cause any expansion
 # of special characters.
-#
-# The whitespace trim doesn't work with multiline strings so we use
-# '${1//[[:space:]]/ }' to remove newlines beofre we trim the whitespace.
 trim() {
     set -f
-    builtin echo -E ${1//$'\n'/ }
+    builtin echo -En $1
     set +f
 }
 

--- a/neofetch
+++ b/neofetch
@@ -3229,7 +3229,7 @@ while [ "$1" ]; do
             esac
         ;;
         --test)
-            info=(title underline distro kernel uptime packages shell resolution de wm wmtheme theme icons cpu gpu memory font disk battery song localip publicip users birthday term termfont)
+            info=(title underline distro kernel uptime packages shell resolution de wm wmtheme theme icons cpu cpu_usage gpu memory font disk battery song localip publicip users birthday term termfont)
 
             refresh_rate="on"
             shell_version="on"

--- a/neofetch
+++ b/neofetch
@@ -1177,6 +1177,7 @@ getcpu_usage () {
         "Windows")
             cpu_usage="$(wmic cpu get loadpercentage /value)"
             cpu_usage="${cpu_usage/LoadPercentage'='}"
+            cpu_usage="${cpu_usage// }"
         ;;
 
         "BSD")
@@ -2799,10 +2800,12 @@ getlinebreak () {
 #
 # The 'set -f/+f' is here so that 'echo' doesn't cause any expansion
 # of special characters.
+#
+# The whitespace trim doesn't work with multiline strings so we use
+# '${1//[[:space:]]/ }' to remove newlines beofre we trim the whitespace.
 trim() {
     set -f
-    builtin echo -En ${1//
-}
+    builtin echo -E ${1//[[:space:]]/ }
     set +f
 }
 

--- a/neofetch
+++ b/neofetch
@@ -2545,6 +2545,7 @@ stdout () {
             *)
                 "get$func" 2>/dev/null
                 eval output="\$$func"
+                output="$(trim "$output")"
                 stdout+="${output}${stdout_separator}"
             ;;
         esac
@@ -2803,7 +2804,7 @@ getlinebreak () {
 # '${1//[[:space:]]/ }' to remove newlines beofre we trim the whitespace.
 trim() {
     set -f
-    builtin echo -E ${1//[[:space:]]/ }
+    builtin echo -E ${1//$'\n'/ }
     set +f
 }
 

--- a/neofetch
+++ b/neofetch
@@ -1149,13 +1149,13 @@ getcpu () {
 
     if [ "$cpu_display" != "off" ]; then
         cpu_usage="$(ps aux | awk 'BEGIN { sum = 0 }  { sum += $3 }; END { print sum }')"
-        cpu_usage="${cpu_usage/\.*}%"
+        cpu_usage=$((${cpu_usage/\.*} / cores))
 
         case "$cpu_display" in
-            "info") prin "$subtitle Usage" "$cpu_usage" ;;
-            "bar") prin "$subtitle Usage" "$(bar "${cpu_usage/'%'}" $(( 100 * cores )))" ;;
-            "infobar") prin "$subtitle Usage" "${cpu_usage} $(bar "${cpu_usage/'%'}" $(( 100 * cores )))" ;;
-            "barinfo") prin "$subtitle Usage" "$(bar "${cpu_usage/'%'}" $(( 100 * cores ))) $cpu_usage" ;;
+            "info") prin "$subtitle Usage" "${cpu_usage}%" ;;
+            "bar") prin "$subtitle Usage" "$(bar "$cpu_usage" 100)" ;;
+            "infobar") prin "$subtitle Usage" "${cpu_usage}% $(bar $cpu_usage 100)" ;;
+            "barinfo") prin "$subtitle Usage" "$(bar $cpu_usage 100) ${cpu_usage}%" ;;
         esac
     fi
     [ "$stdout_mode" != "on" ] && unset cpu

--- a/neofetch
+++ b/neofetch
@@ -2801,7 +2801,8 @@ getlinebreak () {
 # of special characters.
 trim() {
     set -f
-    builtin echo -En $1
+    builtin echo -En ${1//
+}
     set +f
 }
 

--- a/neofetch
+++ b/neofetch
@@ -1161,28 +1161,23 @@ getcpu () {
 
 getcpu_usage () {
     case "$os" in
-        "Linux" | "Mac OS X" | "iPhone OS")
-            # Get cores if unset
-            if [ -z "$cores" ]; then
-                case "$os" in
-                    "Linux") cores="$(awk -F ': ' '/siblings/ {printf $2; exit}' /proc/cpuinfo)" ;;
-                    "Mac OS X") cores="$(sysctl -n hw.ncpu)" ;;
-                esac
-            fi
-
-            cpu_usage="$(ps aux | awk 'BEGIN { sum = 0 }  { sum += $3 }; END { print sum }')"
-            cpu_usage="$((${cpu_usage/\.*} / ${cores:-1}))"
-        ;;
-
         "Windows")
             cpu_usage="$(wmic cpu get loadpercentage /value)"
             cpu_usage="${cpu_usage/LoadPercentage'='}"
             cpu_usage="${cpu_usage//[[:space:]]}"
         ;;
 
-        "BSD")
-            # BSD support coming soon.
-            return
+        "Linux" | "Mac OS X" | "iPhone OS" | "BSD")
+            # Get cores if unset
+            if [ -z "$cores" ]; then
+                case "$os" in
+                    "Linux") cores="$(awk -F ': ' '/siblings/ {printf $2; exit}' /proc/cpuinfo)" ;;
+                    "Mac OS X" | "BSD") cores="$(sysctl -n hw.ncpu)" ;;
+                esac
+            fi
+
+            cpu_usage="$(ps aux | awk 'BEGIN { sum = 0 }  { sum += $3 }; END { print sum }')"
+            cpu_usage="$((${cpu_usage/\.*} / ${cores:-1}))"
         ;;
     esac
 

--- a/neofetch.1
+++ b/neofetch.1
@@ -145,27 +145,25 @@ Colors to make the progress bar.
 .br
 Set in this order: elapsed, total
 .TP
-.B \--cpu_display 'mode1' 'mode2'
-Which shorthand to use and how CPU usage should be printed
+.B \--cpu_display       'mode'
+Progress bar mode.
 .br
-mode1 takes: name, speed, tiny, on, off
-.br
-mode2 takes: info, bar, infobar, barinfo
+Takes: bar, infobar, barinfo, off
 .TP
-.B \--memory_display 'mode'
-Which way should the memory progress bar be added
+.B \--memory_display    'mode'
+Progress bar mode.
 .br
-Takes: bar, infobar, barinfo
+Takes: bar, infobar, barinfo, off
 .TP
-.B \--battery_display 'mode'
-Which way should the battery progress bar be added
+.B \--battery_display   'mode'
+Progress bar mode.
 .br
-Takes: bar, infobar, barinfo
+Takes: bar, infobar, barinfo, off
 .TP
-.B \--disk_display mode
-Which way should the disk progress bar be added
+.B \--disk_display      'mode'
+Progress bar mode.
 .br
-Takes: bar, infobar, barinfo, perc
+Takes: bar, infobar, barinfo, off
 
 .SH IMAGE
 .TP


### PR DESCRIPTION
This PR fixes CPU usage on BSD and Windows.

- Fixes CPU usage output on BSD and Windows
- Fixes misleading output on Linux / Mac OS X
- Moves CPU Usage to its own dedicated function
- Trim white-space in stdout mode.