### PR TITLE
Android (Termux): Fix default config location

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2712,6 +2712,9 @@ getdefaultconfig() {
     elif [ -f "/usr/local/share/neofetch/config" ]; then
         default_config="/usr/local/share/neofetch/config"
 
+    elif [ -f "/data/data/com.termux/files/usr/share/neofetch/config" ]; then
+        default_config="/data/data/com.termux/files/usr/share/neofetch/config"
+
     else
         getscriptdir
         default_config="${script_dir}/config/config"


### PR DESCRIPTION
Without this change I get the following error when running `neofetch` after a clean install:

    neofetch: line 3261: printinfo: command not found

After applying this change it works beautifully!