### PR TITLE
Added Solaris support

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -442,6 +442,7 @@ case "$(uname)" in
     "Darwin")  os="$(sw_vers -productName)" ;;
     *"BSD" | "DragonFly") os="BSD" ;;
     "CYGWIN"*) os="Windows" ;;
+    "SunOS") os="Solaris" ;;
     *) printf "%s\n" "Unknown OS detected: $(uname)"; exit 1 ;;
 esac
 
@@ -510,6 +511,10 @@ getdistro () {
             # Strip crap from the output of wmic
             distro="${distro/Caption'='}"
             distro="${distro/Microsoft }"
+        ;;
+
+        "Solaris")
+            distro="$(nawk 'NR==1{gsub(/^ \t]+|[ \t]+$/,""); printf $1 " " $2;}' /etc/release)"
         ;;
     esac
 
@@ -609,6 +614,10 @@ getuptime () {
                 days+=","
 
             uptime="up $days $hours $minutes"
+        ;;
+
+        "Solaris")
+            uptime="$(uptime | /usr/xpg4/bin/awk -F ':[0-9]{2}+[a-z][a-z]  |(, ){1}+' '{printf $2}')"
         ;;
     esac
 
@@ -711,6 +720,10 @@ getpackages () {
             # Count chocolatey packages
             [ -d "/cygdrive/c/ProgramData/chocolatey/lib" ] && \
                 packages="$((packages+=$(ls -1 /cygdrive/c/ProgramData/chocolatey/lib | wc -l)))"
+        ;;
+
+        "Solaris")
+            packages="$(pkg list | wc -l)"
         ;;
     esac
 }
@@ -1110,6 +1123,29 @@ getcpu () {
 
             cpu="$cpu @ ${speed}GHz"
         ;;
+
+        "Solaris")
+            # Get cpuname
+            cpu="$(psrinfo -pv | tail -1)"
+            cpu="${cpu/[0-9]\.*}"
+            cpu="${cpu/ @*}"
+
+            # Get cpu speed
+            speed="$(psrinfo -v | tail -2 | head -1 | awk '{print $6}')"
+            speed="$((speed / 100))"
+
+            # Get cpu cores
+            cores="$(kstat -m cpu_info | grep "chip_id" | wc -l | tr -d ' ')"
+
+            # Fix for speeds under 1ghz
+            if [ -z "${speed:1}" ]; then
+               speed="0.${speed}"
+            else
+               speed="${speed:0:1}.${speed:1}"
+            fi
+
+            cpu="$cpu @ ${speed}GHz"
+        ;;
     esac
 
 
@@ -1165,12 +1201,13 @@ getcpu_usage () {
             cpu_usage="${cpu_usage//[[:space:]]}"
         ;;
 
-        "Linux" | "Mac OS X" | "iPhone OS" | "BSD")
+        "Linux" | "Mac OS X" | "iPhone OS" | "BSD" | "Solaris")
             # Get cores if unset
             if [ -z "$cores" ]; then
                 case "$os" in
                     "Linux") cores="$(awk -F ': ' '/siblings/ {printf $2; exit}' /proc/cpuinfo)" ;;
                     "Mac OS X" | "BSD") cores="$(sysctl -n hw.ncpu)" ;;
+                    "Solaris") cores="$(kstat -m cpu_info | grep "chip_id" | wc -l | tr -d ' ')"
                 esac
             fi
 
@@ -1335,7 +1372,7 @@ getgpu () {
             esac
         ;;
 
-        "BSD")
+        "BSD" | "Solaris")
             case "$distro" in
                 "FreeBSD"*)
                     gpu="$(pciconf -lv 2>/dev/null | grep -B 4 "VGA" | grep "device")"
@@ -1416,6 +1453,12 @@ getmemory () {
             esac
 
             memtotal="$(($(sysctl -n hw.physmem) / 1024 / 1024))"
+            memused="$((memtotal - memfree))"
+        ;;
+
+        "Solaris")
+            memtotal="$(prtconf | grep Memory | head -1 | awk 'BEGIN {FS=" "} {print $3}')"
+            memfree="$(($(sar -r 1 1 | tail -1 | awk 'BEGIN {FS=" "} {print $2}') / 1024))"
             memused="$((memtotal - memfree))"
         ;;
     esac
@@ -1515,7 +1558,7 @@ getsong () {
 
 getresolution () {
     case "$os" in
-        "Linux" | "BSD")
+        "Linux" | "BSD" | "Solaris")
             if type -p xrandr >/dev/null 2>&1; then
                 case "$refresh_rate" in
                     "on") resolution="$(xrandr --nograb --current | awk 'match($0,/[0-9]*\.[0-9]*\*/) {printf $1 " @ " substr($0,RSTART,RLENGTH) "Hz, "}')" ;;
@@ -1831,7 +1874,7 @@ gettermfont () {
 getdisk () {
     # df flags
     case "$os" in
-        "Linux" | "iPhone OS" | "Windows") df_flags="-h -l --total" ;;
+        "Linux" | "iPhone OS" | "Windows" | "Solaris") df_flags="-h -l --total" ;;
         "Mac OS X" | "BSD")
             case "$distro" in
                 "FreeBSD"* | *"OS X"* ) df_flags="-H / -l" ;;
@@ -1987,7 +2030,7 @@ getlocalip () {
             [ -z "$localip" ] && localip="$(ipconfig getifaddr en1)"
         ;;
 
-        "BSD")
+        "BSD" | "Solaris")
             localip="$(ifconfig | awk '/broadcast/ {print $2}')"
         ;;
 
@@ -2067,6 +2110,11 @@ getbirthday () {
 
         "Windows")
             birthday="$(ls -alct --full-time /cygdrive/c/Windows/explorer.exe | awk '{printf $8 " " $9}')"
+            date_cmd="$(date -d"$birthday" "$birthday_format")"
+        ;;
+
+        "Solaris")
+            birthday="$(ls -alct --full-time /var/sadm/system/logs/install_log | awk '{printf $6 " " $7}')"
             date_cmd="$(date -d"$birthday" "$birthday_format")"
         ;;
     esac


### PR DESCRIPTION
This adds Solaris detection to neofetch.

The only function I can't get is battery detection. This is caused by:
1. No laptop to test it on
2. Neither Oracle nor OpenIndiana has any documentation about it, the latest information I can get is from [2006](https://blogs.oracle.com/DanX/entry/solaris_laptop_battery_status)

![virtualbox_openindiana_07_08_2016_15_21_28](https://cloud.githubusercontent.com/assets/15692230/17461363/53524a30-5cb4-11e6-8327-e909557b78e1.png)

(Yes, I used Arch logo because I don't know how to make ASCII logos, especially OpenIndiana.)