### PR TITLE
Kernel: Removed `-m` from `uname` in kernel_shorthand's off option

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -272,9 +272,8 @@ getkernel() {
     esac
 
     case "$kernel_shorthand" in
-        "on")   kernel_flags="-sr" ;;
-        "tiny") kernel_flags="-r" ;;
-        "off")  kernel_flags="-srm" ;;
+        "tiny" | "on")   kernel_flags="-r" ;;
+        "off")  kernel_flags="-sr" ;;
     esac
     kernel="$(uname $kernel_flags)"
 }


### PR DESCRIPTION
## Description

### Features
The reason that I removed it from the beacuse we already have `os_arch` option in `getdistro`. So I don't see the point in adding another architecture option in `getkernel`.