### PR TITLE
Fix issues with URxvt and XFT fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,10 @@ alias neofetch2="neofetch \
     --crop_offset value         Change the crop offset for normal mode.
                                 Possible values: northwest, north, northeast,
                                 west, center, east, southwest, south, southeast
+    --image_border on/off       Add a border around the info in image
+                                mode to fix issues with URxvt and XFT
+                                fonts.
+    --border_char char          Character to draw the border with.
 
     --xoffset px                How close the image will be to the left edge of the
                                 window. This only works with w3m.
@@ -449,7 +453,7 @@ alias neofetch2="neofetch \
     --logo | -L                 Hide the info text and only show the ascii logo.
 
     Screenshot:
-    --scrot /path/to/img        Take a screenshot, if path is left empty the screen-
+    --scrot | -s /path/to/img   Take a screenshot, if path is left empty the screen-
                                 shot function will use \$scrot_dir and \$scrot_name.
     --upload | -su /pth/t/img   Same as --scrot but uploads the scrot to a website.
     --image_host                Website to upload scrots to. Takes: imgur, teknik

--- a/README.md
+++ b/README.md
@@ -428,10 +428,6 @@ alias neofetch2="neofetch \
     --crop_offset value         Change the crop offset for normal mode.
                                 Possible values: northwest, north, northeast,
                                 west, center, east, southwest, south, southeast
-    --image_border on/off       Add a border around the info in image
-                                mode to fix issues with URxvt and XFT
-                                fonts.
-    --border_char char          Character to draw the border with.
 
     --xoffset px                How close the image will be to the left edge of the
                                 window. This only works with w3m.
@@ -441,6 +437,11 @@ alias neofetch2="neofetch \
                                 NOTE: --gap can take a negative value which will
                                 move the text closer to the left side.
     --clean                     Remove all cropped images
+    --image_border on/off       Add a border around the info in image
+                                mode to fix issues with URxvt and XFT
+                                fonts.
+    --border_char char          Character to draw the border with.
+    --border_color fg, 000      Change color of border.
 
     Ascii:
     --ascii value               Where to get the ascii from, Possible values:

--- a/config/config
+++ b/config/config
@@ -331,6 +331,16 @@ crop_offset="center"
 # --size auto, 00px, 00%, none
 image_size="auto"
 
+# Right gap between image and text
+# --gap num
+gap=2
+
+# Image offsets
+# --xoffset px
+# --yoffset px
+yoffset=0
+xoffset=0
+
 # Image border
 # When 'on', adds a border between the image and the info to
 # fix issues with URxvt and XFT fonts.
@@ -341,15 +351,9 @@ image_border="off"
 # Character to draw the border with.
 border_char="|"
 
-# Right gap between image and text
-# --gap num
-gap=2
-
-# Image offsets
-# --xoffset px
-# --yoffset px
-yoffset=0
-xoffset=0
+# Image border color
+# Takes: fg, 000
+border_color="fg"
 
 
 # }}}

--- a/config/config
+++ b/config/config
@@ -331,6 +331,16 @@ crop_offset="center"
 # --size auto, 00px, 00%, none
 image_size="auto"
 
+# Image border
+# When 'on', adds a border between the image and the info to
+# fix issues with URxvt and XFT fonts.
+# --image_border on, off
+image_border="off"
+
+# Image border character
+# Character to draw the border with.
+border_char="|"
+
 # Right gap between image and text
 # --gap num
 gap=2

--- a/neofetch
+++ b/neofetch
@@ -1902,7 +1902,13 @@ getcols() {
 
         # Add newlines to the string.
         cols="${cols%%'nl'}"
-        cols="${cols//nl/\\n${padding}}"
+
+        # Add image border to all block lines.
+        if [ "$image_border" == "on" ]; then
+            cols="${cols//nl/\\n${padding}${border_char} }"
+        else
+            cols="${cols//nl/\\n${padding}}"
+        fi
     fi
 }
 
@@ -2372,6 +2378,10 @@ info() {
     # If there's no subtitle don't print one
     [ -z "$2" ] && string="${string/*: }"
 
+    # Add a border to fix issues with urxvt/xft fonts
+    [ "$image_border" == "on" ] && \
+        string="${clear}${border_char} $string"
+
     # Print the string
     printf "%b%s\n" "${padding}${string}${reset}"
 
@@ -2406,6 +2416,10 @@ prin() {
 
     # Trim whitespace
     string="$(trim "$string")"
+
+    # Add a border to fix issues with urxvt/xft fonts
+    [ "$image_border" == "on" ] && \
+        string="${clear}${border_char} $string"
 
     # Print the info
     printf "%b%s\n" "${padding}${string}${reset}"
@@ -3097,6 +3111,8 @@ getargs() {
             ;;
 
             --image_size | --size) image_size="$2" ;;
+            --image_border) image_border="$2" ;;
+            --border_char) border_char="$2" ;;
             --crop_mode) crop_mode="$2" ;;
             --crop_offset) crop_offset="$2" ;;
             --xoffset) xoffset="$2" ;;

--- a/neofetch
+++ b/neofetch
@@ -2050,7 +2050,7 @@ getimage() {
 
     case "$image" in
         "wall") getwallpaper ;;
-        "ascii") getascii; return ;;
+        "ascii") image_border="off"; getascii; return ;;
         *)
             if [ -d "$image" ]; then
                 files=("${image%/}"/*.{png,jpg,jpeg})
@@ -3247,6 +3247,8 @@ main() {
 
         # Display the image if enabled
         displayimage
+    else
+        image_border="off"
     fi
 
     # Set cursor position next to ascii art

--- a/neofetch
+++ b/neofetch
@@ -1905,7 +1905,7 @@ getcols() {
 
         # Add image border to all block lines.
         if [ "$image_border" == "on" ]; then
-            cols="${cols//nl/\\n${padding}${border_char} }"
+            cols="${cols//nl/\\n${padding}$(color ${border_color})${border_char} }"
         else
             cols="${cols//nl/\\n${padding}}"
         fi
@@ -2380,7 +2380,7 @@ info() {
 
     # Add a border to fix issues with urxvt/xft fonts
     [ "$image_border" == "on" ] && \
-        string="${clear}${border_char} $string"
+        string="${clear}$(color ${border_color})${border_char} $string"
 
     # Print the string
     printf "%b%s\n" "${padding}${string}${reset}"
@@ -2419,7 +2419,7 @@ prin() {
 
     # Add a border to fix issues with urxvt/xft fonts
     [ "$image_border" == "on" ] && \
-        string="${clear}${border_char} $string"
+        string="${clear}$(color ${border_color})${border_char} $string"
 
     # Print the info
     printf "%b%s\n" "${padding}${string}${reset}"
@@ -2969,10 +2969,6 @@ usage() { cat << EOF
     --crop_offset value         Change the crop offset for normal mode.
                                 Possible values: northwest, north, northeast,
                                 west, center, east, southwest, south, southeast
-    --image_border on/off       Add a border around the info in image
-                                mode to fix issues with URxvt and XFT
-                                fonts.
-    --border_char char          Character to draw the border with.
 
     --xoffset px                How close the image will be to the left edge of the
                                 window. This only works with w3m.
@@ -2982,6 +2978,11 @@ usage() { cat << EOF
                                 NOTE: --gap can take a negative value which will
                                 move the text closer to the left side.
     --clean                     Remove all cropped images
+    --image_border on/off       Add a border around the info in image
+                                mode to fix issues with URxvt and XFT
+                                fonts.
+    --border_char char          Character to draw the border with.
+    --border_color fg, 000      Change color of border.
 
     Ascii:
     --ascii value               Where to get the ascii from, Possible values:
@@ -3115,8 +3116,6 @@ getargs() {
             ;;
 
             --image_size | --size) image_size="$2" ;;
-            --image_border) image_border="$2" ;;
-            --border_char) border_char="$2" ;;
             --crop_mode) crop_mode="$2" ;;
             --crop_offset) crop_offset="$2" ;;
             --xoffset) xoffset="$2" ;;
@@ -3127,6 +3126,9 @@ getargs() {
                 rm -rf "/Library/Caches/neofetch/"
                 exit
             ;;
+            --image_border) image_border="$2" ;;
+            --border_char) border_char="$2" ;;
+            --border_color) border_color="$2" ;;
 
             # Ascii
             --ascii)

--- a/neofetch
+++ b/neofetch
@@ -2969,6 +2969,10 @@ usage() { cat << EOF
     --crop_offset value         Change the crop offset for normal mode.
                                 Possible values: northwest, north, northeast,
                                 west, center, east, southwest, south, southeast
+    --image_border on/off       Add a border around the info in image
+                                mode to fix issues with URxvt and XFT
+                                fonts.
+    --border_char char          Character to draw the border with.
 
     --xoffset px                How close the image will be to the left edge of the
                                 window. This only works with w3m.

--- a/neofetch.1
+++ b/neofetch.1
@@ -193,12 +193,6 @@ Change the crop offset for normal mode.
 Possible values: northwest, north, northeast,
 west, center, east, southwest, south, southeast
 .TP
-.B \--image_border on/off
-Add a border around the info in image mode to fix issues with URxvt and XFT fonts.
-.TP
-.B \--border_char char
-Character to draw the border with.
-.TP
 .B \--xoffset 'value'
 How close the image will be to the left edge of the
 window in pixel. This only works with w3m.
@@ -215,6 +209,15 @@ will move the text closer to the left side.
 .TP
 .B \--clean
 Remove all cropped images
+.TP
+.B \--image_border on/off
+Add a border around the info in image mode to fix issues with URxvt and XFT fonts.
+.TP
+.B \--border_char char
+Character to draw the border with.
+.TP
+.B \--border_color fg, 000
+Change color of border.
 
 .SH ASCII
 .TP

--- a/neofetch.1
+++ b/neofetch.1
@@ -193,6 +193,12 @@ Change the crop offset for normal mode.
 Possible values: northwest, north, northeast,
 west, center, east, southwest, south, southeast
 .TP
+.B \--image_border on/off
+Add a border around the info in image mode to fix issues with URxvt and XFT fonts.
+.TP
+.B \--border_char char
+Character to draw the border with.
+.TP
 .B \--xoffset 'value'
 How close the image will be to the left edge of the
 window in pixel. This only works with w3m.


### PR DESCRIPTION
This PR fixes image drawing issues in URxvt when a XFT font is used.

The PR adds a new option called `image_border`. When set to `on` it adds a border between the text and image which fixes all drawing issues in URxvt.

- `image_border on/off`: Toggle border.
- `border_char 'string'`: Border char.
- `border_color 'fg' | '000'`: Border color. 

TODO

- [ ] Testing
- [ ] Documentation

**image_border=off**

![2016-10-12-165824_1576x1776_scrot](https://cloud.githubusercontent.com/assets/6799467/19298969/19dedaee-909d-11e6-9f10-1c8ec8a180cb.png)

**image_border=on**

![2016-10-12-165830_1576x1776_scrot](https://cloud.githubusercontent.com/assets/6799467/19298975/233820a0-909d-11e6-9dc6-4a5e6a7e7ffb.png)


Note: I don't know why this works.

Closes #357 