### PR TITLE
change all references of Mac OS X to macOS

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -43,7 +43,7 @@ https://github.com/dylanaraps/neofetch/commit/3e9c3d648cb4c6f0d5fe5f0b96f9e29429
 
 **Distro**<br \>
 
-- Expanded `distro_shorthand` to Mac OS X and Solaris. **[@konimex](https://github.com/konimex)**
+- Expanded `distro_shorthand` to macOS and Solaris. **[@konimex](https://github.com/konimex)**
 - Removed `osx_buildversion` and `osx_codename` in favour of `distro_shorthand`. **[@konimex](https://github.com/konimex)**
 
 **Theme Font**<br \>

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Have a look at the wiki, I've updated/added some new pages!<br \>
     - [BunsenLabs](#bunsenlabs)
     - [Solus](#solus)
     - [Slackware](#slackware)
-    - [Mac OS X](#mac-os-x)
+    - [macOS](#mac-os-x)
     - [iOS](#ios-1)
     - [Others](#others)
 - [Post Install](#post-install)
@@ -51,7 +51,7 @@ Have a look at the wiki, I've updated/added some new pages!<br \>
 
 ![Linux](https://ipfs.pics/ipfs/QmRRYwcSRz1FHNx8VQiBixZq3qvBNk487fKGwUNTs7GQjA)
 ![Windows](https://ipfs.pics/ipfs/Qmf5GpmqnMRhEzC1qoQ2tM4699tEXLManZTs5pz4mWJbCg)
-![Mac OS X](https://ipfs.pics/ipfs/QmWA8XX6pFkEuLLcrq5JZBx1KFEUaXanTy1jMxzKVRpwaT)
+![macOS](https://ipfs.pics/ipfs/QmWA8XX6pFkEuLLcrq5JZBx1KFEUaXanTy1jMxzKVRpwaT)
 ![bsd](https://ipfs.pics/ipfs/QmSpyCGzSgYnyfbMetKqxy9cU3UFbneS3G8JrbdxkiNLgm)
 ![bsd](https://ipfs.pics/ipfs/QmeZhs3CwGtM8CSVoorA2d2CqLxRzbJkdD7aYxa4Dixsea)
 
@@ -64,7 +64,7 @@ Have a look at the wiki, I've updated/added some new pages!<br \>
 
 ## Features
 
-- Supports **Linux**, **Mac OS X**, **iOS**, **BSD**, **Solaris** and **Windows** (Cygwin/Windows 10 Linux subsystem)
+- Supports **Linux**, **macOS**, **iOS**, **BSD**, **Solaris** and **Windows** (Cygwin/Windows 10 Linux subsystem)
 - Display a **full color image**, a file containing **ascii art** or your **distro's logo** in ascii next to the info.
 - The script is **fast**. We use bash builtins wherever possible and only spawn external processes when necessary.
 - Take a screenshot of your desktop on script finish.
@@ -166,7 +166,7 @@ https://github.com/dylanaraps/neofetch/wiki/Following-HEAD
 - [BunsenLabs](#bunsenlabs)
 - [Solus](#solus)
 - [Slackware](#slackware)
-- [Mac OS X](#mac-os-x)
+- [macOS](#mac-os-x)
 - [iOS](##ios-1)
 - [Others](#others)
 
@@ -263,7 +263,7 @@ Use the Software Center or type `sudo eopkg it neofetch`.
 
 Download the files from [SlackBuilds](https://slackbuilds.org/repository/14.2/desktop/neofetch/) and follow [their instructions](https://slackbuilds.org/howto/).
 
-### Mac OS X
+### macOS
 
 1. Install `neofetch` with Homebrew
     - `brew install neofetch`
@@ -366,7 +366,7 @@ alias neofetch2="neofetch \
                                 Possible values: name, speed, tiny, on, off
     --cpu_cores on/off          Whether or not to display the number of CPU cores
     --distro_shorthand on/off   Shorten the output of distro (tiny, on, off)
-                                NOTE: This is only possible on Linux, Mac OS X, and Solaris
+                                NOTE: This is only possible on Linux, macOS, and Solaris
     --kernel_shorthand on/off   Shorten the output of kernel
     --uptime_shorthand on/off   Shorten the output of uptime (tiny, on, off)
     --refresh_rate on/off       Whether to display the refresh rate of each monitor

--- a/config/config
+++ b/config/config
@@ -62,7 +62,7 @@ kernel_shorthand="on"
 # Distro
 
 # Shorten the output of distro (tiny, on, off)
-# NOTE: This is only possible on Linux, Mac OS X, and Solaris
+# NOTE: This is only possible on Linux, macOS, and Solaris
 distro_shorthand="off"
 
 # Show 'x86_64' and 'x86' in 'Distro:' output.

--- a/neofetch
+++ b/neofetch
@@ -185,7 +185,7 @@ getdistro() {
                 "10.10"*) codename="OS X Yosemite" ;;
                 "10.11"*) codename="OS X El Capitan" ;;
                 "10.12"*) codename="macOS Sierra" ;;
-                *) codename="Mac OS X" ;;
+                *) codename="macOS" ;;
             esac
             distro="$codename $osx_version $osx_build"
 
@@ -1527,7 +1527,7 @@ getterm() {
     # Check $PPID for terminal emulator.
     case "$os" in
         "Mac OS X")
-            # Workaround for OS X systems that
+            # Workaround for macOS systems that
             # don't support the block below.
             case "$TERM_PROGRAM" in
                 "iTerm.app") term="iTerm2" ;;
@@ -2917,7 +2917,7 @@ usage() { cat << EOF
                                 Possible values: name, speed, tiny, on, off
     --cpu_cores on/off          Whether or not to display the number of CPU cores
     --distro_shorthand on/off   Shorten the output of distro (tiny, on, off)
-                                NOTE: This is only possible on Linux, Mac OS X, and Solaris
+                                NOTE: This is only possible on Linux, macOS, and Solaris
     --kernel_shorthand on/off   Shorten the output of kernel
     --uptime_shorthand on/off   Shorten the output of uptime (tiny, on, off)
     --refresh_rate on/off       Whether to display the refresh rate of each monitor

--- a/neofetch.1
+++ b/neofetch.1
@@ -41,7 +41,7 @@ Whether or not to display the number of CPU cores
 .B \--distro_shorthand 'on/off'
 Shorten the output of distro (tiny, on, off)
 .br
-NOTE: This is only possible on Linux, Mac OS X, and Solaris
+NOTE: This is only possible on Linux, macOS, and Solaris
 .TP
 .B \--kernel_shorthand 'on/off'
 Shorten the output of kernel


### PR DESCRIPTION
This does not change any programatical references as `sw_vers` still prints `Mac OS X` in Sierra