### PR TITLE
Fix all Shellcheck messages

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1898,7 +1898,7 @@ get_ascii() {
 
         # Calculate size of ascii file in line length / line count.
         line="${line//\$\{??\}}"
-        line="${line//'\\'/'\'}"
+        line="${line//\\\\/\\}"
         (("${#line}" > "${ascii_length:-0}")) && ascii_length="${#line}"
         lines="$((lines+=1))"
     done < "$ascii"
@@ -2756,9 +2756,9 @@ dynamic_prompt() {
 
     # Set the prompt location
     if (("$lines" < 0)); then
-        printf "\033[${lines/-}A"
+        printf "%b" "\033[${lines/-}A"
     else
-        printf "\033[${lines}B"
+        printf "%b" "\033[${lines}B"
     fi
 
     # Add some padding
@@ -2795,7 +2795,7 @@ cache_uname() {
 usage() { printf "%s" "
     NEOFETCH
 
-    USAGE: neofetch --option "value" --option "value"
+    USAGE: neofetch --option \"value\" --option \"value\"
 
     NOTE: There's also a config option for each flag below.
 
@@ -3119,7 +3119,7 @@ main() {
         display_image
 
         # Set cursor position next to ascii art
-        printf "\033[$((${lines:-0} - ${prompt_loc:-0}))A"
+        printf "%b" "\033[$((${lines:-0} - ${prompt_loc:-0}))A"
 
         # Reset horizontal cursor position
         printf "\033[9999999D"

--- a/neofetch
+++ b/neofetch
@@ -405,7 +405,7 @@ get_packages() {
 
         "Mac OS X")
             [[ -d "/usr/local/bin" ]] && \
-                packages="$(($(ls -l /usr/local/bin/ | grep -v "\(../Cellar/\|brew\)" | wc -l) - 1))"
+                packages="$(($(ls -l /usr/local/bin/ | grep -cv "\(../Cellar/\|brew\)") - 1))"
 
             type -p port >/dev/null && \
                 packages="$((packages + $(port installed | wc -l) - 1))"
@@ -1686,7 +1686,7 @@ get_public_ip() {
     fi
 
     if [[ -z "$public_ip" ]] && type -p wget >/dev/null; then
-        public_ip="$(wget -T 10 -qO- "$public_ip_host"; printf "%s")"
+        public_ip="$(wget -T 10 -qO- "$public_ip_host")"
     fi
 }
 


### PR DESCRIPTION
## Description

This PR aims to fix most shellcheck errors in neofetch.

Edit: All that remains is the `find > ls` error which I'll fix at a later time since it requires a lot of testing.

## Testing

There are a few shellcheck error codes that we can happily ignore since they're false positives or intended behavior. This is the command I'm currently using to test neofetch.

```sh
shellcheck -e 1090 -e 1091 -e 2034 -e 2016 -e 2009 -e 2178 -e 2128 -e 2086 -e 2153 -e 2154 -e 2068 -e 2154 -e 2153 neofetch
```

## Ignored codes

**1090**

> Shellcheck can't find the files being sourced. 
> https://github.com/koalaman/shellcheck/wiki/SC1090

This is OK to ignore.

**1091**

> Shellcheck can't find the files being sourced.
> https://github.com/koalaman/shellcheck/wiki/SC1091

This is OK to ignore.

**2034**

> foo appears unused. Verify it or export it.
> https://github.com/koalaman/shellcheck/wiki/SC2034

This is due to `info()` indirectly calling variables.

**2016**

> Expressions don't expand in single quotes, use double quotes for that.
> https://github.com/koalaman/shellcheck/wiki/SC2016

This is OK to ignore since it's intended.

**2009**

> Consider using pgrep instead of grepping ps output.
> https://github.com/koalaman/shellcheck/wiki/SC2009

This is OK to ignore since it's intended.

**2178**

> Variable was used as an array but is now assigned a string.
> https://github.com/koalaman/shellcheck/wiki/SC2178

This is OK since the variable is an array on one OS and a var on another OS.

**2128**

> Expanding an array without an index only gives the first element.
> https://github.com/koalaman/shellcheck/wiki/SC2128

Same as **2178**.

**2086**

> Double quote to prevent globbing and word splitting.
> https://github.com/koalaman/shellcheck/wiki/SC2086

This is intended.

**2153**

> Possible Misspelling: MYVARIABLE may not be assigned, but MY_VARIABLE is.
> https://github.com/koalaman/shellcheck/wiki/SC2153

False positive.

**2154**

> var is referenced but not assigned.
> https://github.com/koalaman/shellcheck/wiki/SC2154

False positive.

**2068**

> Double quote array expansions to avoid re-splitting elements.
> https://github.com/koalaman/shellcheck/wiki/SC2068

This is intended.

**2154**

> var is referenced but not assigned.
> https://github.com/koalaman/shellcheck/wiki/SC2154

False positive.

**2153**

> Possible Misspelling: MYVARIABLE may not be assigned, but MY_VARIABLE is.
> https://github.com/koalaman/shellcheck/wiki/SC2153

False positive.


