### PR TITLE
Add terminal font detection support for terminology

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1816,7 +1816,7 @@ gettermfont () {
         ;;
 
         "terminology")
-            termfont="$(strings ${XDG_CONFIG_HOME}/terminology/config/standard/base.cfg | grep -B1 font.name | head -1)"
+            termfont="$(strings ${XDG_CONFIG_HOME}/terminology/config/standard/base.cfg | awk '/^font.name$/{print a}{a=$0}')"
             termfont="${termfont/.pcf}"
             termfont="${termfont/:*}"
         ;;

--- a/neofetch
+++ b/neofetch
@@ -1814,6 +1814,12 @@ gettermfont () {
         "Apple_Terminal")
             termfont="$(osascript -e 'tell application "Terminal" to font name of window frontmost')"
         ;;
+
+        "terminology")
+            termfont="$(strings ${XDG_CONFIG_HOME}/terminology/config/standard/base.cfg | grep -B1 font.name | head -1)"
+            termfont="${termfont/.pcf}"
+            termfont="${termfont/:*}"
+        ;;
     esac
 }
 

--- a/neofetch
+++ b/neofetch
@@ -1816,7 +1816,7 @@ gettermfont () {
         ;;
 
         "terminology")
-            termfont="$(strings ${XDG_CONFIG_HOME}/terminology/config/standard/base.cfg | awk '/^font.name$/{print a}{a=$0}')"
+            termfont="$(strings ${XDG_CONFIG_HOME}/terminology/config/standard/base.cfg | awk '/^font\.name$/{print a}{a=$0}')"
             termfont="${termfont/.pcf}"
             termfont="${termfont/:*}"
         ;;


### PR DESCRIPTION
Support for terminology font name detection is based on the terminology config file. This file is always located here: `~/.config/terminology/config/standard/base.cfg` (https://github.com/billiob/terminology/blob/30cb65625bfa3b9030b80308d76ec2f30b62bd02/src/bin/config.c#L216) and is in a data/binary format. The only way I found (beside coding a dedicated extractor) is to use `strings`. The font name seems to be placed right before the `font.name` string.

    strings ~/.config/terminology/config/standard/base.cfg | grep -B1 font.name | head -1

Here are results that could be output:

    $ strings ~/.config/terminology/config/standard/base.cfg | grep -B1 font.name | head -1
    6x13.pcf
    --> (for a bitmap font) and with another font selected
    $ strings ~/.config/terminology/config/standard/base.cfg | grep -B1 font.name | head -1
    Inconsolata:style=Regular

These results are easily "parseable" in order to extract the font name for display.
