### PR TITLE
General: Cache uname output for use later in the script

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -248,7 +248,7 @@ get_distro() {
 
     # Get architecture
     [[ "$os_arch" == "on" ]] && \
-        distro+=" ${HOSTTYPE:-${machine_arch}}"
+        distro+=" ${machine_arch}"
 
     [[ "${ascii_distro:-auto}" == "auto" ]] && \
         ascii_distro="$(trim "$distro")"

--- a/neofetch
+++ b/neofetch
@@ -19,12 +19,15 @@ export LANG=C
 # Set no case match.
 shopt -s nocasematch
 
+# Cache uname output for use later in the script.
+uname=($(uname -srm))
+
 # Gather Info {{{
 
 # Operating System {{{
 
 get_os() {
-    case "$(uname)" in
+    case "${uname[0]}" in
         "Linux")   os="Linux" ;;
         "Darwin")  os="$(sw_vers -productName)" ;;
         *"BSD" | "DragonFly" | "Bitrig") os="BSD" ;;
@@ -32,7 +35,7 @@ get_os() {
         "SunOS") os="Solaris" ;;
         "Haiku") os="Haiku" ;;
         "GNU"*) os="GNU" ;;
-        *) printf "%s\n" "Unknown OS detected: $(uname)"; exit 1 ;;
+        *) printf "%s\n" "Unknown OS detected: ${uname[0]}"; exit 1 ;;
     esac
 }
 
@@ -62,7 +65,7 @@ get_model() {
 
         "Mac OS X") model="$(sysctl -n hw.model)" ;;
         "iPhone OS")
-            case "${ios_model:="$(uname -m)"}" in
+            case "${uname[2]}" in
                 "iPad1,1") model="iPad" ;;
                 "iPad2,"[1-4]) model="iPad2" ;;
                 "iPad3,"[1-3]) model="iPad3" ;;
@@ -224,8 +227,8 @@ get_distro() {
 
         "BSD")
             case "$distro_shorthand" in
-                "tiny" | "on") distro="$(uname -s)" ;;
-                *) distro="$(uname -sr)" ;;
+                "tiny" | "on") distro="${uname[0]}" ;;
+                *) distro="${uname[0]} ${uname[1]}" ;;
             esac
 
             distro="${distro/DragonFly/DragonFlyBSD}"
@@ -258,7 +261,7 @@ get_distro() {
 
     # Get architecture
     [[ "$os_arch" == "on" ]] && \
-        distro+=" $(uname -m)"
+        distro+=" ${uname[2]}"
 
     [[ "${ascii_distro:-auto}" == "auto" ]] && \
         ascii_distro="$(trim "$distro")"
@@ -278,18 +281,16 @@ get_title() {
 
 get_kernel() {
     case "$kernel_shorthand" in
-        "on")  kernel_flags="-r" ;;
-        "off") kernel_flags="-sr" ;;
+        "on")  kernel="${uname[1]}" ;;
+        "off") kernel="${uname[0]} ${uname[1]}" ;;
     esac
 
     # Hardcode kernel settings in BSDs
     if [[ "$os" == "BSD" && ! "$distro" =~ (PacBSD|PCBSD) ]]; then
         case "$distro_shorthand" in
-            "on" | "tiny") kernel=$(uname -r) ;;
+            "on" | "tiny") kernel="${uname[1]}" ;;
             *) unset kernel ;;
         esac
-    else
-        kernel="$(uname $kernel_flags)"
     fi
 }
 
@@ -773,7 +774,7 @@ get_cpu() {
         ;;
 
         "iPhone OS")
-            case "${ios_model:="$(uname -m)"}" in
+            case "${uname[2]}" in
                 "iPhone1,"[1-2] | "iPod1,1") cpu="Samsung S5L8900 (1) @ 412MHz" ;;
                 "iPhone2,1") cpu="Samsung S5PC100 (1) @ 600MHz" ;;
                 "iPhone3,"[1-3] | "iPod4,1") cpu="Apple A4 (1) @ 800MHz" ;;
@@ -995,7 +996,7 @@ get_gpu() {
         ;;
 
         "iPhone OS")
-            case "${ios_model:="$(uname -m)"}" in
+            case "${uname[2]}" in
                 "iPhone1,"[1-2]) gpu="PowerVR MBX Lite 3D" ;;
                 "iPhone5,"[1-4]) gpu="PowerVR SGX543MP3" ;;
                 "iPhone8,"[1-4]) gpu="PowerVR GT7600" ;;


### PR DESCRIPTION
## Description

This PR speeds up neofetch by only calling `uname` once instead of 4-5 times.

In this PR we assume that each flag `-s -r -m` only take up a single field each. This seems to be ok if you look at the wikipedia page for `uname` below.

https://en.wikipedia.org/wiki/Uname

## TODO

- [x] Testing
    - [x] Linux
        - [x] Arch
        - [x] Ubuntu
        - [x] Android
    - [x] BSD
    - [x] Mac OS
        - [x] Travis
    - [x] iOS
    - [x] Windows
    - [x] Solaris
    - [x] Haiku
    - [x] Hurd 
    



