### PR TITLE
Fix TravisCI for macOS build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ os:
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update                  ; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install screenresolution; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PREFIX=/usr/local     ; fi
 
 script:
-    - sudo make install
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then PREFIX=/usr/local make install     ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo make install                ; fi
     - time neofetch --ascii --config off --ascii_distro travis -v --test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ os:
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update                  ; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install screenresolution; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PREFIX=/usr/local     ; fi
 
 script:
     - sudo make install


### PR DESCRIPTION
Travis updated the macOS build server to El Capitan, which means it has SIP now. Prefix changed to /usr/local to mitigate this