### PR TITLE
Solaris: Changed Solaris' getpackage behaviour and getdistro output

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -233,6 +233,7 @@ getdistro() {
                 "on" | "tiny") distro="$(awk 'NR==1{print $1 " " $2;}' /etc/release)" ;;
                 *) distro="$(awk 'NR==1{print $1 " " $2 " " $3;}' /etc/release)" ;;
             esac
+            distro="${distro/\(*}"
         ;;
     esac
 

--- a/neofetch
+++ b/neofetch
@@ -343,7 +343,7 @@ getuptime() {
 
 getpackages() {
     case "$os" in
-        "Linux" | "iPhone OS")
+        "Linux" | "iPhone OS" | "Solaris")
             type -p pacman >/dev/null 2>&1 && \
                 packages="$(pacman -Qq --color never | wc -l)"
 
@@ -367,6 +367,7 @@ getpackages() {
 
             type -p pkg >/dev/null 2>&1 && \
                 packages="$((packages+=$(ls -1 /var/db/pkg | wc -l)))"
+                [ "$packages" == "0" ] && packages="$((packages+=$(pkg list | wc -l)))"
 
             type -p emerge >/dev/null 2>&1 && \
                 packages="$((packages+=$(ls -d /var/db/pkg/*/* | wc -l)))"
@@ -425,10 +426,6 @@ getpackages() {
             # Count chocolatey packages
             [ -d "/cygdrive/c/ProgramData/chocolatey/lib" ] && \
                 packages="$((packages+=$(ls -1 /cygdrive/c/ProgramData/chocolatey/lib | wc -l)))"
-        ;;
-
-        "Solaris")
-            packages="$(pkg list | wc -l)"
         ;;
     esac
 }


### PR DESCRIPTION
Some Solaris/illumos-based distribution used various Linux package managers such as dpkg, rpm, and portage (see more [here](http://wiki.illumos.org/display/illumos/Distributions)). It would make sense for Solaris' case to be unified with Linux.

However, Linux's `pkg` detection (I don't know which distro is that) are vastly different from Oracle Solaris/OpenIndiana's `pkg`, so a workaround (if acceptable) is used.