### PR TITLE
macOS: fix iTunes automatically opening

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1242,7 +1242,7 @@ getsong() {
         song="$(gpmdp-remote current)"
         state="$(gpmdp-remote status)"
 
-    elif [ -n "$(ps x | awk '!(/awk/ || /Helper/) && /iTunes/')" ]; then
+    elif [ -n "$(ps x | awk '!(/awk/ || /Helper/ || /Cache/) && /iTunes.app/')" ]; then
         song="$(osascript -e 'tell application "iTunes" to artist of current track as string & " - " & name of current track as string')"
         state="$(osascript -e 'tell application "iTunes" to player state as string')"
 


### PR DESCRIPTION
Fixes iTunes opening if it's not running on macOS. I believe this is because of a new cache extension in Sierra, because I'm sure I fixed this bug before...