### PR TITLE
Rewrite uptime for Linux/Windows/Solaris to match macOS/BSD

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -288,9 +288,9 @@ getuptime() {
                 ;;
             esac
 
-            days="$((seconds / 86400)) days"
-            hours="$((seconds / 3600)) hours"
-            minutes="$((seconds % 3600 / 60)) minutes"
+            days="$((seconds / 60 / 60 / 24)) days"
+            hours="$((seconds / 60 / 60 % 24)) hours"
+            minutes="$((seconds / 60 % 60)) minutes"
 
             case "$days" in
                 "0 days") unset days ;;

--- a/neofetch
+++ b/neofetch
@@ -307,8 +307,9 @@ getuptime() {
                 "1 minutes") minutes="${minutes/s}" ;;
             esac
 
-            uptime="up ${days:+$days,} ${hours:+$hours,} ${minutes}"
+            uptime="${days:+$days, }${hours:+$hours, }${minutes}"
             uptime="${uptime%', '}"
+            uptime="up ${uptime:-${seconds} seconds}"
         ;;
 
         "Solaris")

--- a/neofetch
+++ b/neofetch
@@ -269,65 +269,46 @@ getkernel() {
 
 getuptime() {
     case "$os" in
-        "Linux" | "Windows")
-            case "$distro" in
-                *"Puppy"* | "Quirky Werewolf"* | "Alpine Linux"* | "OpenWRT"* | "Windows"*)
-                    uptime="$(uptime | awk -F ':[0-9]{2}+ |(, ){1}+' '{printf $2}')"
+        "Linux" | "Windows" | "Mac OS X" | "iPhone OS" | "BSD")
+            # Get uptime in seconds
+            case "$os" in
+                "Linux" | "Windows")
+                    seconds="$(< /proc/uptime)"
+                    seconds="${seconds/.*}"
                 ;;
 
-                "openSUSE"*)
-                    uptime="$(uptime | awk -F ':[0-9]{2}+[a-z][a-z]  |(, ){1}+' '{printf $2}')"
-                ;;
+                "Mac OS X" | "iPhone OS" | "BSD")
+                    boot="$(sysctl -n kern.boottime)"
+                    boot="${boot/'{ sec = '}"
+                    boot="${boot/,*}"
 
-                *)
-                    uptime="$(uptime -p)"
-                    [ "$uptime" == "up " ] && uptime="up $(awk -F'.' '{print $1}' /proc/uptime) seconds"
+                    # Get current date in seconds
+                    now="$(date +%s)"
+                    seconds="$((now - boot))"
                 ;;
             esac
-        ;;
 
-        "Mac OS X" | "iPhone OS" | "BSD")
-            # Get boot time in seconds
-            boot="$(sysctl -n kern.boottime)"
-            boot="${boot/'{ sec = '}"
-            boot="${boot/,*}"
+            days="$((seconds / 86400)) days"
+            hours="$((seconds / 3600)) hours"
+            minutes="$((seconds % 3600 / 60)) minutes"
 
-            # Get current date in seconds
-            now="$(date +%s)"
-            uptime="$((now - boot))"
-
-            # Convert uptime to days/hours/mins
-            minutes="$((uptime / 60%60))"
-            hours="$((uptime / 3600%24))"
-            days="$((uptime / 86400))"
-
-            case "$minutes" in
-                1) minutes="1 minute" ;;
-                0) unset minutes ;;
-                *) minutes="$minutes minutes" ;;
+            case "$days" in
+                "0 days") unset days ;;
+                "1 days") days="${days/s}" ;;
             esac
 
             case "$hours" in
-                1) hours="1 hour" ;;
-                0) unset hours ;;
-                *) hours="$hours hours" ;;
+                "0 hours") unset hours ;;
+                "1 hours") hours="${hours/s}" ;;
             esac
 
-            case "$days" in
-                1) days="1 day" ;;
-                0) unset days ;;
-                *) days="$days days" ;;
+            case "$minutes" in
+                "0 minutes") unset minutes ;;
+                "1 minutes") minutes="${minutes/s}" ;;
             esac
 
-            [ "$hours" ] && \
-            [ "$minutes" ] && \
-                hours+=","
-
-            [ "$days" ] && \
-            [ "$hours" ] && \
-                days+=","
-
-            uptime="up $days $hours $minutes"
+            uptime="up ${days:+$days,} ${hours:+$hours,} ${minutes}"
+            uptime="${uptime%', '}"
         ;;
 
         "Solaris")
@@ -353,7 +334,7 @@ getuptime() {
             uptime="${uptime/ minutes/m}"
             uptime="${uptime/ minute/m}"
             uptime="${uptime/ seconds/s}"
-            uptime="${uptime/,}"
+            uptime="${uptime//,}"
         ;;
     esac
 }


### PR DESCRIPTION
This PR aims to remove issues on Linux based systems where there are an endless amount of different `uptime` commands all with a different output format. Instead of using the `uptime` command we now parse `/proc/uptime` which provides us with the uptime in seconds. We then convert those seconds into days, hours and minutes.

This is how neofetch calculates uptime on macOS/BSD and this allows us to merge both functions removing ~20 lines from the script. 

Notes:

- This removes the `procps`/`procps-ng` dependency from Windows systems.
- This fixes output errors on Android.
- This allows us to add an option to enable seconds in the output. I don't know if I'll add this or not but the possibility is there.

Testing:

- [x] Linux
- [x] Windows
- [x] Solaris
- [x] BSD
- [ ] macOS / iOS 

@iandrewt, can you test this on macOS?