### PR TITLE
wm: Add support for Windows WMs and Shells

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -537,18 +537,23 @@ getwm() {
 
         # Fallback for Wayland wms
         case "$wm" in
-            "xwlc")
-                wm="$(ps -e | grep -m 1 -oE "sway|orbment|velox|orbital")"
-                [ "$version" -ge 4 ] && wm="${wm^}"
-            ;;
+            "xwlc") wm="$(ps -e | grep -m 1 -oE "sway|orbment|velox|orbital")" ;;
         esac
 
     else
         case "$os" in
             "Mac OS X") wm="Quartz Compositor" ;;
-            "Windows")  wm="Explorer" ;;
+            "Windows")
+                wm="$(tasklist | grep -m 1 -o "bugn\|Windawesome\|blackbox\|emerge\|litestep")"
+                [ -z "$wm" ] && wm="Explorer"
+            ;;
         esac
     fi
+
+    # Don't uppercase i3
+    [ "$version" -ge 4 ] && \
+    [ "$wm" != "i3" ] && \
+         wm="${wm^}"
 }
 
 # }}}


### PR DESCRIPTION
This PR adds support for Windows WMs and Shells.

Supported: bugn, Windawesome, blackbox, emerge, litestep