### PR TITLE
Add support for macOS Sierra

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -483,6 +483,7 @@ getdistro () {
                 "10.9") codename="OS X Mavericks" ;;
                 "10.10") codename="OS X Yosemite" ;;
                 "10.11") codename="OS X El Capitan" ;;
+                "10.12") codename="macOS Sierra" ;;
                 *) codename="Mac OS X" ;;
             esac
             distro="$codename $osx_version $osx_build"


### PR DESCRIPTION
I can't test this yet, but unless the output of `sw_vers -productName` has changed then this will work. Can't test until mid July though... unless someone else has a Apple Developer Program subscription and can test it for me.