### PR TITLE
fixed refresh rate on OS X

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1538,7 +1538,7 @@ getresolution () {
                     awk '/Resolution:/ {printf $2"x"$4" @ "$6"Hz, "}')"
             fi
 
-            [[ "$refresh_rate" == "off" ]] || [[ "${resolution// * @ }" == "0Hz" ]] && \
+            [[ "$refresh_rate" == "off" ]] || [ "${resolution// * @ }" == "0Hz" ] && \
                 resolution="${resolution// @ *[0-9]Hz}"
         ;;
 

--- a/neofetch
+++ b/neofetch
@@ -1538,8 +1538,8 @@ getresolution () {
                     awk '/Resolution:/ {printf $2"x"$4" @ "$6"Hz, "}')"
             fi
 
-            [[ "$refresh_rate" == "off" ]] && \
-                 resolution="${resolution// @ *([0-9])Hz}"
+            [[ "$refresh_rate" == "off" ]] || [[ "$resolution" =~ "@ 0Hz" ]] && \
+                resolution="${resolution// @ *[0-9]Hz}"
         ;;
 
         "Windows")

--- a/neofetch
+++ b/neofetch
@@ -1538,7 +1538,7 @@ getresolution () {
                     awk '/Resolution:/ {printf $2"x"$4" @ "$6"Hz, "}')"
             fi
 
-            [[ "$refresh_rate" == "off" ]] || [ "${resolution// * @ }" == "0Hz" ] && \
+            [ "$refresh_rate" == "off" ] || [ "${resolution// * @ }" == "0Hz" ] && \
                 resolution="${resolution// @ *[0-9]Hz}"
         ;;
 

--- a/neofetch
+++ b/neofetch
@@ -1538,7 +1538,7 @@ getresolution () {
                     awk '/Resolution:/ {printf $2"x"$4" @ "$6"Hz, "}')"
             fi
 
-            [[ "$refresh_rate" == "off" ]] || [[ "$resolution" =~ "@ 0Hz" ]] && \
+            [[ "$refresh_rate" == "off" ]] || [[ "${resolution// * @ }" == "0Hz" ]] && \
                 resolution="${resolution// @ *[0-9]Hz}"
         ;;
 


### PR DESCRIPTION
Refresh rate no longer prints when OS X reports it as being `0Hz`