### PR TITLE
General: Remove all fold markers.

### DIFF
--- a/config/config
+++ b/config/config
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# vim:fdm=marker
 #
 # Neofetch config file
 # https://github.com/dylanaraps/neofetch
@@ -8,10 +7,7 @@
 export LC_ALL=C
 export LANG=C
 
-# Info Options {{{
 
-
-# Info
 # See this wiki page for more info:
 # https://github.com/dylanaraps/neofetch/wiki/Customizing-Info
 print_info() {
@@ -54,15 +50,18 @@ print_info() {
 
 # Kernel
 
-# Show more kernel info
+
+# Shorten the output of the kernel function
 # --kernel_shorthand on, off
 kernel_shorthand="on"
 
 
 # Distro
 
-# Shorten the output of distro (tiny, on, off)
+
+# Shorten the output of the distro function
 # NOTE: This is only possible on Linux, macOS, and Solaris
+# --distro_shorthand on, off, tiny
 distro_shorthand="off"
 
 # Show 'x86_64' and 'x86' in 'Distro:' output.
@@ -72,6 +71,7 @@ os_arch="on"
 
 # Uptime
 
+
 # Shorten the output of the uptime function
 # --uptime_shorthand tiny, on, off
 uptime_shorthand="off"
@@ -79,16 +79,18 @@ uptime_shorthand="off"
 
 # Shell
 
+
 # Show the path to $SHELL
 # --shell_path on, off
 shell_path="off"
 
-# Show $SHELL's version
+# Show $SHELL version
 # --shell_version on, off
 shell_version="on"
 
 
 # CPU
+
 
 # CPU speed type
 # Only works on Linux with cpufreq.
@@ -96,8 +98,7 @@ shell_version="on"
 # scaling_current, scaling_min, scaling_max
 speed_type="max"
 
-# CPU Shorthand
-# Set shorthand setting
+# Shorten the output of the CPU function
 # --cpu_shorthand name, speed, tiny, on, off
 cpu_shorthand="off"
 
@@ -115,18 +116,19 @@ cpu_speed="on"
 # Display CPU cores in output
 # Logical: All virtual cores
 # Physical: All physical cores
-# --cpu_cores logical, physical, off
 # Note: 'physical' doesn't work on BSD.
+# --cpu_cores logical, physical, off
 cpu_cores="logical"
 
 # CPU Temperature
 # Hide/Show CPU temperature.
-# --cpu_temp on, off
 # Note: Only works on Linux.
+# --cpu_temp on, off
 cpu_temp="off"
 
 
 # GPU
+
 
 # Enable/Disable GPU Brand
 # --gpu_brand on, off
@@ -135,6 +137,7 @@ gpu_brand="on"
 
 # Resolution
 
+
 # Display refresh rate next to each monitor
 # Unsupported on Windows
 # --refresh_rate on, off
@@ -142,6 +145,7 @@ refresh_rate="off"
 
 
 # Gtk Theme / Icons
+
 
 # Shorten output (Hide [GTK2] etc)
 # --gtk_shorthand on, off
@@ -159,6 +163,7 @@ gtk3="on"
 
 # IP Address
 
+
 # Website to ping for the public IP
 # --ip_host url
 public_ip_host="http://ident.me"
@@ -166,12 +171,14 @@ public_ip_host="http://ident.me"
 
 # Song
 
+
 # Print the Artist and Title on seperate lines
 # --song_shorthand on, off
 song_shorthand="off"
 
 
 # Birthday
+
 
 # Whether to show a long pretty output
 # or a shortened one
@@ -188,9 +195,7 @@ birthday_time="on"
 birthday_format="+%a %d %b %Y %l:%M %p"
 
 
-# }}}
-
-# Text Colors {{{
+# Text Colors
 
 
 # Text Colors
@@ -203,9 +208,7 @@ birthday_format="+%a %d %b %Y %l:%M %p"
 colors=(distro)
 
 
-# }}}
-
-# Text Options {{{
+# Text Options
 
 
 # Toggle bold text
@@ -221,9 +224,7 @@ underline_enabled="on"
 underline_char="-"
 
 
-# }}}
-
-# Color Blocks {{{
+# Color Blocks
 
 
 # Color block range
@@ -244,9 +245,7 @@ block_width=3
 block_height=1
 
 
-# }}}
-
-# Progress Bars {{{
+# Progress Bars
 
 
 # Progress bar character
@@ -284,9 +283,7 @@ battery_display="off"
 disk_display="off"
 
 
-# }}}
-
-# Image Options {{{
+# Image Options
 
 
 # Image Source
@@ -345,9 +342,7 @@ xoffset=0
 background_color=
 
 
-# }}}
-
-# Ascii Options {{{
+# Ascii Options
 
 
 # Default ascii image to use
@@ -383,9 +378,7 @@ ascii_logo_size="normal"
 ascii_bold="on"
 
 
-# }}}
-
-# Scrot Options {{{
+# Scrot Options
 
 
 # Whether or not to always take a screenshot
@@ -417,9 +410,7 @@ image_host="imgur"
 imgur_client_id="0e8b44d15e9fc95"
 
 
-# }}}
-
-# Config Options {{{
+# Config Options
 
 
 # Enable/Disable config file
@@ -429,6 +420,3 @@ config="on"
 # Path to custom config file location
 # --config path/to/config
 config_file="${XDG_CONFIG_HOME:-${HOME}/.config}/neofetch/config"
-
-
-# }}}

--- a/config/travis
+++ b/config/travis
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# vim:fdm=marker
 #
 # Neofetch config file for travis.ci
 # https://github.com/dylanaraps/neofetch

--- a/neofetch
+++ b/neofetch
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # set -x
-# vim: fdm=marker:noai:ts=4:sw=4:expandtab
+# vim: noai:ts=4:sw=4:expandtab
 #
 # Neofetch: Simple system information script.
 # https://github.com/dylanaraps/neofetch
@@ -19,9 +19,7 @@ export LANG=C
 # Set no case match.
 shopt -s nocasematch
 
-# Gather Info {{{
-
-# Operating System {{{
+# DETECT INFORMATION
 
 get_os() {
     case "$(uname)" in
@@ -35,10 +33,6 @@ get_os() {
         *) printf "%s\n" "Unknown OS detected: $(uname)"; exit 1 ;;
     esac
 }
-
-# }}}
-
-# Model {{{
 
 get_model() {
     case "$os" in
@@ -118,17 +112,13 @@ get_model() {
     esac
 }
 
-# }}}
-
-# Distro {{{
-
 get_distro() {
     [[ "$distro" ]] && return
 
     case "$os" in
         "Linux" | "GNU")
-            if grep -q -F 'Microsoft' /proc/version >/dev/null || \
-               grep -q -F 'Microsoft' /proc/sys/kernel/osrelease >/dev/null; then
+            if grep -q -F 'Microsoft' /proc/version || \
+               grep -q -F 'Microsoft' /proc/sys/kernel/osrelease; then
                 case "$distro_shorthand" in
                     "on")   distro="$(lsb_release -sir) [Windows 10]" ;;
                     "tiny") distro="Windows 10" ;;
@@ -264,17 +254,9 @@ get_distro() {
         ascii_distro="$(trim "$distro")"
 }
 
-# }}}
-
-# Title {{{
-
 get_title() {
     title="${USER:-$(whoami || printf "%s" "${HOME/*\/}")}@${HOSTNAME:-$(hostname)}"
 }
-
-# }}}
-
-# Kernel {{{
 
 get_kernel() {
     case "$kernel_shorthand" in
@@ -292,10 +274,6 @@ get_kernel() {
         kernel="$(uname $kernel_flags)"
     fi
 }
-
-# }}}
-
-# Uptime {{{
 
 get_uptime() {
     # Since Haiku's uptime cannot be fetched in seconds, a case outside
@@ -375,10 +353,6 @@ get_uptime() {
         ;;
     esac
 }
-
-# }}}
-
-# Package Count {{{
 
 get_packages() {
     case "$os" in
@@ -476,10 +450,6 @@ get_packages() {
     (("$packages" == "0")) && unset packages
 }
 
-# }}}
-
-# Shell {{{
-
 get_shell() {
     case "$shell_path" in
         "on")  shell="$SHELL" ;;
@@ -519,9 +489,6 @@ get_shell() {
     fi
 }
 
-# }}}
-
-# Desktop Environment {{{
 get_de() {
     case "$os" in
         "Mac OS X") de="Aqua" ;;
@@ -552,10 +519,6 @@ get_de() {
     fi
 }
 
-# }}}
-
-# Window Manager {{{
-
 get_wm() {
     if [[ -n "$DISPLAY" && "$os" != "Mac OS X" ]]; then
         id="$(xprop -root -notype | awk '$1=="_NET_SUPPORTING_WM_CHECK:"{print $5}')"
@@ -580,10 +543,6 @@ get_wm() {
         esac
     fi
 }
-
-# }}}
-
-# Window Manager Theme {{{
 
 get_wm_theme() {
     [[ -z "$wm" ]] && get_wm
@@ -703,10 +662,6 @@ get_wm_theme() {
     wm_theme="${wm_theme//\'}"
     (("$version" >= 4)) && wm_theme="${wm_theme^}"
 }
-
-# }}}
-
-# CPU {{{
 
 get_cpu() {
     # NetBSD emulates the linux /proc filesystem instead of using sysctl for hw
@@ -897,10 +852,6 @@ get_cpu() {
     esac
 }
 
-# }}}
-
-# CPU Usage {{{
-
 get_cpu_usage() {
     case "$os" in
         "Windows")
@@ -933,10 +884,6 @@ get_cpu_usage() {
         *) cpu_usage="${cpu_usage}%" ;;
     esac
 }
-
-# }}}
-
-# GPU {{{
 
 get_gpu() {
     case "$os" in
@@ -1058,10 +1005,6 @@ get_gpu() {
     fi
 }
 
-# }}}
-
-# Memory {{{
-
 get_memory() {
     case "$os" in
         "Linux" | "Windows" | "GNU")
@@ -1127,10 +1070,6 @@ get_memory() {
         "barinfo") memory="$(bar "${memused}" "${memtotal}") ${memory}" ;;
     esac
 }
-
-# }}}
-
-# Song {{{
 
 get_song() {
     # This is absurdly long.
@@ -1246,10 +1185,6 @@ get_song() {
     fi
 }
 
-# }}}
-
-# Resolution {{{
-
 get_resolution() {
     case "$os" in
         "Linux" | "BSD" | "Solaris" | "GNU")
@@ -1308,10 +1243,6 @@ get_resolution() {
 
     resolution="${resolution%,*}"
 }
-
-# }}}
-
-# Theme/Icons/Font {{{
 
 get_style() {
     # Fix weird output when the function
@@ -1484,10 +1415,6 @@ get_font() {
     font="$theme"
 }
 
-# }}}
-
-# Terminal Emulator {{{
-
 get_term() {
     # Check $PPID for terminal emulator.
     case "$os" in
@@ -1531,10 +1458,6 @@ get_term() {
         *) term="${name##*/}" ;;
     esac
 }
-
-# }}}
-
-# Terminal Emulator Font {{{
 
 get_term_font() {
     [[ -z "$term" ]] && get_term
@@ -1586,10 +1509,6 @@ get_term_font() {
 
     (("$version" >= 4)) && term_font="${term_font^}"
 }
-
-# }}}
-
-# Disk Usage {{{
 
 get_disk() {
     # df flags
@@ -1651,10 +1570,6 @@ get_disk() {
         "perc") disk="$disk_total_per $(bar "${disk_used/'.'*}" "${disk_total/'.'*}")" ;;
     esac
 }
-
-# }}}
-
-# Battery Usage {{{
 
 get_battery() {
     case "$os" in
@@ -1737,10 +1652,6 @@ get_battery() {
     esac
 }
 
-# }}}
-
-# IP Address {{{
-
 get_local_ip() {
     case "$os" in
         "Linux")
@@ -1781,18 +1692,10 @@ get_public_ip() {
     fi
 }
 
-# }}}
-
-# Logged In Users {{{
-
 get_users() {
     users="$(who | awk '!seen[$1]++ {printf $1 ", "}')"
     users="${users%\,*}"
 }
-
-# }}}
-
-# Birthday {{{
 
 get_birthday() {
     case "$os" in
@@ -1863,10 +1766,6 @@ get_birthday() {
         birthday="${birthday/??:??*}"
 }
 
-# }}}
-
-# Terminal colors {{{
-
 get_cols() {
     if [[ "$color_blocks" == "on" ]]; then
         # Convert the width to space chars.
@@ -1896,13 +1795,7 @@ get_cols() {
     fi
 }
 
-# }}}
-
-# }}}
-
-# Images {{{
-
-# Wallpaper {{{
+# IMAGES
 
 get_wallpaper() {
     case "$os" in
@@ -1955,10 +1848,6 @@ get_wallpaper() {
     # Error msg
     [[ -z "$img" ]] && err "Image: Wallpaper detection failed, falling back to ascii mode."
 }
-
-# }}}
-
-# Ascii {{{
 
 get_ascii() {
     if [[ ! -f "$ascii" || "$ascii" == "distro" ]]; then
@@ -2031,10 +1920,6 @@ get_ascii() {
     printf "%b" "$print"
     export LC_ALL=C
 }
-
-# }}}
-
-# Image {{{
 
 get_image() {
     # Fallback to ascii mode if imagemagick isn't installed.
@@ -2236,11 +2121,6 @@ get_image() {
     img="$thumbnail_dir/$imgname"
 }
 
-# }}}
-
-# Find w3m-img {{{
-
-# Find w3mimgdisplay automatically
 get_w3m_img_path() {
     if [[ -x "$w3m_img_path" ]]; then
         return
@@ -2262,10 +2142,6 @@ get_w3m_img_path() {
         err "Image: w3m-img wasn't found on your system, falling back to ascii mode."
     fi
 }
-
-# }}}
-
-# Display image {{{
 
 display_image() {
     if [[ "$image" != "ascii" ]]; then
@@ -2289,10 +2165,6 @@ display_image() {
     fi
 }
 
-# }}}
-
-# Get image backend {{{
-
 get_image_backend() {
     if [[ -n "$ITERM_PROFILE" ]]; then
         image_backend="iterm2"
@@ -2305,18 +2177,12 @@ get_image_backend() {
     fi
 }
 
-# }}}
-
-# Screenshot {{{
+# SCREENSHOT
 
 take_scrot() {
     $scrot_cmd "${scrot_dir}${scrot_name}"
     [[ "$scrot_upload" == "on" ]] && scrot_upload
 }
-
-# }}}
-
-# Screenshot Upload {{{
 
 scrot_upload() {
     if ! type -p curl >/dev/null 2>&1; then
@@ -2343,13 +2209,18 @@ scrot_upload() {
     printf "%s\n" "${image_url:-'[!] Image failed to upload'}"
 }
 
-# }}}
+scrot_args() {
+    scrot="on"
+    case "$2" in
+        "-"* | "") ;;
+        *)
+            scrot_name="${2##*/}"
+            scrot_dir="${2/$scrot_name}"
+        ;;
+    esac
+}
 
-# }}}
-
-# Text Formatting {{{
-
-# Info {{{
+# TEXT FORMATTING
 
 info() {
     # $1 is the subtitle
@@ -2404,10 +2275,6 @@ info() {
     fi
 }
 
-# }}}
-
-# Prin {{{
-
 prin() {
     string="${1//$'\033[0m'}${2:+: $2}"
 
@@ -2439,20 +2306,12 @@ prin() {
     prin=1
 }
 
-# }}}
-
-# Underline {{{
-
 get_underline() {
     if [[ "$underline_enabled" == "on" ]]; then
         underline="$(printf %"$length"s)"
         underline="${underline// /$underline_char}"
     fi
 }
-
-# }}}
-
-# Colors {{{
 
 colors() {
     # Reset colors/bold
@@ -2688,10 +2547,6 @@ color() {
     esac
 }
 
-# }}}
-
-# Bold {{{
-
 bold() {
     case "$ascii_bold" in
         "on") ascii_bold="\033[1m" ;;
@@ -2704,10 +2559,6 @@ bold() {
     esac
 }
 
-# }}}
-
-# Linebreak {{{
-
 get_line_break() {
     line_break="​ "
 
@@ -2715,41 +2566,28 @@ get_line_break() {
     info_height="$((info_height+=1))"
 }
 
-# }}}
-
-# Trim whitespace {{{
-
-# When a string is passed to 'echo' all trailing and leading
-# whitespace is removed and inside the string multiple spaces are
-# condensed into single spaces.
-#
-# The 'set -f/+f' is here so that 'echo' doesn't cause any expansion
-# of special characters.
-#
-# The whitespace trim doesn't work with multiline strings so we use
-# '${1//[[:space:]]/ }' to remove newlines beofre we trim the whitespace.
 trim() {
+    # When a string is passed to 'echo' all trailing and leading
+    # whitespace is removed and inside the string multiple spaces are
+    # condensed into single spaces.
+    #
+    # The 'set -f/+f' is here so that 'echo' doesn't cause any expansion
+    # of special characters.
+    #
+    # The whitespace trim doesn't work with multiline strings so we use
+    # '${1//[[:space:]]/ }' to remove newlines beofre we trim the whitespace.
+
     set -f
     builtin echo -E ${1//[[:space:]]/ }
     set +f
 }
 
-# }}}
-
-# }}}
-
-# Other {{{
-
-# Error {{{
+# OTHER
 
 err() {
     err+="$(color 1)[!]\033[0m $1
 "
 }
-
-# }}}
-
-# Check for old flags {{{
 
 check_old_flags() {
     [[ -n "$osx_buildversion" ]] && err "Config: \$osx_buildversion is deprecated, use \$distro_shorthand instead."
@@ -2757,10 +2595,6 @@ check_old_flags() {
     [[ -n "$progress_char" ]] && err "Config: \$progress_char is deprecated, use \$progress_char_elapsed and \$progress_char_total instead."
     [[ "$cpu_cores" == "on" ]] && err "Config: \$cpu_cores='on' is deprecated, use \$cpu_cores='logical|physical|off' instead."
 }
-
-# }}}
-
-# Get script directory {{{
 
 get_script_dir() {
     [[ "$script_dir" ]] && return
@@ -2779,10 +2613,6 @@ get_script_dir() {
     # Final directory
     script_dir="$(pwd -P)"
 }
-
-# }}}
-
-# Source default config {{{
 
 get_default_config() {
     if [[ -f "/usr/share/neofetch/config" ]]; then
@@ -2806,10 +2636,6 @@ get_default_config() {
         err "Config: Default config not found, continuing..."
     fi
 }
-
-# }}}
-
-# Source config {{{
 
 get_user_config() {
     # Check $config_file
@@ -2849,10 +2675,6 @@ get_user_config() {
     err "Config: Sourced user config    ($config_file)"
 }
 
-# }}}
-
-# Progress bars {{{
-
 bar() {
     # Get the values
     elapsed="$(($1 * progress_length / $2))"
@@ -2874,18 +2696,10 @@ bar() {
     printf "%b\n" "${bar}${info_color}"
 }
 
-# }}}
-
-# Cache {{{
-
 cache() {
     mkdir -p "$3/neofetch"
     echo "${1/*-}=\"$2\"" > "$3/neofetch/${1/*-}"
 }
-
-# }}}
-
-# KDE config directory {{{
 
 kde_config_dir() {
     if [[ "$kde_config_dir" ]]; then
@@ -2905,20 +2719,18 @@ kde_config_dir() {
     fi
 }
 
-# }}}
-
-# Terminal info {{{
-#
-# Parse terminal config files to get
-# info about padding. Due to how w3m-img
-# works padding around the terminal throws
-# off the cursor placement calculation in
-# specific terminals.
-#
-# Note: This issue only seems to affect
-# URxvt.
-
 get_term_padding() {
+    # Terminal info
+    #
+    # Parse terminal config files to get
+    # info about padding. Due to how w3m-img
+    # works padding around the terminal throws
+    # off the cursor placement calculation in
+    # specific terminals.
+    #
+    # Note: This issue only seems to affect
+    # URxvt.
+
     [[ -z "$term" ]] && get_term
 
     case "$term" in
@@ -2928,10 +2740,6 @@ get_term_padding() {
         ;;
     esac
 }
-
-# }}}
-
-# Dynamic prompt location {{{
 
 dynamic_prompt() {
     # Calculate image height in terminal cells.
@@ -2960,29 +2768,12 @@ dynamic_prompt() {
     printf "\n\n\n\n"
 }
 
-# }}}
-
-# Scrot args {{{
-
-scrot_args() {
-    scrot="on"
-    case "$2" in
-        "-"* | "") ;;
-        *)
-            scrot_name="${2##*/}"
-            scrot_dir="${2/$scrot_name}"
-        ;;
-    esac
-}
-
-# }}}
-
-# Deprecated functions {{{
-# Neofetch 2.0 changed the names of a few variables.
-# This function adds backwards compatibility for the
-# old variable names.
-
 old_functions() {
+    # Deprecated functions
+    # Neofetch 2.0 changed the names of a few variables.
+    # This function adds backwards compatibility for the
+    # old variable names.
+
     if type printinfo >/dev/null 2>&1; then
         print_info() { printinfo ; }
         get_wmtheme() { get_wm_theme; wmtheme="$wm_theme"; }
@@ -2993,11 +2784,7 @@ old_functions() {
     fi
 }
 
-# }}}
-
-# }}}
-
-# Usage {{{
+# FINISH uP
 
 usage() { printf "%s" "
     NEOFETCH
@@ -3122,10 +2909,6 @@ usage() { printf "%s" "
 "
 exit 1
 }
-
-# }}}
-
-# Args {{{
 
 get_args() {
     # Check the commandline flags early for '--config none/off'
@@ -3295,10 +3078,6 @@ get_args() {
     done
 }
 
-# }}}
-
-# Call Functions and Finish Up {{{
-
 main() {
     get_os
     get_default_config 2>/dev/null
@@ -3367,5 +3146,3 @@ main() {
 }
 
 main "$@"
-
-# }}}

--- a/neofetch
+++ b/neofetch
@@ -2143,6 +2143,18 @@ get_w3m_img_path() {
     fi
 }
 
+get_image_backend() {
+    if [[ -n "$ITERM_PROFILE" ]]; then
+        image_backend="iterm2"
+
+    elif [[ "$(tycat 2>/dev/null)" ]]; then
+        image_backend="tycat"
+
+    else
+        image_backend="w3m"
+    fi
+}
+
 display_image() {
     if [[ "$image" != "ascii" ]]; then
         case "$image_backend" in
@@ -2162,18 +2174,6 @@ display_image() {
                 tycat "$img"
             ;;
         esac
-    fi
-}
-
-get_image_backend() {
-    if [[ -n "$ITERM_PROFILE" ]]; then
-        image_backend="iterm2"
-
-    elif [[ "$(tycat 2>/dev/null)" ]]; then
-        image_backend="tycat"
-
-    else
-        image_backend="w3m"
     fi
 }
 
@@ -2730,7 +2730,6 @@ get_term_padding() {
     #
     # Note: This issue only seems to affect
     # URxvt.
-
     [[ -z "$term" ]] && get_term
 
     case "$term" in
@@ -2773,7 +2772,6 @@ old_functions() {
     # Neofetch 2.0 changed the names of a few variables.
     # This function adds backwards compatibility for the
     # old variable names.
-
     if type printinfo >/dev/null 2>&1; then
         print_info() { printinfo ; }
         get_wmtheme() { get_wm_theme; wmtheme="$wm_theme"; }
@@ -2784,7 +2782,7 @@ old_functions() {
     fi
 }
 
-# FINISH uP
+# FINISH UP
 
 usage() { printf "%s" "
     NEOFETCH

--- a/neofetch.1
+++ b/neofetch.1
@@ -1,4 +1,4 @@
-.TH NEOFETCH "1" "November 2016" "1.9.1" "User Commands"
+.TH NEOFETCH "1" "November 2016" "2.0" "User Commands"
 .SH NAME
 neofetch \- simple system information script
 


### PR DESCRIPTION
## Description

This PR removes all vim fold marker comments that littered neofetch and stops enforcing a fold method for people editing the file. 

Instead I recommend using bash syntax folding with the following settings in your .vimrc:

```vim
filetype plugin indent on
augroup Bashfold
    au!
    autocmd Filetype sh let g:sh_fold_enabled=3
    autocmd Filetype sh let g:is_bash=1
    autocmd Filetype sh setlocal foldmethod=syntax
augroup END
syntax on
```

> autocmd Filetype sh let g:sh_fold_enabled=3

The `3` will set vim to only fold functions. Raising this number will make vim fold `if` statements and etc.


