### PR TITLE
Fixed percent not displaying in cpu_display

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -919,10 +919,10 @@ getcpu_usage() {
 
     # Print the bar
     case "$cpu_display" in
-        "info") cpu_usage="${cpu_usage}%" ;;
         "bar") cpu_usage="$(bar $cpu_usage 100)" ;;
         "infobar") cpu_usage="${cpu_usage}% $(bar $cpu_usage 100)" ;;
         "barinfo") cpu_usage="$(bar $cpu_usage 100) ${cpu_usage}%" ;;
+        *) cpu_usage="${cpu_usage}%" ;;
     esac
 }
 


### PR DESCRIPTION
`cpu_display` won't appear with `%` if `cpu_display="off"` is set. This PR fixes it.

In README.md (and in the man pages), the 4 accepted modes are `off`, `barinfo`, `infobar` and `bar`. Though I'm sure we can have a fall-back mode (which is `off`) if users don't set `cpu_display`to one of those 4 values.