### PR TITLE
Add option to hide/show hyperthreaded cpu cores.

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ alias neofetch2="neofetch \
                                 Possible values: name, speed, tiny, on, off
     --cpu_cores type            Whether or not to display the number of CPU cores
                                 Takes: logical, physical, off
+                                Note: 'physical' only works on Linux, Windows and macOS.
     --distro_shorthand on/off   Shorten the output of distro (tiny, on, off)
                                 NOTE: This is only possible on Linux, macOS, and Solaris
     --kernel_shorthand on/off   Shorten the output of kernel

--- a/README.md
+++ b/README.md
@@ -364,7 +364,8 @@ alias neofetch2="neofetch \
                                 NOTE: This only support Linux with cpufreq.
     --cpu_shorthand type        Shorten the output of CPU
                                 Possible values: name, speed, tiny, on, off
-    --cpu_cores on/off          Whether or not to display the number of CPU cores
+    --cpu_cores type            Whether or not to display the number of CPU cores
+                                Takes: logical. physical, off
     --distro_shorthand on/off   Shorten the output of distro (tiny, on, off)
                                 NOTE: This is only possible on Linux, macOS, and Solaris
     --kernel_shorthand on/off   Shorten the output of kernel

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ alias neofetch2="neofetch \
                                 Possible values: name, speed, tiny, on, off
     --cpu_cores type            Whether or not to display the number of CPU cores
                                 Takes: logical, physical, off
-                                Note: 'physical' only works on Linux, Windows and macOS.
+                                Note: 'physical' doesn't work on BSD.
     --distro_shorthand on/off   Shorten the output of distro (tiny, on, off)
                                 NOTE: This is only possible on Linux, macOS, and Solaris
     --kernel_shorthand on/off   Shorten the output of kernel

--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ alias neofetch2="neofetch \
     --cpu_shorthand type        Shorten the output of CPU
                                 Possible values: name, speed, tiny, on, off
     --cpu_cores type            Whether or not to display the number of CPU cores
-                                Takes: logical. physical, off
+                                Takes: logical, physical, off
     --distro_shorthand on/off   Shorten the output of distro (tiny, on, off)
                                 NOTE: This is only possible on Linux, macOS, and Solaris
     --kernel_shorthand on/off   Shorten the output of kernel

--- a/config/config
+++ b/config/config
@@ -111,7 +111,7 @@ cpu_display="off"
 # Logical: All virtual cores
 # Physical: All physical cores
 # --cpu_cores logical, physical, off
-# Note: 'physical' only works on Linux, Windows and macOS.
+# Note: 'physical' doesn't work on BSD.
 cpu_cores="logical"
 
 

--- a/config/config
+++ b/config/config
@@ -108,7 +108,9 @@ cpu_display="off"
 
 # CPU Cores
 # Display CPU cores in output
-# --cpu_cores on/off
+# Logical: All virtual cores
+# Physical: All physical cores
+# --cpu_cores logical, physical, off
 cpu_cores="on"
 
 

--- a/config/config
+++ b/config/config
@@ -111,7 +111,7 @@ cpu_display="off"
 # Logical: All virtual cores
 # Physical: All physical cores
 # --cpu_cores logical, physical, off
-cpu_cores="on"
+cpu_cores="logical"
 
 
 # GPU

--- a/config/config
+++ b/config/config
@@ -111,6 +111,7 @@ cpu_display="off"
 # Logical: All virtual cores
 # Physical: All physical cores
 # --cpu_cores logical, physical, off
+# Note: 'physical' only works on Linux, Windows and macOS.
 cpu_cores="logical"
 
 

--- a/neofetch
+++ b/neofetch
@@ -725,9 +725,9 @@ getcpu() {
             fi
 
             # Show/hide hyperthreaded cores
-            case "$cores_ht" in
-                "on") cores="$(grep -c ^processor /proc/cpuinfo)" ;;
-                "off") cores="$(grep "^core id" /proc/cpuinfo | sort -u | wc -l)" ;;
+            case "$cpu_cores" in
+                "logical" | "on") cores="$(grep -c ^processor /proc/cpuinfo)" ;;
+                "physical") cores="$(grep "^core id" /proc/cpuinfo | sort -u | wc -l)" ;;
             esac
 
             # Fix for speeds under 1ghz
@@ -744,9 +744,9 @@ getcpu() {
             cpu="$(sysctl -n machdep.cpu.brand_string)"
 
             # Show/hide hyperthreaded cores
-            case "$cores_ht" in
-                "on") cores="$(sysctl -n hw.logicalcpu_max)" ;;
-                "off") cores="$(sysctl -n hw.physicalcpu_max)" ;;
+            case "$cpu_cores" in
+                "logical" | "on") cores="$(sysctl -n hw.logicalcpu_max)" ;;
+                "physical") cores="$(sysctl -n hw.physicalcpu_max)" ;;
             esac
         ;;
 
@@ -922,7 +922,7 @@ getcpu() {
     cpu="${cpu//with Radeon HD Graphics}"
 
     # Add cpu cores to output
-    [ "$cpu_cores" == "on" ] && [ "$cores" ] && \
+    [ "$cpu_cores" != "off" ] && [ "$cores" ] && \
         cpu="${cpu/@/(${cores}) @}"
 
     # Make the output of cpu shorter
@@ -2956,7 +2956,8 @@ usage() { cat << EOF
                                 NOTE: This only support Linux with cpufreq.
     --cpu_shorthand type        Shorten the output of CPU
                                 Possible values: name, speed, tiny, on, off
-    --cpu_cores on/off          Whether or not to display the number of CPU cores
+    --cpu_cores type            Whether or not to display the number of CPU cores
+                                Takes: logical. physical, off
     --distro_shorthand on/off   Shorten the output of distro (tiny, on, off)
                                 NOTE: This is only possible on Linux, macOS, and Solaris
     --kernel_shorthand on/off   Shorten the output of kernel

--- a/neofetch
+++ b/neofetch
@@ -724,7 +724,11 @@ getcpu() {
                 speed="$((speed / 100))"
             fi
 
-            cores="$(grep -c ^processor /proc/cpuinfo)"
+            # Show/hide hyperthreaded cores
+            case "$cores_ht" in
+                "on") cores="$(grep -c ^processor /proc/cpuinfo)" ;;
+                "off") cores="$(grep "^core id" /proc/cpuinfo | sort -u | wc -l)" ;;
+            esac
 
             # Fix for speeds under 1ghz
             if [ -z "${speed:1}" ]; then
@@ -738,7 +742,12 @@ getcpu() {
 
         "Mac OS X")
             cpu="$(sysctl -n machdep.cpu.brand_string)"
-            cores="$(sysctl -n hw.ncpu)"
+
+            # Show/hide hyperthreaded cores
+            case "$cores_ht" in
+                "on") cores="$(sysctl -n hw.logicalcpu_max)" ;;
+                "off") cores="$(sysctl -n hw.physicalcpu_max)" ;;
+            esac
         ;;
 
         "iPhone OS")

--- a/neofetch
+++ b/neofetch
@@ -2957,7 +2957,7 @@ usage() { cat << EOF
     --cpu_shorthand type        Shorten the output of CPU
                                 Possible values: name, speed, tiny, on, off
     --cpu_cores type            Whether or not to display the number of CPU cores
-                                Takes: logical. physical, off
+                                Takes: logical, physical, off
     --distro_shorthand on/off   Shorten the output of distro (tiny, on, off)
                                 NOTE: This is only possible on Linux, macOS, and Solaris
     --kernel_shorthand on/off   Shorten the output of kernel

--- a/neofetch
+++ b/neofetch
@@ -738,7 +738,7 @@ getcpu() {
 
         "Mac OS X")
             cpu="$(sysctl -n machdep.cpu.brand_string)"
-            cores="$(sysctl -n hw.physicalcpu)"
+            cores="$(sysctl -n hw.ncpu)"
         ;;
 
         "iPhone OS")

--- a/neofetch
+++ b/neofetch
@@ -893,8 +893,11 @@ getcpu() {
             speed="$(psrinfo -v | awk '/operates at/ {print $6}')"
             speed="$((speed / 100))"
 
-            # Get cpu cores
-            cores="$(kstat -m cpu_info | grep -c "chip_id")"
+            # Show/hide hyperthreaded cores
+            case "$cpu_cores" in
+                "logical" | "on") cores="$(kstat -m cpu_info | grep -c "chip_id")" ;;
+                "physical") cores="$(psrinfo -p)" ;;
+            esac
 
             # Fix for speeds under 1ghz
             if [ -z "${speed:1}" ]; then

--- a/neofetch
+++ b/neofetch
@@ -2958,6 +2958,7 @@ usage() { cat << EOF
                                 Possible values: name, speed, tiny, on, off
     --cpu_cores type            Whether or not to display the number of CPU cores
                                 Takes: logical, physical, off
+                                Note: 'physical' only works on Linux, Windows and macOS.
     --distro_shorthand on/off   Shorten the output of distro (tiny, on, off)
                                 NOTE: This is only possible on Linux, macOS, and Solaris
     --kernel_shorthand on/off   Shorten the output of kernel

--- a/neofetch
+++ b/neofetch
@@ -2961,7 +2961,7 @@ usage() { cat << EOF
                                 Possible values: name, speed, tiny, on, off
     --cpu_cores type            Whether or not to display the number of CPU cores
                                 Takes: logical, physical, off
-                                Note: 'physical' only works on Linux, Windows and macOS.
+                                Note: 'physical' doesn't work on BSD.
     --distro_shorthand on/off   Shorten the output of distro (tiny, on, off)
                                 NOTE: This is only possible on Linux, macOS, and Solaris
     --kernel_shorthand on/off   Shorten the output of kernel

--- a/neofetch.1
+++ b/neofetch.1
@@ -35,7 +35,7 @@ Shorten the output of CPU
 .br
 Possible values: name, speed, tiny, on, off
 .TP
-.B \--cpu_cores 'on/off'
+.B \--cpu_cores 'logical/physical/off'
 Whether or not to display the number of CPU cores
 .TP
 .B \--distro_shorthand 'on/off'

--- a/neofetch.1
+++ b/neofetch.1
@@ -53,7 +53,8 @@ Shorten the output of uptime (tiny, on, off)
 .TP
 .B \--refresh_rate 'on/off'
 Whether to display the refresh rate of each monitor
-Unsupported on Windows
+.br
+Note: Unsupported on Windows
 .TP
 .B \--gpu_shorthand 'on/off'
 Shorten the output of GPU (tiny, on, off)

--- a/neofetch.1
+++ b/neofetch.1
@@ -37,6 +37,8 @@ Possible values: name, speed, tiny, on, off
 .TP
 .B \--cpu_cores 'logical/physical/off'
 Whether or not to display the number of CPU cores
+.br
+Note: 'physical' only works on Linux, Windows and macOS.
 .TP
 .B \--distro_shorthand 'on/off'
 Shorten the output of distro (tiny, on, off)

--- a/neofetch.1
+++ b/neofetch.1
@@ -38,7 +38,7 @@ Possible values: name, speed, tiny, on, off
 .B \--cpu_cores 'logical/physical/off'
 Whether or not to display the number of CPU cores
 .br
-Note: 'physical' only works on Linux, Windows and macOS.
+Note: 'physical' doesn't work on BSD.
 .TP
 .B \--distro_shorthand 'on/off'
 Shorten the output of distro (tiny, on, off)


### PR DESCRIPTION
This PR adds expands on `cpu_cores` by adding two new values, `logical` and `physical`.

Values: 

- `logical`: All virtual cores.
- `physical`: All physical cores.

Changes:

- `cpu_cores` will be set to `logical` by default.
- [macOS] Changes `hw.ncpu` to `hw.logicalcpu_max` since `hw.ncpu` is deprecated.
  
>HW_NCPU (DEPRECATED)
             The number of cpus.  It is recommended that you use "hw.physicalcpu" "hw.physicalcpu_max"
             "hw.logicalcpu" or "hw.logicalcpu_max" instead. 

[source](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man3/sysctlbyname.3.html)

- [macOS] Use `_max` for core output to show all cores, not just available cores.


TODO

- [x] Add config option
- [x] Add flag
- [x] Update docs
- Support
    - [x] Linux / Windows
        - `physical` doesn't work on android.
    - [x] macOS
    - [ ] BSD
    - [x] Solaris

Closes #379 