### PR TITLE
Fixed gpu detection on linux

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,22 @@
 ## Contributors
 
+- **[@JorgeGonzalez](https://github.com/JorgeGonzalez)**
+
+
 ## General
 
 - Fixed issue where info wasn't detected properly but the subtitle was still displayed.
+
+
+
+## Info
+
+**Terminal**<br \>
+
+- Added support for HyperTerm. **[@JorgeGonzalez](https://github.com/JorgeGonzalez)**
+
+
+**Terminal Font**<br \>
+
+- Added support for HyperTerm. **[@JorgeGonzalez](https://github.com/JorgeGonzalez)**
 

--- a/neofetch
+++ b/neofetch
@@ -1542,7 +1542,7 @@ gettermfont() {
             termfont="${termfont/:*}"
         ;;
 
-        "HyperTerm")
+        "Hyper"*)
             termfont="$(awk -F "," '/fontFamily/ {a=$1} END{print a}' "${HOME}/.hyper.js" | awk -F "'" '{a=$2} END{print a}')"
         ;;
     esac

--- a/neofetch
+++ b/neofetch
@@ -934,8 +934,18 @@ getgpu() {
             if [ -f "/tmp/neofetch/gpu" ]; then
                 source "/tmp/neofetch/gpu"
             else
-                gpu="$(PATH="/sbin:$PATH" lspci -mm | awk -F '\\"|\\" \\"' '/3D|VGA/ {print $3 " " $4}')"
 
+                # Try to find out the BDF (bus:device.function number) of the currently used GPU
+                bdf_number="$(PATH="/sbin:$PATH" lspci -k | grep -P 'VGA(?=.*\n.*\n\tKernel driver in use)' | awk -F ' ' '{print $1}')"
+
+                if [ -z "$bdf_number" ]; then
+                    # Fallback if no kernel driver is in use
+                    gpu="$(PATH="/sbin:$PATH" lspci -mm | awk -F '\\"|\\" \\"' '/3D|VGA/ {print $3 " " $4}')"
+                else
+                    # Find the currently used GPU by its BDF
+                    gpu="$(PATH="/sbin:$PATH" lspci -mm | awk -v bdf_number="$bdf_number" -F '\\"|\\" \\"' '$0 ~ bdf_number {print $3 " " $4}')"
+                fi
+                
                 case "$gpu" in
                     intel*) gpu="Intel Integrated Graphics" ;;
 


### PR DESCRIPTION
## The issue

In case of several GPUs present, current version does not detect which one is active at the moment.

For example: 
`lspci -mm | awk -F '\\"|\\" \\"' '/3D|VGA/ {print $3 " " $4}'`
on my system returns: 
`Intel Corporation Xeon E3-1200 v3/4th Gen Core Processor Integrated Graphics Controller
NVIDIA Corporation GK106 [GeForce GTX 660]`

Which is afterwards immediately grabbed by:
```bash
case "$gpu" in
     intel*) gpu="Intel Integrated Graphics" ;;
```
Whether the GPU that goes first in the returned string is currently being used is disregarded.

## The fix

I believe that this issue can be fixed by checking whether there is a kernel driver in use for a given GPU. 
The check is performed by the regex:
`'VGA(?=.*\n.*\n\tKernel driver in use)'`
Then we grab the BDF number of that GPU and proceed to finding the right GPU by it (would not be necessary if `lspci -kmm` worked the way it's supposed to but alas).

I also added a fallback to the old detection method in case of no drivers present (e.g. an X-less system) or some other issues.

## Issues
I haven't tested it anywhere but on my own system so I believe some additional testing is required.




