### PR TITLE
Add initial support for HyperTerm

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1461,6 +1461,7 @@ getterm() {
             case "$TERM_PROGRAM" in
                 "iTerm.app") term="iTerm2" ;;
                 "Terminal.app") term="Apple Terminal" ;;
+                "Hyper") term="HyperTerm" ;;
                 *) term="${TERM_PROGRAM/\.app}" ;;
             esac
             return

--- a/neofetch
+++ b/neofetch
@@ -1541,6 +1541,10 @@ gettermfont() {
             termfont="${termfont/.pcf}"
             termfont="${termfont/:*}"
         ;;
+
+        "HyperTerm")
+            termfont="$(awk -F "," '/fontFamily/ {a=$1} END{print a}' "${HOME}/.hyper.js" | awk -F "'" '{a=$2} END{print a}')"
+        ;;
     esac
 
     [ "$version" -ge 4 ] && termfont="${termfont^}"


### PR DESCRIPTION
## Description

[Hyper](https://github.com/zeit/hyper) is a relatively new JavaScript-based terminal that Neofetch has yet to add support for. I have added proper terminal and terminal font detection for HyperTerm running on macOS Sierra. 

[Picture](https://i.imgur.com/BHkh7J1.jpg)

## Issues

There is a Ubuntu/Debian build of Hyper though, so these initial changes may need to be generalized in the future.