### PR TITLE
OpenBSD's battery status get back into the BSD case

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1670,19 +1670,19 @@ getbattery() {
                     battery="$(envstat | awk '\\(|\\)' '/charge:/ {print $2}')"
                     battery="${battery/\.*/%}"
                 ;;
+
+                "OpenBSD"*)
+                    battery0full="$(sysctl -n hw.sensors.acpibat0.watthour0)"
+                    battery0full="${battery0full/ Wh*}"
+
+                    battery0now="$(sysctl -n hw.sensors.acpibat0.watthour3)"
+                    battery0now="${battery0now/ Wh*}"
+
+                    [ "$battery0full" ] && \
+                    battery="$((100 * ${battery0now/\.} / ${battery0full/\.}))%"
+                 ;;
             esac
-        ;;
-
-        "OpenBSD")
-            battery0full="$(sysctl -n hw.sensors.acpibat0.watthour0)"
-            battery0full="${battery0full/ Wh*}"
-
-            battery0now="$(sysctl -n hw.sensors.acpibat0.watthour3)"
-            battery0now="${battery0now/ Wh*}"
-
-            [ "$battery0full" ] && \
-                battery="$((100 * ${battery0now/\.} / ${battery0full/\.}))%"
-        ;;
+         ;;
 
         "Mac OS X")
             battery="$(pmset -g batt | grep -o '[0-9]*%')"


### PR DESCRIPTION
Maybe the original committer forgot the `*` so s/he decided to get OpenBSD's case nest into the `$os` instead of `$distro`.

I suspect the original reason that because OpenBSD's `$distro` output is `OpenBSD $(uname -m)` instead of just `OpenBSD` so the results didn't appear when s/he first tested it out.

Anyway, for consistency, I decided to bring OpenBSD's battery case back to the `$distro` case and add a very little fix (which is the `*`), the problem should be fixed.

(I can't test this personally, any help would be appreciated.)