### PR TITLE
Remove stdout mode

### DIFF
--- a/1.8.md
+++ b/1.8.md
@@ -19,6 +19,8 @@
     - See [trim()](https://github.com/dylanaraps/neofetch/commit/d3c87cdaacf1ea9fbf245146c910dc53b49dba08#diff-e863270127ca6116fd30e708cdc582fcR2789)
 - Only call `tput` when we really need to.
 - Supress `getconfig` and `getscriptdir` errors.
+- Removed `stdout` mode since it's been broken for a while now and I don't see the<br\>
+point in fixing it.
 - Fix issue when title and background were both color `7`.
 - Added `--version` to print the neofetch version.
 - The title at the top is now much more colorful.

--- a/README.md
+++ b/README.md
@@ -446,12 +446,6 @@ alias neofetch2="neofetch \
                                 Supported distros: Arch, Gentoo, Crux, OpenBSD.
     --ascii_bold on/off         Whether or not to bold the ascii logo.
 
-    Stdout:
-    --stdout info info          Launch neofetch in stdout mode which prints the info
-                                in a plain-text format that you can use with
-                                lemonbar etc.
-    --stdout_separator string   String to use as a separator in stdout mode.
-
     Screenshot:
     --scrot /path/to/img        Take a screenshot, if path is left empty the screen-
                                 shot function will use \$scrot_dir and \$scrot_name.

--- a/config/config
+++ b/config/config
@@ -398,14 +398,6 @@ scrot_name="neofetch-$(date +%F-%T).png"
 
 # }}}
 
-# Stdout options {{{
-
-# Separator for stdout mode
-# --stdout_separator string
-stdout_separator="  "
-
-# }}}
-
 # Config Options {{{
 
 

--- a/neofetch
+++ b/neofetch
@@ -781,8 +781,6 @@ getcpu() {
             esac
         ;;
     esac
-
-    [ "$cpu" ] && prin "$subtitle" "$cpu"
 }
 
 # }}}

--- a/neofetch
+++ b/neofetch
@@ -783,8 +783,6 @@ getcpu() {
     esac
 
     [ "$cpu" ] && prin "$subtitle" "$cpu"
-
-    [ "$stdout_mode" != "on" ] && unset cpu
 }
 
 # }}}
@@ -1135,7 +1133,7 @@ getsong() {
     esac
 
     # Display Artist and Title on seperate lines.
-    if [ "$song_shorthand" == "on" ] && [ "$stdout_mode" != "on" ]; then
+    if [ "$song_shorthand" == "on" ]; then
         artist="${song/ -*}"
         song="${song/$artist - }"
 
@@ -1537,7 +1535,7 @@ getbattery() {
                 title="$subtitle"
 
                 # If shorthand is on, print each value on the same line
-                if [ "$battery_shorthand" == "on" ] || [ "$stdout_mode" == "on" ]; then
+                if [ "$battery_shorthand" == "on" ]; then
                     battery="${batteries[*]}"
                     battery="${battery// /%, }"
                     battery="${battery}%"
@@ -2226,34 +2224,6 @@ prin() {
 
 # }}}
 
-# Stdout {{{
-
-stdout() {
-    # Read args early for the separator
-    stdout_separator_flag="$(awk -F '--stdout_separator ' '{printf $2}' <<< "${args[@]}")"
-    stdout_separator_flag="${stdout_separator_flag/ '--'*}"
-
-    [ "$stdout_separator_flag" ] && \
-        stdout_separator="$stdout_separator_flag"
-
-    for func in "${args[@]}"; do
-        case "$func" in
-            "--"*) break ;;
-            *)
-                "get$func" 2>/dev/null
-                eval output="\$$func"
-                output="$(trim "$output")"
-                stdout+="${output}${stdout_separator}"
-            ;;
-        esac
-    done
-
-    printf "%s" "${stdout%%${stdout_separator}}"
-    exit
-}
-
-# }}}
-
 # Underline {{{
 
 getunderline() {
@@ -2780,12 +2750,6 @@ usage() { cat << EOF
                                 Supported distros: Arch, Gentoo, Crux, OpenBSD.
     --ascii_bold on/off         Whether or not to bold the ascii logo.
 
-    Stdout:
-    --stdout info info          Launch neofetch in stdout mode which prints the info
-                                in a plain-text format that you can use with
-                                lemonbar etc.
-    --stdout_separator string   String to use as a separator in stdout mode.
-
     Screenshot:
     --scrot /path/to/img        Take a screenshot, if path is left empty the screen-
                                 shot function will use \$scrot_dir and \$scrot_name.
@@ -2813,7 +2777,7 @@ getargs() {
     # Check the commandline flags early for '--config none/off'
     case "$@" in
         *"--config off"* | *'--config "off"'* | *"--config 'off'"* | \
-        *"--config none"* | *'--config "none"'* | *"--config 'none'"* | *"--stdout"*)
+        *"--config none"* | *'--config "none"'* | *"--config 'none'"*)
             config="off"
         ;;
 
@@ -2950,17 +2914,6 @@ getargs() {
                 fi
             ;;
             --scrot_cmd) scrot_cmd="$2" ;;
-
-            # Stdout
-            --stdout)
-                unset info_color prin clear bar
-                stdout_mode="on"
-                config="off"
-                case "$2" in
-                    "--"* | "") printf "%s\n" "--stdout requires at least one argument"; exit ;;
-                    *) shift; args=("$@"); stdout ;;
-                esac
-            ;;
 
             # Other
             --config)

--- a/neofetch.1
+++ b/neofetch.1
@@ -223,15 +223,6 @@ Possible values: small, normal
 .B \--ascii_bold 'on/off'
 Whether or not to bold the ascii logo.
 
-.SH STDOUT
-.TP
-.B \--stdout info info
-Launch fetch in stdout mode which prints the info in
-a plain-text format that you can use with lemonbar etc.
-.TP
-.B \--stdout_separator 'string'
-String to use as a separator in stdout mode.
-
 .SH SCREENSHOT
 .TP
 .B \--scrot 'path'


### PR DESCRIPTION
Removes `stdout` mode since it's been broken for a while now and I don't see the point in fixing it.