### PR TITLE
Image mode: Add support for terminal emulators that don't support \033[14t

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,21 @@ Have a look at the wiki, I've updated/added some new pages!<br \>
     - Alpine Linux: You also need `ncurses`.
 
 
+##### Image mode
+
+These dependencies are required for image mode to work.
+
+- Displaying images: `w3m-img` \[1\] or `iTerm2` or `Terminology` \[2\]
+- Thumbnail creation: `imagemagick`
+- Window size: A terminal emulator that supports `\033[14t` \[3\] or `xdotool` or `xwininfo + xprop` or `xwininfo + xdpyinfo`
+
+\[1\] `w3m-img` is sometimes bundled together with `w3m`.
+
+\[2\] Image support is built into Terminology and iTerm2, and doesn't require w3m-img.
+
+\[3\] See this wiki page to find out if your terminal emulator supports `\033[14t` or if you need an additonal dependency.
+
+
 ##### iOS
 
 These dependencies can all be installed through Cydia.<br \>
@@ -99,19 +114,18 @@ Note: The cydia package installs these dependencies for you.
 - `Gawk`
 - `grep`
 
+
 ### Optional dependencies:
 
-- Desktop Environment and Window Manager: `xprop` \[1\]
-- Displaying images: `w3m-img` \[2\] \[3\] or `iTerm2` or `Terminology` \[4\]
-- Thumbnail creation: `imagemagick`
 - Displaying song information from Google Play Music Desktop Player: [`gpmdp-remote`](https://github.com/iAndrewT/gpmdp-remote)
+- Desktop Environment and Window Manager: `xprop` \[1\]
 
 ##### Linux / BSD / Solaris
 
 - Wallpaper: `feh`, `nitrogen` or `gsettings`
 - Current Song: `mpc`, `cmus`, `moc`, `spotify`, `gpmdc`
-- Resolution: `xorg-xrandr` or `xorg-xdpyinfo` \[5\]
-- Screenshot: `scrot` \[6\]
+- Resolution: `xorg-xrandr` or `xorg-xdpyinfo` \[2\]
+- Screenshot: `scrot` \[3\]
 
 ##### OSX
 
@@ -128,17 +142,10 @@ Note: The cydia package installs these dependencies for you.
 
 \[1\] See **[#79](https://github.com/dylanaraps/neofetch/issues/79)** about why this is now a required dependency.
 
-\[2\] `w3m-img` is sometimes bundled together with `w3m`.
-
-\[3\] Image support only works in certain terminal emulators. The script will fallback to ascii mode on<br \>
-terminal emulators that don't support the xterm escape sequences we're using for image sizing.
-
-\[4\] Image support is built into Terminology and iTerm2, and doesn't require w3m-img.
-
-\[5\] Xrandr is prefered over xdpyinfo as Xrandr supports multi monitor and refresh rate display in the<br \>
+\[2\] Xrandr is prefered over xdpyinfo as Xrandr supports multi monitor and refresh rate display in the<br \>
 output.
 
-\[6\] You can use the launch flag `--scrot_cmd` or change the config option `$scrot_cmd` to your screenshot<br \>
+\[3\] You can use the launch flag `--scrot_cmd` or change the config option `$scrot_cmd` to your screenshot<br \>
 program's cmd and neofetch will use it instead of scrot.
 
 

--- a/neofetch
+++ b/neofetch
@@ -2906,25 +2906,25 @@ kdeconfigdir() {
 
 dynamicprompt() {
     # Calculate image height in terminal cells.
-    # The '+ 4' adds a gap between the prompt and the content.
+    # The '+ 1' adds a gap between the prompt and the content.
     [ "$image" != "ascii" ] && \
-        lines="$((${height:-1} / ${font_height:-1} + 4))"
+        lines="$((${height:-1} / ${font_height:-1} + 1))"
 
     # If the info is higher than the ascii/image place the prompt
     # based on the info height instead of the ascii/image height.
     if [ "${lines:-0}" -lt "${info_height:-0}" ]; then
         lines="0"
     else
-        lines="$((lines - info_height - 4))"
+        lines="$((lines - info_height + $((${yoffset:-1} / ${font_height:-1}))))"
     fi
 
     # Set the prompt location
     [ "$image" != "off" ] && printf "\033[${lines/-*/0}B"
 
-    # Add some padding if the lines are above 0
-    if [ "$lines" -gt 0 ]; then
+    # Add some padding
+    [ "$image_backend" != "w3m" ] && \
+    [ "$lines" -gt 0 ] && \
         printf "\n\n"
-    fi
 }
 
 # }}}

--- a/neofetch
+++ b/neofetch
@@ -3317,6 +3317,10 @@ main() {
     printinfo
     [ "$image" != "off" ] && dynamicprompt
 
+    # w3m-img: Draw the image a second time to fix
+    # rendering issues in specific terminal emulators.
+    [ "$image_backend" == "w3m" ] && displayimage
+
     # Re-enable line wrap
     printf "%b%s" "\033[?7h"
 

--- a/neofetch
+++ b/neofetch
@@ -2098,39 +2098,66 @@ getimage() {
     esac
 
     # Get terminal width and height
-    if [ -n "$TMUX" ]; then
-        printf "%b%s" "\033Ptmux;\033\033[14t\033\033[c\033\\"
-        read_flags="-d c"
+    if type -p xdotool >/dev/null 2>&1 && \
+        [ "$image_backend" != "iterm2" ]; then
 
-    elif [ "$image_backend" == "tycat" ]; then
-        printf "%b%s" "\033}qs\000"
+        current_window="$(xdotool getactivewindow)"
+        eval "$(xdotool getwindowgeometry --shell "$current_window")"
+        term_height="$HEIGHT"
+        term_width="$WIDTH"
+
+    elif type -p xwininfo >/dev/null 2>&1 && \
+        type -p xdpyinfo >/dev/null 2>&1 || \
+        type -p xprop >/dev/null 2>&1 && \
+        [ "$image_backend" != "iterm2" ]; then
+
+        if type -p xdpyinfo >/dev/null 2>&1; then
+            current_window="$(xdpyinfo | grep focus | grep -E -o 0x[0-9a-f]+)"
+        elif type -p xprop >/dev/null 2>&1; then
+            current_window="$(xprop -root | awk '/_NET_ACTIVE_WINDOW\(WINDOW\)/{print $NF}')"
+        fi
+
+        term_size="$(xwininfo -id "$current_window" | awk -F ': ' '/Width|Height/ {printf $2 " "}')"
+        term_width="${term_size/ *}"
+        term_height="${term_size/${term_width}}"
 
     else
-        printf "%b%s" "\033[14t\033[c"
-        read_flags="-d c"
-    fi
+        if [ -n "$TMUX" ]; then
+            printf "%b%s" "\033Ptmux;\033\033[14t\033\033[c\033\\"
+            read_flags="-d c"
 
-    # The escape code above prints the output AFTER the prompt so this
-    builtin read -s -t 1 ${read_flags} -r term_size
+        elif [ "$image_backend" == "tycat" ]; then
+            printf "%b%s" "\033}qs\000"
 
-    # Split the string
-    if [ "$image_backend" == "tycat" ]; then
-        term_size=(${term_size//;/ })
-        term_width="$((term_size[2] * term_size[0]))"
-        term_height="$((term_size[3] * term_size[1]))"
+        else
+            printf "%b%s" "\033[14t\033[c"
+            read_flags="-d c"
+        fi
 
-    else
-        term_size="${term_size//'['}"
-        term_size="${term_size/';'}"
-        term_size="${term_size/$'\E4'}"
-        term_size="${term_size/t*}"
-        term_height="${term_size/';'*}"
-        term_width="${term_size/*';'}"
+        # The escape code above prints the output AFTER the prompt so this
+        builtin read -s -t 1 ${read_flags} -r term_size
+
+        # Split the string
+        if [ "$image_backend" == "tycat" ]; then
+            term_size=(${term_size//;/ })
+            term_width="$((term_size[2] * term_size[0]))"
+            term_height="$((term_size[3] * term_size[1]))"
+
+        else
+            term_size="${term_size//'['}"
+            term_size="${term_size/';'}"
+            term_size="${term_size/$'\E4'}"
+            term_size="${term_size/t*}"
+            term_height="${term_size/';'*}"
+            term_width="${term_size/*';'}"
+        fi
+
+        [ "${#term_size}" -le 5 ] && no_esc="1"
     fi
 
     # If $img isn't a file or the terminal doesn't support xterm escape sequences,
     # fallback to ascii mode.
-    if [ ! -f "$img" ] || ([ "${#term_size}" -le 5 ] && [ "$image_backend" != "tycat" ]); then
+    if [ ! -f "$img" ] || ([ "$no_esc" == 1 ] && [ "$image_backend" != "tycat" ]); then
         image="ascii"
         getascii
 


### PR DESCRIPTION
This PR adds support for terminal emulators that don't support `\033[14t`. This escape sequence is used to get the terminal window geometry in pixels.

Those using terminals that don't support the sequence now have three alternatives to get image mode working.

- `xdotool`
- `xwininfo + xprop`
- `xwininfo + xdpyinfo`

Neofetch will detect whatever combination you have installed and use these programs to get the terminal size. 

Note: This change only affects systems running an `X server`  so macOS/iOS/Windows are excluded.

Also includes:

- w3m-img: Draw image twice
- prompt location: Take yoffset into account

Closes #382 + #385 