### PR TITLE
Don't clear the screen in 'Ascii' and 'No Image' modes. Fixes #335

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3155,10 +3155,8 @@ main() {
     printf "\033[9999999D"
 
     # Move cursor to top of ascii art
-    case "$image" in
-        "ascii" | "off") ;;
-        *) printf "\033[0H" ;;
-    esac
+    [ "$image" != "ascii" ] && [ "$image" != "off" ] && \
+        printf "\033[0H"
 
     # Print the info
     printinfo

--- a/neofetch
+++ b/neofetch
@@ -2085,6 +2085,8 @@ getimage() {
         [ "${#term_size}" -le 5 ] && err "Your terminal doesn't support \\\033[14t, falling back to ascii mode."
 
         return
+    else
+        clear
     fi
 
     # Get terminal lines and columns
@@ -3126,12 +3128,6 @@ main() {
 
     # If the script exits for any reason, unhide the cursor.
     trap 'printf "\033[?25h"' EXIT
-
-    # Clear the screen
-    case "$image" in
-        "ascii" | "off") ;;
-        *) clear ;;
-    esac
 
     # Hide the cursor and disable line wrap
     printf "\033[?25l\033[?7l"

--- a/neofetch
+++ b/neofetch
@@ -2776,7 +2776,7 @@ kdeconfigdir() {
 
 dynamicprompt() {
     # Calculate image height in terminal cells.
-    # The '+ 3' adds a gap between the prompt and the content.
+    # The '+ 4' adds a gap between the prompt and the content.
     [ "$image" != "ascii" ] && [ "$image" != "off" ] && \
         lines="$((${height:-1} / ${font_height:-1} + 4))"
 
@@ -3158,12 +3158,9 @@ main() {
     # Reset horizontal cursor position
     printf "\033[9999999D"
 
-    # Save cursor position
-    printf "\0337"
-
     # Move cursor to top of ascii art
     case "$image" in
-        "ascii" | "off") printf "\0338" ;;
+        "ascii" | "off") ;;
         *) printf "\033[0H" ;;
     esac
 

--- a/neofetch
+++ b/neofetch
@@ -2329,7 +2329,7 @@ info() {
     printf "%b%s\n" "${padding}${string}${reset}"
 
     # Calculate info height
-    info_height="$((info_height + 1))"
+    info_height="$((info_height+=1))"
 }
 
 # }}}
@@ -2364,7 +2364,7 @@ prin() {
     printf "%b%s\n" "${padding}${string}${reset}"
 
     # Calculate info height
-    info_height="$((info_height + 1))"
+    info_height="$((info_height+=1))"
 }
 
 # }}}

--- a/neofetch
+++ b/neofetch
@@ -3144,8 +3144,8 @@ main() {
         # Display the image if enabled
         displayimage
     fi
-
     printf "\033[$((${lines:-0} - 4))A"
+    printf "\033[9999999D"
     printf "\0337"
 
     # Move cursor to top of ascii art

--- a/neofetch
+++ b/neofetch
@@ -3121,7 +3121,10 @@ main() {
     trap 'printf "\033[?25h"' EXIT
 
     # Clear the screen
-    clear
+    case "$image" in
+        "ascii" | "off") ;;
+        *) clear ;;
+    esac
 
     # Hide the cursor and disable line wrap
     printf "\033[?25l\033[?7l"
@@ -3142,8 +3145,14 @@ main() {
         displayimage
     fi
 
-    # Move cursor to the top
-    printf "\033[0H"
+    printf "\033[$((${lines:-0} - 4))A"
+    printf "\0337"
+
+    # Move cursor to top of ascii art
+    case "$image" in
+        "ascii" | "off") printf "\0338" ;;
+        *) printf "\033[0H" ;;
+    esac
 
     # Print the info
     printinfo

--- a/neofetch
+++ b/neofetch
@@ -2789,7 +2789,7 @@ dynamicprompt() {
     fi
 
     # Set the prompt location
-    [ "$image" != "off" ] && printf "%b%s" "\033[${lines:-0}B"
+    [ "$image" != "off" ] && printf "\033[${lines/-*/0}B"
 }
 
 # }}}

--- a/neofetch
+++ b/neofetch
@@ -3144,8 +3144,14 @@ main() {
         # Display the image if enabled
         displayimage
     fi
+
+    # Set cursor position next to ascii art
     printf "\033[$((${lines:-0} - 4))A"
+
+    # Reset horizontal cursor position
     printf "\033[9999999D"
+
+    # Save cursor position
     printf "\0337"
 
     # Move cursor to top of ascii art

--- a/neofetch
+++ b/neofetch
@@ -2327,6 +2327,9 @@ info() {
 
     # Print the string
     printf "%b%s\n" "${padding}${string}${reset}"
+
+    # Calculate info height
+    info_height="$((info_height + 1))"
 }
 
 # }}}
@@ -2359,6 +2362,9 @@ prin() {
 
     # Print the info
     printf "%b%s\n" "${padding}${string}${reset}"
+
+    # Calculate info height
+    info_height="$((info_height + 1))"
 }
 
 # }}}
@@ -2769,20 +2775,21 @@ kdeconfigdir() {
 # Dynamic prompt location {{{
 
 dynamicprompt() {
-    # Get cursor position
-    info_height="$(IFS=';' builtin read -srdR -t 1 -d c -p $'\033[6n\033[c' ROW COL; printf "%s" "${ROW#*[}")"
-
     # Calculate image height in terminal cells.
     # The '+ 3' adds a gap between the prompt and the content.
     [ "$image" != "ascii" ] && [ "$image" != "off" ] && \
-        lines="$((${height:-1} / ${font_height:-1} + 3))"
+        lines="$((${height:-1} / ${font_height:-1} + 4))"
 
     # If the info is higher than the ascii/image place the prompt
     # based on the info height instead of the ascii/image height.
-    [ "${lines:-0}" -lt "${info_height:-0}" ] && lines="$info_height"
+    if [ "${lines:-0}" -lt "${info_height:-0}" ]; then
+        lines="$((info_height - lines - 2))"
+    else
+        lines="$((lines - info_height - 2))"
+    fi
 
     # Set the prompt location
-    [ "$image" != "off" ] && printf "%b%s" "\033[${lines:-0}H"
+    [ "$image" != "off" ] && printf "%b%s" "\033[${lines:-0}B"
 }
 
 # }}}


### PR DESCRIPTION
Neofetch will no longer clear the screen when run in `ascii` or `no image` modes. Stuff like this is now possible:

```sh
echo "Hello, bla bla"; figlet "hello, world"; neofetch --ascii
```

Bugs:

- [x] ~~If neofetch fallsback from `image` to `ascii` mode the screen is still cleared.~~
- [x] ~~Sometimes garbage in the prompt.~~

TODO: 

- [ ] Testing
    - [x] VTE Terminals
    - [x] URxvt
    - [x] Xterm
    - [x] TTY
        - [x] Prompt is incorrectly placed on script finish.
    - [ ] Terminal.app
        - Works in Travis.ci(?)
    - [ ] iTerm2
    - [x] MinTTY
    - [x] Terminator
    - [x] st
    - [x] Windows 10 cmd
    - [x] Tmux
    - [x] Screen