### PR TITLE
Adding PacBSD support to neofetch

### DIFF
--- a/ascii/distro/pacbsd
+++ b/ascii/distro/pacbsd
@@ -1,0 +1,26 @@
+"\
+${c1}               :+sMs.
+             `:ddNMd-                    `   -o--`
+            -sMMMMh:  `        `              `+N+``
+            yMMMMMs`     `.....-/-...``        `mNh/
+            yMMMMMmh+-`:sdmmmmmmMmmmmddy+-``./ddNMMm
+            yNMMNMMMMNdyyNNMMMMMMMMMMMMMMMhyshNmMMMm
+            :yMMMMMMMMMNdooNMMMMMMMMMMMMMMMMNmy:mMMd
+             +MMMMMMMMMmy:sNMMMMMMMMMMMMMMMMMMMmshs-
+             :hNMMMMMMN+-+MMMMMMMMMMMMMMMMMMMMMMMs.
+            .omysmNNhy/+yNMMMMMMMMMMNMMMMMMMMMNdNNy-
+            /hMM:::::/hNMMMMMMMMMMMm/-yNMMMMMMN.mMNh``
+           .hMMMMdhdMMMMMMMMMMMMMMmo  `sMMMMMMN mMMm-`
+           :dMMMMMMMMMMMMMMMMMMMMMdo+  oMMMMMMN`smMNo`
+           /dMMMMMMMMMMMMMMMMMMMMMNd/` :yMMMMMN:-hMMM.
+           :dMMMMMMMMMMMMMMMMMMMMMNh`  oMMMMMMNo/dMNN`
+           :hMMMMMMMMMMMMMMMMMMMMMMNs--sMMMMMMMNNmy++`
+            sNMMMMMMMMMMMMMMMMMMMMMMMmmNMMMMMMNho::o.
+            :yMMMMMMMMMMMMMNho+sydNNNNNNNmysso/` -//                      `
+             /dMMMMMMMMMMMMMs-  ````````..``    ./:`      /oooo.       -+ooo:`       `/ooo.`
+              .oMMMMMMMMMMMMNs`               ./y:`      `MMMMM/`     `+MMMMNy      `hNMMMm:
+                +dNMMNMMMMMMMmy`          ``./ys.         omNNm-`      -sNNNh/      `+hNNNo.
+                 `/hMMMMMMMMMMMNo-``    `.+yy+-`           ``.`         `````         ``.``
+                   `-/hmNMNMMMMMMmmddddhhy/-`                                                 `
+                       `-+oooyMMMdsoo+/:. 
+"

--- a/ascii/distro/pacbsd
+++ b/ascii/distro/pacbsd
@@ -1,26 +1,26 @@
 "\
-${c1}               :+sMs.
-             `:ddNMd-                    `   -o--`
-            -sMMMMh:  `        `              `+N+``
-            yMMMMMs`     `.....-/-...``        `mNh/
-            yMMMMMmh+-`:sdmmmmmmMmmmmddy+-``./ddNMMm
-            yNMMNMMMMNdyyNNMMMMMMMMMMMMMMMhyshNmMMMm
-            :yMMMMMMMMMNdooNMMMMMMMMMMMMMMMMNmy:mMMd
-             +MMMMMMMMMmy:sNMMMMMMMMMMMMMMMMMMMmshs-
-             :hNMMMMMMN+-+MMMMMMMMMMMMMMMMMMMMMMMs.
-            .omysmNNhy/+yNMMMMMMMMMMNMMMMMMMMMNdNNy-
-            /hMM:::::/hNMMMMMMMMMMMm/-yNMMMMMMN.mMNh``
-           .hMMMMdhdMMMMMMMMMMMMMMmo  `sMMMMMMN mMMm-`
-           :dMMMMMMMMMMMMMMMMMMMMMdo+  oMMMMMMN`smMNo`
-           /dMMMMMMMMMMMMMMMMMMMMMNd/` :yMMMMMN:-hMMM.
-           :dMMMMMMMMMMMMMMMMMMMMMNh`  oMMMMMMNo/dMNN`
-           :hMMMMMMMMMMMMMMMMMMMMMMNs--sMMMMMMMNNmy++`
-            sNMMMMMMMMMMMMMMMMMMMMMMMmmNMMMMMMNho::o.
-            :yMMMMMMMMMMMMMNho+sydNNNNNNNmysso/` -//                      `
-             /dMMMMMMMMMMMMMs-  ````````..``    ./:`      /oooo.       -+ooo:`       `/ooo.`
-              .oMMMMMMMMMMMMNs`               ./y:`      `MMMMM/`     `+MMMMNy      `hNMMMm:
-                +dNMMNMMMMMMMmy`          ``./ys.         omNNm-`      -sNNNh/      `+hNNNo.
-                 `/hMMMMMMMMMMMNo-``    `.+yy+-`           ``.`         `````         ``.``
-                   `-/hmNMNMMMMMMmmddddhhy/-`                                                 `
-                       `-+oooyMMMdsoo+/:. 
+${c1}      :+sMs.
+  \`:ddNMd-                         -o--\`
+ -sMMMMh:                          \`+N+\`\`
+ yMMMMMs\`     .....-/-...           \`mNh/
+ yMMMMMmh+-\`:sdmmmmmmMmmmmddy+-\`\`./ddNMMm
+ yNMMNMMMMNdyyNNMMMMMMMMMMMMMMMhyshNmMMMm
+ :yMMMMMMMMMNdooNMMMMMMMMMMMMMMMMNmy:mMMd
+  +MMMMMMMMMmy:sNMMMMMMMMMMMMMMMMMMMmshs-
+  :hNMMMMMMN+-+MMMMMMMMMMMMMMMMMMMMMMMs.
+ .omysmNNhy/+yNMMMMMMMMMMNMMMMMMMMMNdNNy-
+ /hMM:::::/hNMMMMMMMMMMMm/-yNMMMMMMN.mMNh\`
+.hMMMMdhdMMMMMMMMMMMMMMmo  \`sMMMMMMN mMMm-
+:dMMMMMMMMMMMMMMMMMMMMMdo+  oMMMMMMN\`smMNo\`
+/dMMMMMMMMMMMMMMMMMMMMMNd/\` :yMMMMMN:-hMMM.
+:dMMMMMMMMMMMMMMMMMMMMMNh\`  oMMMMMMNo/dMNN\`
+:hMMMMMMMMMMMMMMMMMMMMMMNs--sMMMMMMMNNmy++\`
+ sNMMMMMMMMMMMMMMMMMMMMMMMmmNMMMMMMNho::o.
+ :yMMMMMMMMMMMMMNho+sydNNNNNNNmysso/\` -//
+  /dMMMMMMMMMMMMMs-  \`\`\`\`\`\`\`\`..\`\`
+   .oMMMMMMMMMMMMNs\`               ./y:\`
+     +dNMMNMMMMMMMmy\`          \`\`./ys.
+      \`/hMMMMMMMMMMMNo-\`\`    \`.+yy+-\`
+        \`-/hmNMNMMMMMMmmddddhhy/-\`                                                 \`
+            \`-+oooyMMMdsoo+/:.
 "

--- a/neofetch
+++ b/neofetch
@@ -695,16 +695,18 @@ getpackages () {
         ;;
 
         "BSD")
-            # PacBSD has both pacman and pkg, but only pacman is used
-            if [[ "$distro" == "PacBSD"* ]]; then
-                packages="$(pacman -Qq --color never | wc -l)"
-            else
-                if type -p pkg_info >/dev/null 2>&1; then
-                    packages="$(pkg_info | wc -l)"
-                elif type -p pkg >/dev/null 2>&1; then
-                    packages="$(pkg info | wc -l)"
-                fi
-            fi
+            case "$distro" in
+                # PacBSD has both pacman and pkg, but only pacman is used
+                "PacBSD"*) packages="$(pacman -Qq --color never | wc -l)" ;;
+
+                *)
+                    if type -p pkg_info >/dev/null 2>&1; then
+                        packages="$(pkg_info | wc -l)"
+                    elif type -p pkg >/dev/null 2>&1; then
+                        packages="$(pkg info | wc -l)"
+                    fi
+                ;;
+            esac
         ;;
 
         "Windows")

--- a/neofetch
+++ b/neofetch
@@ -497,6 +497,9 @@ getdistro () {
 
             # Workaround for PCBSD as uname still displays FreeBSD.
             [ -f "/etc/pcbsd-lang" ] && distro="PCBSD"
+
+            # Workaround for PacBSD as uname displays FreeBSD.
+            [ -f "/etc/pacbsd-release" ] && distro="PacBSD"
         ;;
 
         "Windows")
@@ -692,11 +695,15 @@ getpackages () {
         ;;
 
         "BSD")
-            if type -p pkg_info >/dev/null 2>&1; then
-                packages="$(pkg_info | wc -l)"
-
-            elif type -p pkg >/dev/null 2>&1; then
-                packages="$(pkg info | wc -l)"
+            # PacBSD has both pacman and pkg, but only pacman is used
+            if [[ "$distro" == "PacBSD"* ]]; then
+                packages="$(pacman -Qq --color never | wc -l)"
+            else
+                if type -p pkg_info >/dev/null 2>&1; then
+                    packages="$(pkg_info | wc -l)"
+                elif type -p pkg >/dev/null 2>&1; then
+                    packages="$(pkg info | wc -l)"
+                fi
             fi
         ;;
 


### PR DESCRIPTION
This commit adds support for PacBSD, a FreeBSD and Arch Linux based OS.  If you can think of a better way to do the package counts let me know and I'll be glad to change it.  The problem is PacBSD has both `pacman` and `pkg` package managers installed by default, but only `pacman` is used.  I had to do the package section the way it is because if `pkg` got called `neofetch` would hang due to `pkg` wanting user input.

This commit also lacks ASCII art because I couldn't find a good way to convert our logo to ASCII, if you have any recommendations on good tools to do so let me know and I'll gladly add it to my PR.

Signed-off-by: Adam Jimerson <vendion@gmail.com>