### PR TITLE
Logo mode - Only print ascii art.

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,7 @@ alias neofetch2="neofetch \
     --ascii_logo_size           Size of ascii logo.
                                 Supported distros: Arch, Gentoo, Crux, OpenBSD.
     --ascii_bold on/off         Whether or not to bold the ascii logo.
+    --logo | -L                 Hide the info text and only show the ascii logo.
 
     Screenshot:
     --scrot /path/to/img        Take a screenshot, if path is left empty the screen-

--- a/neofetch
+++ b/neofetch
@@ -3055,6 +3055,11 @@ getargs() {
             ;;
 
             # Ascii
+            --logo | -L)
+                image="ascii"
+                printinfo() { info linebreak; }
+            ;;
+
             --ascii)
                 image="ascii"
                 ascii="$2"

--- a/neofetch
+++ b/neofetch
@@ -2922,6 +2922,7 @@ usage() { cat << EOF
     --ascii_logo_size           Size of ascii logo.
                                 Supported distros: Arch, Gentoo, Crux, OpenBSD.
     --ascii_bold on/off         Whether or not to bold the ascii logo.
+    --logo | -L                 Hide the info text and only show the ascii logo.
 
     Screenshot:
     --scrot /path/to/img        Take a screenshot, if path is left empty the screen-
@@ -3055,11 +3056,6 @@ getargs() {
             ;;
 
             # Ascii
-            --logo | -L)
-                image="ascii"
-                printinfo() { info linebreak; }
-            ;;
-
             --ascii)
                 image="ascii"
                 ascii="$2"
@@ -3084,6 +3080,11 @@ getargs() {
 
             --ascii_logo_size) ascii_logo_size="$2" ;;
             --ascii_bold) ascii_bold="$2" ;;
+            --logo | -L)
+                image="ascii"
+                printinfo() { info linebreak; }
+            ;;
+
 
             # Screenshot
             --scrot | -s)

--- a/neofetch.1
+++ b/neofetch.1
@@ -230,6 +230,9 @@ Possible values: small, normal
 .TP
 .B \--ascii_bold 'on/off'
 Whether or not to bold the ascii logo.
+.TP
+.B \--logo | -L
+Hide the info text and only show the ascii logo.
 
 .SH SCREENSHOT
 .TP


### PR DESCRIPTION
This mode just displays the ascii art.

Usage:

`neofetch -L`
`neofetch -L --ascii_distro gentoo`