### PR TITLE
Source os-release file instead of using awk

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -154,7 +154,7 @@ getdistro() {
                 case "$distro_shorthand" in
                     "on") distro="${NAME:-${DISTRIB_ID}} ${VERSION_ID:-${DISTRIB_RELEASE}}" ;;
                     "tiny") distro="${NAME:-${DISTRIB_ID:-${TAILS_PRODUCT_NAME}}}" ;;
-                    *) distro="${PRETTY_NAME:-${DISTRIB_DESCRIPTION}}" ;;
+                    *) distro="${PRETTY_NAME/${VERSION_ID}:-${DISTRIB_DESCRIPTION}} ${VERSION:-${VERSION_ID}}" ;;
                 esac
             fi
             distro="${distro//\"}"

--- a/neofetch
+++ b/neofetch
@@ -154,7 +154,7 @@ getdistro() {
                 case "$distro_shorthand" in
                     "on") distro="${NAME:-${DISTRIB_ID}} ${VERSION_ID:-${DISTRIB_RELEASE}}" ;;
                     "tiny") distro="${NAME:-${DISTRIB_ID:-${TAILS_PRODUCT_NAME}}}" ;;
-                    *) distro="${PRETTY_NAME:-${DISTRIB_DESCRIPTION}} ${VERSION:-${VERSION_ID}}" ;;
+                    "off") distro="${PRETTY_NAME:-${DISTRIB_DESCRIPTION}} ${UBUNTU_CODENAME}" ;;
                 esac
             fi
             distro="${distro//\"}"

--- a/neofetch
+++ b/neofetch
@@ -154,7 +154,7 @@ getdistro() {
                 case "$distro_shorthand" in
                     "on") distro="${NAME:-${DISTRIB_ID}} ${VERSION_ID:-${DISTRIB_RELEASE}}" ;;
                     "tiny") distro="${NAME:-${DISTRIB_ID:-${TAILS_PRODUCT_NAME}}}" ;;
-                    *) distro="${PRETTY_NAME/${VERSION_ID}:-${DISTRIB_DESCRIPTION}} ${VERSION:-${VERSION_ID}}" ;;
+                    *) distro="${PRETTY_NAME:-${DISTRIB_DESCRIPTION}} ${VERSION:-${VERSION_ID}}" ;;
                 esac
             fi
             distro="${distro//\"}"

--- a/neofetch
+++ b/neofetch
@@ -146,25 +146,15 @@ getdistro() {
                 esac
 
             else
-                # Workarounds are included in every shorthand option
+                # Source the os-release file
+                for file in /etc/*ease /usr/lib/*ease; do
+                    source "$file" 2>/dev/null
+                done
+
                 case "$distro_shorthand" in
-                    "on")
-                        distro="$(awk -F'=' '/^NAME|VERSION_ID=/ {print $2; exit}' /etc/*ease /usr/lib/*ease)"
-                        [ -z "$distro" ] && distro="$(awk -F'=' '/^DISTRIB_ID|DISTRIB_RELEASE=/ {print $2}' /etc/openwrt_release)"
-                    ;;
-
-                    "tiny")
-                        distro="$(awk -F'=' '/^NAME=/ {print $2; exit}' /etc/*ease /usr/lib/*ease)"
-                        [ -z "$distro" ] && distro="$(awk -F'=' '/^TAILS_PRODUCT_NAME=/ {print $2}' /etc/*ease)"
-                        [ -z "$distro" ] && distro="$(awk -F'=' '/^DISTRIB_ID=/ {print $2}' /etc/openwrt_release)"
-                    ;;
-
-                    *)
-                        distro="$(awk -F'=' '/^PRETTY_NAME=/ {print $2; exit}' /etc/*ease /usr/lib/*ease)"
-                        [ -z "$distro" ] && distro="$(awk -F'=' '{print $2}' /etc/*ease)"
-                        [ -z "$distro" ] && distro="$(awk '/BLAG/ {print $1; exit}' /etc/*ease)"
-                        [ -z "$distro" ] && distro="$(awk -F'=' '/^DISTRIB_DESCRIPTION=/ {print $2}' /etc/openwrt_release)"
-                    ;;
+                    "on") distro="${NAME:-${DISTRIB_ID}} ${VERSION_ID:-${DISTRIB_RELEASE}}" ;;
+                    "tiny") distro="${NAME:-${DISTRIB_ID:-${TAILS_PRODUCT_NAME}}}" ;;
+                    *) distro="${PRETTY_NAME:-${DISTRIB_DESCRIPTION}}" ;;
                 esac
             fi
             distro="${distro//\"}"


### PR DESCRIPTION
The `os-release` files store values in the same syntax as shell scripts so sourcing this file adds the info we need directly to variables. This allows us to simplify this part of the function and make it much much smaller.

This still includes all of the workarounds for other OS, I just need to test that they still work.

- TODO
    - [ ] Testing
        - [ ] OpenWRT
        - [ ] BLAG
        - [ ] Tails
    - [ ] Fix BLAG Linux.

Edit: It turns out that some distros go against the `os-release` standard by storing the values differently. This causes the source to fail. Blag, why?

I'm going to have to close this as sourcing isn't as reliable. 