### PR TITLE
Added detection for Unknown OS

### DIFF
--- a/ascii/distro/others
+++ b/ascii/distro/others
@@ -1,0 +1,9 @@
+"${c1}UUU     UUU NNN      NNN IIIII XXX     XXXX
+UUU     UUU NNNN     NNN  III    XX   xXX
+UUU     UUU NNNNN    NNN  III     XX xXX
+UUU     UUU NNN NN   NNN  III      XXXX
+UUU     UUU NNN  NN  NNN  III      xXX
+UUU     UUU NNN   NN NNN  III     xXXXX
+UUU     UUU NNN    NNNNN  III    xXX  XX
+ UUUuuuUUU  NNN     NNNN  III   xXX    XX
+   UUUUU    NNN      NNN IIIII xXXx    xXXx"

--- a/neofetch
+++ b/neofetch
@@ -442,7 +442,7 @@ case "$(uname)" in
     "Darwin")  os="$(sw_vers -productName)" ;;
     *"BSD" | "DragonFly") os="BSD" ;;
     "CYGWIN"*) os="Windows" ;;
-    *) printf "%s\n" "Unknown OS detected: $(uname)"; exit 1 ;;
+    *) os="Others" ;;
 esac
 
 # }}}
@@ -510,6 +510,10 @@ getdistro () {
             # Strip crap from the output of wmic
             distro="${distro/Caption'='}"
             distro="${distro/Microsoft }"
+        ;;
+
+         "Others")
+             distro="Unknown"
         ;;
     esac
 
@@ -711,6 +715,10 @@ getpackages () {
             # Count chocolatey packages
             [ -d "/cygdrive/c/ProgramData/chocolatey/lib" ] && \
                 packages="$((packages+=$(ls -1 /cygdrive/c/ProgramData/chocolatey/lib | wc -l)))"
+        ;;
+
+       "Others")
+           packages="Unknown"
         ;;
     esac
 }
@@ -1110,6 +1118,10 @@ getcpu () {
 
             cpu="$cpu @ ${speed}GHz"
         ;;
+
+        "Others")
+            cpu="Unknown"
+        ;;
     esac
 
 
@@ -1335,7 +1347,7 @@ getgpu () {
             esac
         ;;
 
-        "BSD")
+        "BSD" | "Others")
             case "$distro" in
                 "FreeBSD"*)
                     gpu="$(pciconf -lv 2>/dev/null | grep -B 4 "VGA" | grep "device")"
@@ -1515,7 +1527,7 @@ getsong () {
 
 getresolution () {
     case "$os" in
-        "Linux" | "BSD")
+        "Linux" | "BSD" | "Others")
             if type -p xrandr >/dev/null 2>&1; then
                 case "$refresh_rate" in
                     "on") resolution="$(xrandr --nograb --current | awk 'match($0,/[0-9]*\.[0-9]*\*/) {printf $1 " @ " substr($0,RSTART,RLENGTH) "Hz, "}')" ;;
@@ -2710,8 +2722,13 @@ colors () {
             setcolors 1 2 4 3
         ;;
 
-        "Raspbian"* | *)
+        "Raspbian"*)
             setcolors 2 1
+        ;;
+
+        *)
+            setcolors 2 1
+            ascii_distro="others"
         ;;
     esac
 


### PR DESCRIPTION
This commit adds "support" (well, not exactly support, but a fallback detection method if no other OS than what's supported is detected instead of displaying just `Unknown OS detected: $(uname)`)

Some of the features will immediately work (GPU detection, DE/WM, detection, kernel detection etc.), but other features like CPU detection and RAM detection will not appear, as there'll be differences in how other *NIXes handle this.

Tested on: OpenIndiana Hipster