### PR TITLE
Added distro_shorthand to simplify lsb_release output

### DIFF
--- a/config/config
+++ b/config/config
@@ -61,6 +61,10 @@ kernel_shorthand="on"
 
 # Distro
 
+# Shorten the output of distro
+# NOTE: This is only possible on Linux with lsb_release
+distro_shorthand="off"
+
 # Mac OS X hide/show build version
 # --osx_buildversion on/off
 osx_buildversion="on"

--- a/neofetch
+++ b/neofetch
@@ -119,7 +119,11 @@ getdistro() {
     case "$os" in
         "Linux" )
             if type -p lsb_release >/dev/null 2>&1; then
-                distro="$(lsb_release -d 2>/dev/null | awk -F ':' '/Description/ {printf $2}')"
+                case "$distro_shorthand" in
+                    "on")  distro="$(lsb_release -sir 2>/dev/null)" ;;
+                    "off") distro="$(lsb_release -sd 2>/dev/null)"
+                           distro="${distro//\"}" ;;
+                esac
 
             elif type -p crux >/dev/null 2>&1; then
                 distro="$(crux)"
@@ -2761,6 +2765,8 @@ usage() { cat << EOF
     --cpu_shorthand type        Shorten the output of CPU
                                 Possible values: name, speed, tiny, on, off
     --cpu_cores on/off          Whether or not to display the number of CPU cores
+    --distro_shorthand on/off   Shorten the output of distro
+                                NOTE: This is only possible on Linux with lsb_release
     --kernel_shorthand on/off   Shorten the output of kernel
     --uptime_shorthand on/off   Shorten the output of uptime (tiny, on, off)
     --refresh_rate on/off       Whether to display the refresh rate of each monitor
@@ -2883,6 +2889,7 @@ getargs() {
             --osx_codename) osx_codename="$2" ;;
             --cpu_cores) cpu_cores="$2" ;;
             --speed_type) speed_type="$2" ;;
+            --distro_shorthand) distro_shorthand="$2" ;;
             --kernel_shorthand) kernel_shorthand="$2" ;;
             --uptime_shorthand) uptime_shorthand="$2" ;;
             --cpu_shorthand) cpu_shorthand="$2" ;;

--- a/neofetch.1
+++ b/neofetch.1
@@ -44,6 +44,11 @@ Possible values: name, speed, tiny, on, off
 .B \--cpu_cores 'on/off'
 Whether or not to display the number of CPU cores
 .TP
+.B \--distro_shorthand 'on/off'
+Shorten the output of distro
+.br
+NOTE: This is only possible on Linux with lsb_release
+.TP
 .B \--kernel_shorthand 'on/off'
 Shorten the output of kernel
 .TP


### PR DESCRIPTION
The reason I made this PR is simple.

Some distro's output of `lsb_release -d` is way too long. For example:
![whypr](https://cloud.githubusercontent.com/assets/15692230/18035007/222a8698-6d76-11e6-9e71-18c30347d17c.png)

Therefore, I simplified it to only show the distributor ID and the release number
(aka. `lsb_release -sir`)
![whypr2](https://cloud.githubusercontent.com/assets/15692230/18035009/399b8642-6d76-11e6-8d92-b5890ae02288.png)

Tested on Gentoo, Fedora 24, CentOS 7, and Debian 8.5.