### PR TITLE
GPU: Used FreeBSD's method for DragonFlyBSD and PacBSD

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -983,7 +983,7 @@ getgpu() {
 
         "BSD" | "Solaris")
             case "$distro" in
-                "FreeBSD"*)
+                "FreeBSD"* | "DragonFlyBSD"* | "PacBSD"*)
                     gpu="$(pciconf -lv 2>/dev/null | grep -B 4 "VGA" | grep "device")"
                     gpu="${gpu/*device*= }"
                     gpu="${gpu//\'}"


### PR DESCRIPTION
## Description

### Features

Since DragonFlyBSD has `pciconf`, and PacBSD is basically FreeBSD + `pacman`, we can use `pciconf` for those two distros instead of relying on Xorg.