### PR TITLE
Changed installation instruction for Gentoo/Funtoo

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,17 +178,9 @@ https://github.com/dylanaraps/neofetch/wiki/Following-HEAD
 
 ### Gentoo / Funtoo
 
-1. Add the 3rd party repo
-    - `# wget -O /etc/portage/repos.conf/konimex.conf https://git.io/vocNV`
-2. Sync the repo
-    - `# emerge --sync konimex`
-3. To enable additional features such as w3m and music support, enable the appropriate USE flags. For example:
-    - `# echo "app-misc/neofetch X -moc" >> /etc/portage/package.use`
-4. Install the package
-    - `# emerge -a app-misc/neofetch`
+You can install `app-misc/neofetch` from Gentoo/Funtoo's official repositories.
 
-To install the git version, just add `app-misc/neofetch ~<your architecture>` to `package.accept_keywords`
-
+To install the git version of neofetch, use `=app-misc/neofetch-9999` instead.
 
 ### CRUX
 


### PR DESCRIPTION
Since neofetch is now in [Gentoo's official repository](https://packages.gentoo.org/packages/app-misc/neofetch), a third party repo will not be needed anymore.