### PR TITLE
Added support for various music players

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1242,6 +1242,9 @@ getsong() {
         title="$(qdbus org.kde.amarok /Player GetMetadata | awk -F':' '/title/ {print $2}')"
         song="$artist - $title"
 
+    elif [ -n "$(ps x | awk '!(/awk/) && /deadbeef/')" ]; then
+        song="$(deadbeef --nowplaying '%a - %t')"
+
     else
         song="Not Playing"
     fi

--- a/neofetch
+++ b/neofetch
@@ -1237,6 +1237,11 @@ getsong() {
         song="$artist - $title"
         state="$(banshee --query-current-state | awk -F':' '{print $2}')"
 
+    elif [ -n "$(ps x | awk '!(/awk/) && /amarok/')" ]; then
+        artist="$(qdbus org.kde.amarok /Player GetMetadata | awk -F':' '/^artist/ {print $2}')"
+        title="$(qdbus org.kde.amarok /Player GetMetadata | awk -F':' '/title/ {print $2}')"
+        song="$artist - $title"
+
     else
         song="Not Playing"
     fi

--- a/neofetch
+++ b/neofetch
@@ -1231,6 +1231,12 @@ getsong() {
                  awk -F 'string "' '{printf $2}')"
         state="${state//\"}"
 
+    elif [ -n "$(ps x | awk '!(/awk/) && /banshee/')" ]; then
+        artist="$(banshee --query-artist | awk -F':' '{print $2}')"
+        title="$(banshee --query-title | awk -F':' '{print $2}')"
+        song="$artist - $title"
+        state="$(banshee --query-current-state | awk -F':' '{print $2}')"
+
     else
         song="Not Playing"
     fi

--- a/neofetch
+++ b/neofetch
@@ -1223,16 +1223,24 @@ getsong() {
         song="$(osascript -e 'tell application "iTunes" to artist of current track as string & " - " & name of current track as string')"
         state="$(osascript -e 'tell application "iTunes" to player state as string')"
 
+    elif [ -n "$(ps x | awk '!(/awk/) && /rhythmbox/')" ]; then
+        song="$(rhythmbox-client --print-playing)"
+        # Well, what can you expect? It's dbus after all.
+        state="$(dbus-send --print-reply --dest=org.mpris.MediaPlayer2.rhythmbox /org/mpris/MediaPlayer2 \
+                 org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string: 'PlayBackStatus' |\
+                 awk -F 'string "' '{printf $2}')"
+        state="${state//\"}"
+
     else
         song="Not Playing"
     fi
 
     case "$state" in
-        "paused" | "PAUSE")
+        "paused" | "PAUSE" | "Paused")
             song="Paused"
         ;;
 
-        "stopped" | "STOP")
+        "stopped" | "STOP" | "Stopped")
             song="Stopped"
         ;;
     esac


### PR DESCRIPTION
The commits are for (mostly) default music players that come with DEs. Like Rhythmbox for GNOME, Banshee for Mint (Cinnamon, IIRC?), and Amarok for KDE, with the exception of deadbeef.

If I have the time (and if I figured out how the hell did Clementine break with `core dumped`) I'll expand to Clementine.