### PR TITLE
Line wrap changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,6 @@ Here's what my fetch alias looks like:
 ```sh
 alias fetch2="fetch \
 --block_range 1 8 \
---line_wrap off \
 --bold off \
 --uptime_shorthand on \
 --gtk_shorthand on \
@@ -395,7 +394,6 @@ alias fetch2="fetch \
                                 title, @, underline, subtitle, colon, info
     --underline on/off          enable/disable the underline.
     --underline_char char       Character to use when underlining title
-    --line_wrap on/off          Enable/Disable line wrapping
     --bold on/off               Enable/Disable bold text
 
 
@@ -516,33 +514,6 @@ know where it's stored then adding support won't be a problem!<br \>
 
 
 ## Issues and Workarounds
-
-
-#### The text is too long for my terminal window and wraps to the next line
-
-There are a few ways to fix this.
-
-* Disable line wrapping with `line_wrap=off` in the script or with the launch flag `--line_wrap off`
-* The uptime and gtk info lines each have a shorthand option that makes their output smaller. You can <br \>
-  enable them by changing these variables or using these flags.
-
-```sh
-# Config options
-uptime_shorthand="on"
-gtk_shorthand="on"
-gpu_shorthand="on"
-birthday_shorthand="on"
-
-# Launch flags
---uptime_shorthand on
---gtk_shorthand on
---gpu_shorthand on
---birthday_shorthand on
-
-```
-
-* Edit the config to make the subtitles shorter
-* Resizing the terminal so that the lines don't wrap.
 
 
 #### The text is pushed over too far to the right

--- a/config/config
+++ b/config/config
@@ -212,10 +212,6 @@ colors=(distro)
 # Text Options {{{
 
 
-# Toggle line wrapping
-# --line_wrap on/off
-line_wrap="off"
-
 # Toggle bold text
 # --bold on/off
 bold="on"

--- a/neofetch
+++ b/neofetch
@@ -217,10 +217,6 @@ colors=(distro)
 # Text Options {{{
 
 
-# Toggle line wrapping
-# --line_wrap on/off
-line_wrap="off"
-
 # Toggle bold text
 # --bold on/off
 bold="on"
@@ -2486,6 +2482,14 @@ info () {
     # Trim whitespace
     output="$(trim "$output")"
 
+    # Fix rendering issues with w3m and lines that
+    # wrap to the next line by adding a max line
+    # length.
+    if [ "$image" != "off" ] && [ "$image" != "ascii" ] && [ "$1" != "cols" ]; then
+        padding_num="${padding/\\033\[}"
+        output="$(printf "%.$((columns - ${padding_num/C} - gap - ${#subtitle}))s" "$output")"
+    fi
+
     case "$1" in
         title)
             string="${title_color}${bold}${output}"
@@ -2999,7 +3003,6 @@ usage () { cat << EOF
                                 title, @, underline, subtitle, colon, info
     --underline on/off          enable/disable the underline.
     --underline_char char       Character to use when underlining title
-    --line_wrap on/off          Enable/Disable line wrapping
     --bold on/off               Enable/Disable bold text
 
 

--- a/neofetch
+++ b/neofetch
@@ -2530,6 +2530,12 @@ prin () {
         string="$(printf "%.$((columns - ${padding_num/C} - gap))s" "$string")"
     fi
 
+    # If $2 doesn't exist we format $1 as info
+    if [ -z "$2" ]; then
+        subtitle_color="$info_color"
+        bold=
+    fi
+
     # Format the output
     string="${string/:/"\033[0m"${colon_color}:${info_color}}"
     string="${subtitle_color}${bold}${string}"

--- a/neofetch
+++ b/neofetch
@@ -46,6 +46,7 @@ printinfo () {
     info "CPU" cpu
     info "GPU" gpu
     info "Memory" memory
+    prin "sdddddddddddddddddddddddddddddddddddddasdasdasdasd"
 
     # info "CPU Usage" cpu_usage
     # info "Disk" disk
@@ -3345,7 +3346,7 @@ if [ "$image" != "off" ] && [ "$image" != "ascii" ]; then
 fi
 
 # Disable line wrap
-[ "$line_wrap" == "off" ] && printf "\033[?7l"
+printf "\033[?7l"
 
 # Move cursor to the top
 [ "$image" != "off" ] && printf "\033[0H"
@@ -3374,7 +3375,7 @@ esac
 [ "$image" != "off" ] && printf "%b%s" "\033[${lines:-0}H"
 
 # Re-enable line wrap
-[ "$line_wrap" == "off" ] && printf "%b%s" "\033[?7h"
+printf "%b%s" "\033[?7h"
 
 # If enabled take a screenshot
 if [ "$scrot" == "on" ]; then

--- a/neofetch
+++ b/neofetch
@@ -46,7 +46,6 @@ printinfo () {
     info "CPU" cpu
     info "GPU" gpu
     info "Memory" memory
-    prin "sdddddddddddddddddddddddddddddddddddddasdasdasdasd"
 
     # info "CPU Usage" cpu_usage
     # info "Disk" disk
@@ -2521,15 +2520,19 @@ info () {
 # Prin {{{
 
 prin () {
-    if [ -z "$2" ]; then
-        string="${info_color}${1}"
-        length="${#1}"
+    string="$1${2:+: $2}"
 
-    else
-        string="${subtitle_color}${bold}${1}\033[0m"
-        string+="${colon_color}: ${info_color}${2}"
-        length="$((${#subtitle} +  ${#2} + 1))"
+    # Fix rendering issues with w3m and lines that
+    # wrap to the next line by adding a max line
+    # length.
+    if [ "$image" != "off" ] && [ "$image" != "ascii" ]; then
+        padding_num="${padding/\\033\[}"
+        string="$(printf "%.$((columns - ${padding_num/C} - gap))s" "$string")"
     fi
+
+    # Format the output
+    string="${string/:/"\033[0m"${colon_color}:${info_color}}"
+    string="${subtitle_color}${bold}${string}"
 
     # Trim whitespace
     string="$(trim "$string")"
@@ -3147,7 +3150,6 @@ while [ "$1" ]; do
         # Text Formatting
         --underline) underline_enabled="$2" ;;
         --underline_char) underline_char="$2" ;;
-        --line_wrap) line_wrap="$2" ;;
         --bold) bold="$2" ;;
 
         # Color Blocks

--- a/neofetch.1
+++ b/neofetch.1
@@ -105,9 +105,6 @@ enable/disable the underline.
 .B \--underline_char 'char'
 Character to use when underlining title
 .TP
-.B \--line_wrap 'on/off'
-Enable/Disable line wrapping
-.TP
 .B \--bold 'on/off'
 Enable/Disable bold text
 .TP


### PR DESCRIPTION
Changes:

- Remove `$line_wrap` / `--line_wrap` since changing this from the<br \> 
default value breaks the output.
- In image mode we now use `printf` to enforce a max line width.<br \>
This fixes issues with lines through images. (See screens below)

# Without PR

![2016-08-02-231428_707x454_scrot](https://cloud.githubusercontent.com/assets/6799467/17329653/ee6be564-5906-11e6-9f00-4d86077054f0.png)

# With PR

![2016-08-02-231658_707x454_scrot](https://cloud.githubusercontent.com/assets/6799467/17329740/4ce4d920-5907-11e6-868d-47fa45ea3aa8.png)
