### PR TITLE
Expanded distro_shorthand to Mac OS X and Solaris

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ alias neofetch2="neofetch \
                                 Possible values: name, speed, tiny, on, off
     --cpu_cores on/off          Whether or not to display the number of CPU cores
     --distro_shorthand on/off   Shorten the output of distro (tiny, on, off)
-                                NOTE: This is only possible on Linux and Mac OS X
+                                NOTE: This is only possible on Linux, Mac OS X, and Solaris
     --kernel_shorthand on/off   Shorten the output of kernel
     --uptime_shorthand on/off   Shorten the output of uptime (tiny, on, off)
     --refresh_rate on/off       Whether to display the refresh rate of each monitor

--- a/README.md
+++ b/README.md
@@ -357,8 +357,6 @@ alias neofetch2="neofetch \
                                 in the output.
                                 NOTE: You can supply multiple args. eg.
                                 'neofetch --disable cpu gpu disk shell'
-    --osx_buildversion on/off   Hide/Show Mac OS X build version.
-    --osx_codename on/off       Hide/Show Mac OS X codename.
     --os_arch on/off            Hide/Show OS architecture.
     --speed_type type           Change the type of cpu speed to display.
                                 Possible values: current, min, max, bios,
@@ -368,7 +366,7 @@ alias neofetch2="neofetch \
                                 Possible values: name, speed, tiny, on, off
     --cpu_cores on/off          Whether or not to display the number of CPU cores
     --distro_shorthand on/off   Shorten the output of distro (tiny, on, off)
-                                NOTE: This is only possible on Linux
+                                NOTE: This is only possible on Linux and Mac OS X
     --kernel_shorthand on/off   Shorten the output of kernel
     --uptime_shorthand on/off   Shorten the output of uptime (tiny, on, off)
     --refresh_rate on/off       Whether to display the refresh rate of each monitor

--- a/config/config
+++ b/config/config
@@ -62,16 +62,8 @@ kernel_shorthand="on"
 # Distro
 
 # Shorten the output of distro (tiny, on, off)
-# NOTE: This is only possible on Linux
+# NOTE: This is only possible on Linux and Mac OS X
 distro_shorthand="off"
-
-# Mac OS X hide/show build version
-# --osx_buildversion on/off
-osx_buildversion="on"
-
-# Mac OS X hide/show codename
-# --osx_codename on/off
-osx_codename="on"
 
 # Show 'x86_64' and 'x86' in 'Distro:' output.
 # --os_arch on/off

--- a/config/config
+++ b/config/config
@@ -62,7 +62,7 @@ kernel_shorthand="on"
 # Distro
 
 # Shorten the output of distro (tiny, on, off)
-# NOTE: This is only possible on Linux and Mac OS X
+# NOTE: This is only possible on Linux, Mac OS X, and Solaris
 distro_shorthand="off"
 
 # Show 'x86_64' and 'x86' in 'Distro:' output.

--- a/neofetch
+++ b/neofetch
@@ -231,7 +231,10 @@ getdistro() {
         ;;
 
         "Solaris")
-            distro="$(awk 'NR==1{print $1 " " $2;}' /etc/release)"
+            case "$distro_shorthand" in
+                "on" | "tiny") distro="$(awk 'NR==1{print $1 " " $2;}' /etc/release)" ;;
+                *) distro="$(awk 'NR==1{print $1 " " $2 " " $3;}' /etc/release)" ;;
+            esac
         ;;
     esac
 
@@ -2901,7 +2904,7 @@ usage() { cat << EOF
                                 Possible values: name, speed, tiny, on, off
     --cpu_cores on/off          Whether or not to display the number of CPU cores
     --distro_shorthand on/off   Shorten the output of distro (tiny, on, off)
-                                NOTE: This is only possible on Linux and Mac OS X
+                                NOTE: This is only possible on Linux, Mac OS X, and Solaris
     --kernel_shorthand on/off   Shorten the output of kernel
     --uptime_shorthand on/off   Shorten the output of uptime (tiny, on, off)
     --refresh_rate on/off       Whether to display the refresh rate of each monitor

--- a/neofetch
+++ b/neofetch
@@ -188,6 +188,20 @@ getdistro() {
                 *) codename="Mac OS X" ;;
             esac
             distro="$codename $osx_version $osx_build"
+
+            case "$distro_shorthand" in
+                "on") distro="${distro/ ${osx_build}}" ;;
+                "tiny")
+                    case "$osx_version" in
+                        "10.4"*|"10.5"*|"10.6"*|"10.7"*)
+                            distro="${distro/${codename}/Mac OS X}" ;;
+                        "10.8"*|"10.9"*|"10.10"*|"10.11"*)
+                            distro="${distro/${codename}/OS X}" ;;
+                        "10.12"*)
+                            distro="${distro/${codename}/macOS}" ;;
+                    esac
+                    distro="${distro/ ${osx_build}}" ;;
+            esac
         ;;
 
         "iPhone OS")
@@ -224,12 +238,6 @@ getdistro() {
     # Get architecture
     [ "$os_arch" == "on" ] && \
         distro+=" $(uname -m)"
-
-    [ "$osx_codename" == "off" ] && \
-        distro="${distro/${codename}/Mac OS X}"
-
-    [ "$osx_buildversion" == "off" ] && \
-        distro="${distro/ ${osx_build}}"
 
     [ "${ascii_distro:-auto}" == "auto" ] && \
         ascii_distro="$(trim "$distro")"
@@ -2884,8 +2892,6 @@ usage() { cat << EOF
                                 in the output.
                                 NOTE: You can supply multiple args. eg.
                                 'neofetch --disable cpu gpu disk shell'
-    --osx_buildversion on/off   Hide/Show Mac OS X build version.
-    --osx_codename on/off       Hide/Show Mac OS X codename.
     --os_arch on/off            Hide/Show OS architecture.
     --speed_type type           Change the type of cpu speed to display.
                                 Possible values: current, min, max, bios,
@@ -2895,7 +2901,7 @@ usage() { cat << EOF
                                 Possible values: name, speed, tiny, on, off
     --cpu_cores on/off          Whether or not to display the number of CPU cores
     --distro_shorthand on/off   Shorten the output of distro (tiny, on, off)
-                                NOTE: This is only possible on Linux
+                                NOTE: This is only possible on Linux and Mac OS X
     --kernel_shorthand on/off   Shorten the output of kernel
     --uptime_shorthand on/off   Shorten the output of uptime (tiny, on, off)
     --refresh_rate on/off       Whether to display the refresh rate of each monitor
@@ -3018,8 +3024,6 @@ getargs() {
         case $1 in
             # Info
             --os_arch) os_arch="$2" ;;
-            --osx_buildversion) osx_buildversion="$2" ;;
-            --osx_codename) osx_codename="$2" ;;
             --cpu_cores) cpu_cores="$2" ;;
             --speed_type) speed_type="$2" ;;
             --distro_shorthand) distro_shorthand="$2" ;;

--- a/neofetch
+++ b/neofetch
@@ -2703,6 +2703,15 @@ err() {
 
 # }}}
 
+# Check for old flags {{{
+
+checkoldflags() {
+    [ -n "$osx_buildversion" ] && err "\$osx_buildversion is deprecated, use \$distro_shorthand instead."
+    [ -n "$osx_codename" ] && err "\$osx_codename is deprecated, use \$distro_shorthand instead."
+}
+
+# }}}
+
 # Get script directory {{{
 
 getscriptdir() {
@@ -3208,6 +3217,7 @@ getargs() {
 main() {
     getos
     getdefaultconfig 2>/dev/null
+    checkoldflags
     getargs "$@"
     getdistro
 

--- a/neofetch.1
+++ b/neofetch.1
@@ -19,12 +19,6 @@ NOTE: You can supply multiple args. eg.
 .br
 \'neofetch --disable cpu gpu disk shell\'
 .TP
-.B \--osx_buildversion 'on/off'
-Hide/Show Mac OS X build version.
-.TP
-.B \--osx_codename 'on/off'
-Hide/Show Mac OS X codename.
-.TP
 .B \--os_arch 'on/off'
 Hide/Show OS architecture.
 .TP
@@ -47,7 +41,7 @@ Whether or not to display the number of CPU cores
 .B \--distro_shorthand 'on/off'
 Shorten the output of distro (tiny, on, off)
 .br
-NOTE: This is only possible on Linux
+NOTE: This is only possible on Linux and Mac OS X
 .TP
 .B \--kernel_shorthand 'on/off'
 Shorten the output of kernel

--- a/neofetch.1
+++ b/neofetch.1
@@ -41,7 +41,7 @@ Whether or not to display the number of CPU cores
 .B \--distro_shorthand 'on/off'
 Shorten the output of distro (tiny, on, off)
 .br
-NOTE: This is only possible on Linux and Mac OS X
+NOTE: This is only possible on Linux, Mac OS X, and Solaris
 .TP
 .B \--kernel_shorthand 'on/off'
 Shorten the output of kernel


### PR DESCRIPTION
Instead of using two separate functions for showing/hiding a codename/build version for Mac OS X, I decided to expand `distro_shorthand` instead to Mac OS X (and Solaris).

I can only test this for Solaris, so I need a help to test this from a Mac as well.