### PR TITLE
Initial support for Windows 10 Linux subsystem

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -118,7 +118,16 @@ getdistro() {
 
     case "$os" in
         "Linux" )
-            if type -p lsb_release >/dev/null 2>&1; then
+            if grep -q 'Microsoft' /proc/version >/dev/null 2>&1 || \
+               grep -q 'Microsoft' /proc/sys/kernel/osrelease >/dev/null 2>&1; then
+                case "$distro_shorthand" in
+                    "on")   distro="$(lsb_release -sir 2>/dev/null) [Windows 10]" ;;
+                    "tiny") distro="Windows 10" ;;
+                    *)      distro="$(lsb_release -sd 2>/dev/null) on Windows 10" ;;
+                esac
+                ascii_distro="windows10"
+
+            elif type -p lsb_release >/dev/null 2>&1; then
                 case "$distro_shorthand" in
                     "on")   distro="$(lsb_release -sir 2>/dev/null)" ;;
                     "tiny") distro="$(lsb_release -si 2>/dev/null)" ;;


### PR DESCRIPTION
I actually tried this back in August, but somehow I dropped it.

Anyway, I picked this up again and decided to test around.

Bugs:
- [x] ~~`dynamicprompts` does not work (only occurred on Windows 10's terminal, in a X terminal inside Windows 10, this doesn't happen)~~ (Fixed with #339 )
- [x] ~~There are some.. artifacts after the output (only occurred on Windows 10's terminal, in a X terminal inside Windows 10, this doesn't happen). I suspect these came from the earlier `info_heights`.~~ (Fixed with #339 )
- [ ] CPU ~~Usage~~ clock speed doesn't have any output (0.0GHz) by default
 - Windows 10's `cpufreq` only has `scaling_max_freq` and `cpuinfo_max_freq`. 
 - You cannot read `scaling_max_freq` (insufficient permissions), only `cpuinfo_max_freq`.
   - Possible workaround: Change the default in config to `cpuinfo_max_freq`.

Other than those, it seems to work perfectly. Even in an X session.

![virtualbox_windows 10_18_09_2016_17_30_04](https://cloud.githubusercontent.com/assets/15692230/18615065/8b95f454-7dc6-11e6-891a-4a8bab941e8f.png)
![virtualbox_windows 10_18_09_2016_17_30_31](https://cloud.githubusercontent.com/assets/15692230/18615066/8b9a0bac-7dc6-11e6-8d1a-8966d2b409a1.png)

I can only test this from a VM, so if anyone wants to test it, be my guest.