### PR TITLE
Add new `model` function to print device model name

### DIFF
--- a/config/config
+++ b/config/config
@@ -18,6 +18,7 @@ printinfo () {
     info title
     info underline
 
+    info "Model" model
     info "OS" distro
     info "Kernel" kernel
     info "Uptime" uptime

--- a/neofetch
+++ b/neofetch
@@ -36,6 +36,57 @@ getos() {
 
 # }}}
 
+# Model {{{
+
+getmodel() {
+    case "$os" in
+        "Linux")
+            model="$(< /sys/devices/virtual/dmi/id/product_version)"
+            model="${model/To Be Filled*}"
+        ;;
+
+        "iPhone OS")
+            case "${ios_model:-$(uname -m)}" in
+                "iPad1,1") model="iPad" ;;
+                "iPad2,"[1-4]) model="iPad2" ;;
+                "iPad3,"[1-3]) model="iPad3" ;;
+                "iPad3,"[4-6]) model="iPad4" ;;
+                "iPad4,"[1-3]) model="iPad Air" ;;
+                "iPad5,"[3-4]) model="iPad Air 2" ;;
+                "iPad6,"[7-8]) model="iPad Pro (12.9 Inch)" ;;
+                "iPad6,"[3-4]) model="iPad Pro (9.7 Inch)" ;;
+                "iPad2,"[5-7]) model="iPad mini" ;;
+                "iPad4,"[4-6]) model="iPad mini 2" ;;
+                "iPad4,"[7-9]) model="iPad mini 3" ;;
+                "iPad5,"[1-2]) model="iPad mini 4" ;;
+
+                "iPhone1,1") model="iPhone" ;;
+                "iPhone1,2") model="iPhone 3G" ;;
+                "iPhone2,1") model="iPhone 3GS" ;;
+                "iPhone3,"[1-3]) model="iPhone 4" ;;
+                "iPhone4,1") model="iPhone 4S" ;;
+                "iPhone5,"[1-2]) model="iPhone 4" ;;
+                "iPhone5,"[3-4]) model="iPhone 5c" ;;
+                "iPhone6,"[1-2]) model="iPhone 5s" ;;
+                "iPhone7,2") model="iPhone 6" ;;
+                "iPhone7,1") model="iPhone 6 Plus" ;;
+                "iPhone8,1") model="iPhone 6s" ;;
+                "iPhone8,2") model="iPhone 6s Plus" ;;
+                "iPhone8,4") model="iPhone SE" ;;
+
+                "iPod1,1") model="iPod touch" ;;
+                "ipod2,1") model="iPod touch 2G" ;;
+                "ipod3,1") model="iPod touch 3G" ;;
+                "ipod4,1") model="iPod touch 4G" ;;
+                "ipod5,1") model="iPod touch 5G" ;;
+                "ipod7,1") model="iPod touch 6G" ;;
+            esac
+        ;;
+    esac
+}
+
+# }}}
+
 # Distro {{{
 
 getdistro() {
@@ -587,8 +638,7 @@ getcpu() {
         ;;
 
         "iPhone OS")
-            ios_model="${ios_model:-$(uname -m)}"
-            case "$ios_model" in
+            case "${ios_model:-$(uname -m)}" in
                 "iPhone1,1" | "iPhone1,2" | "iPod1,1")
                     cpu="Samsung S5L8900 @ 412MHz"
                     cores="1"

--- a/neofetch
+++ b/neofetch
@@ -41,7 +41,7 @@ getos() {
 getmodel() {
     case "$os" in
         "Linux")
-            model="$(< /sys/devices/virtual/dmi/id/product_version)"
+            model="$(< /sys/devices/virtual/dmi/id/product_{name,version} 2>/dev/null)"
             model="${model/To Be Filled*}"
         ;;
 

--- a/neofetch
+++ b/neofetch
@@ -84,6 +84,10 @@ getmodel() {
             esac
         ;;
 
+        "BSD")
+            model="$(sysctl -n hw.vendor hw.product 2>/dev/null)"
+        ;;
+
         "Windows")
             model="$(wmic computersystem get manufacturer,model /value)"
             model="${model/Manufacturer'='}"

--- a/neofetch
+++ b/neofetch
@@ -45,6 +45,7 @@ getmodel() {
             model="${model/To Be Filled*}"
         ;;
 
+        "Mac OS X") model="$(sysctl -n hw.model)" ;;
         "iPhone OS")
             case "${ios_model:-$(uname -m)}" in
                 "iPad1,1") model="iPad" ;;
@@ -82,8 +83,6 @@ getmodel() {
                 "ipod7,1") model="iPod touch 6G" ;;
             esac
         ;;
-
-		"Mac OS X") model="$(sysctl -n hw.model)" ;;
     esac
 }
 
@@ -3018,7 +3017,7 @@ getargs() {
                 esac
             ;;
             --test)
-                info=(title underline distro kernel uptime packages shell resolution de wm wmtheme theme icons cpu cpu_usage gpu memory font disk battery song localip publicip users birthday term termfont)
+                info=(title underline model distro kernel uptime packages shell resolution de wm wmtheme theme icons cpu cpu_usage gpu memory font disk battery song localip publicip users birthday term termfont)
 
                 refresh_rate="on"
                 shell_version="on"

--- a/neofetch
+++ b/neofetch
@@ -83,6 +83,12 @@ getmodel() {
                 "ipod7,1") model="iPod touch 6G" ;;
             esac
         ;;
+
+        "Windows")
+            model="$(wmic computersystem get manufacturer,model /value)"
+            model="${model/Manufacturer'='}"
+            model="${model/Model'='}"
+        ;;
     esac
 }
 

--- a/neofetch
+++ b/neofetch
@@ -41,7 +41,7 @@ getos() {
 getmodel() {
     case "$os" in
         "Linux")
-            model="$(< /sys/devices/virtual/dmi/id/product_{name,version} 2>/dev/null)"
+            model="$(cat /sys/devices/virtual/dmi/id/product_{name,version} 2>/dev/null)"
             model="${model/To Be Filled*}"
         ;;
 


### PR DESCRIPTION
This PR adds a new function which will be enabled by default. The function displays the product/model name of your device if it exists. For example on my laptop it shows `Lenovo YOGA 900-13ISK` and my iPhone it shows `iPhone 5s`.

Note: This feature won't work on custom built PCs or devices without OEM info.

**TODO:**

- [x] Add support
    - [x] Add support for Linux
        - ~~Not sure if this works on every machine yet.~~
        - The file we check for the info was added in `linux 2.6.26 ~2009`<br \>
           so this should be fine.
    - [x] Add support for MacOS (OS X)
    - [x] Add support for iOS
    - [x] Add support for BSD
    - [x] Add support for Solaris
    - [x] Add support for Windows
- [x] Testing
    - [x] Test the feature on Linux
    - [x] Test the feature on MacOS (OS X)
    - [x] Test the feature on iOS
    - [x] Test the feature on BSD
    - [x] Test the feature on Solaris
    - [x] Test the feature on Windows

**Testing:**

If you'd like to help me test this is what you need to do:

1. Git clone neofetch.
    - `git clone https://github.com/dylanaraps/neofetch`
2. cd to the new directory.
    - `cd neofetch`
2. Swap to the `model` branch. 
    - `git checkout model`
3. Run neofetch without a config from the directory.
    - `./neofetch --config off`
4. Let me know if the feature works/doesn't work on your machine.
5. Screenshots are nice too. :)

Old PR #308 