### PR TITLE
improved refresh_rate fix, now actually works on OS X...

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1538,15 +1538,13 @@ getresolution () {
                     awk '/Resolution:/ {printf $2"x"$4" @ "$6"Hz, "}')"
             fi
 
-            if [ "$refresh_rate" == "off" ] || [ "${resolution// * @ }" == "0Hz" ]; then 
-                IFS=","
-                for res in $resolution; do
-                    res="${res// @ *[0-9]Hz}"
-                    newres="$newres, $res"
-                done
-                unset IFS
-                resolution="${newres:2}"
+            if [ "$refresh_rate" == "off" ]; then 
+                resolution="${resolution// @ [0-9][0-9]Hz}"
+                resolution="${resolution// @ [0-9][0-9][0-9]Hz}"
             fi
+
+            [[ "$resolution" =~ "0Hz" ]] && \
+                resolution="${resolution// @ 0Hz}"
         ;;
 
         "Windows")

--- a/neofetch
+++ b/neofetch
@@ -1538,8 +1538,15 @@ getresolution () {
                     awk '/Resolution:/ {printf $2"x"$4" @ "$6"Hz, "}')"
             fi
 
-            [ "$refresh_rate" == "off" ] || [ "${resolution// * @ }" == "0Hz" ] && \
-                resolution="${resolution// @ *[0-9]Hz}"
+            if [ "$refresh_rate" == "off" ] || [ "${resolution// * @ }" == "0Hz" ]; then 
+                IFS=","
+                for res in $resolution; do
+                    res="${res// @ *[0-9]Hz}"
+                    newres="$newres, $res"
+                done
+                unset IFS
+                resolution="${newres:2}"
+            fi
         ;;
 
         "Windows")


### PR DESCRIPTION
So the last refresh rate fix didn't really fix anything, in fact it broke resolution without refresh rate all together when using multiple screens... Turns out the refresh rate was never removed at all when you have multiple screens. Now it works perfectly, by looping over the individual refresh rates and removing them there (all still in pure bash)