### PR TITLE
Images: Rewrite image functions

### DIFF
--- a/config/config
+++ b/config/config
@@ -287,8 +287,8 @@ disk_display="off"
 
 
 # Image Source
-# --image wall, ascii, /path/to/img, /path/to/dir/, off
-image="wall"
+# --image wallpaper, /path/to/img, /path/to/dir/, off
+image_source="wallpaper"
 
 # Thumbnail directory
 thumbnail_dir="$HOME/.cache/thumbnails/neofetch"

--- a/neofetch
+++ b/neofetch
@@ -2001,9 +2001,6 @@ get_wallpaper() {
 
     # If image is an xml file, don't use it.
     [[ "${image/*\./}" == "xml" ]] && image=""
-
-    # Error msg
-    [[ ! -f "$image" ]] && err "Image: Wallpaper detection failed, falling back to ascii mode."
 }
 
 get_term_size() {
@@ -2646,13 +2643,6 @@ err() {
 "
 }
 
-check_old_flags() {
-    [[ -n "$osx_buildversion" ]] && err "Config: \$osx_buildversion is deprecated, use \$distro_shorthand instead."
-    [[ -n "$osx_codename" ]] && err "Config: \$osx_codename is deprecated, use \$distro_shorthand instead."
-    [[ -n "$progress_char" ]] && err "Config: \$progress_char is deprecated, use \$progress_char_elapsed and \$progress_char_total instead."
-    [[ "$cpu_cores" == "on" ]] && err "Config: \$cpu_cores='on' is deprecated, use \$cpu_cores='logical|physical|off' instead."
-}
-
 get_script_dir() {
     [[ "$script_dir" ]] && return
 
@@ -2837,6 +2827,14 @@ old_functions() {
         get_publicip() { get_public_ip; publicip="$public_ip"; }
         get_linebreak() { get_line_break; linebreak="$line_break"; }
     fi
+}
+
+old_flags() {
+    [[ -n "$osx_buildversion" ]] && err "Config: \$osx_buildversion is deprecated, use \$distro_shorthand instead."
+    [[ -n "$osx_codename" ]] && err "Config: \$osx_codename is deprecated, use \$distro_shorthand instead."
+    [[ -n "$progress_char" ]] && err "Config: \$progress_char is deprecated, use \$progress_char_elapsed and \$progress_char_total instead."
+    [[ "$cpu_cores" == "on" ]] && err "Config: \$cpu_cores='on' is deprecated, use \$cpu_cores='logical|physical|off' instead."
+    [[ -n "$image" ]] && { err "Config: \$image is deprecated, use \$image_source instead."; image_source="$image"; }
 }
 
 cache_uname() {
@@ -3147,7 +3145,7 @@ main() {
     cache_uname
     get_os
     get_default_config 2>/dev/null
-    check_old_flags
+    old_flags
     get_args "$@"
     get_distro
     bold

--- a/neofetch
+++ b/neofetch
@@ -1464,7 +1464,7 @@ get_term_font() {
 
     case "$term" in
         "urxvt" | "urxvtd" | "xterm")
-            term_font="$(grep -i -F "${term/d}*font" <<< "$(xrdb -query)")"
+            term_font="$(grep -i -F "${term/d}*font" < <(xrdb -query))"
             term_font="${term_font/*font:}"
             term_font="$(trim "$term_font")"
 
@@ -1864,8 +1864,8 @@ get_image_program() {
 get_ascii() {
     if [[ ! -f "$ascii" || "$ascii" == "distro" ]]; then
         # Error message
-        [[ "$ascii" != "distro" ]] && \
-        [[ ! -f "$ascii" ]] && err "Ascii: Ascii file not found, using distro ascii."
+        [[ "$ascii" != "distro" ]] && [[ ! -f "$ascii" ]] && \
+            err "Ascii: Ascii file not found, using distro ascii."
 
         # Lowercase the distro name
         if (("$version" <= 3)); then
@@ -1999,7 +1999,7 @@ get_wallpaper() {
         ;;
     esac
 
-    # If image is an xml file don't use it.
+    # If image is an xml file, don't use it.
     [[ "${image/*\./}" == "xml" ]] && image=""
 
     # Error msg

--- a/neofetch
+++ b/neofetch
@@ -1797,56 +1797,46 @@ get_cols() {
 
 # IMAGES
 
-get_wallpaper() {
-    case "$os" in
-        "Linux" | "BSD")
-            if type -p feh >/dev/null && [[ -f "$HOME/.fehbg" ]]; then
-                img="$(awk -F\' '/feh/ {printf $2}' "$HOME/.fehbg")"
+get_image_backend() {
+    get_w3m_img_path
 
-            elif type -p nitrogen >/dev/null; then
-                img="$(awk -F'=' '/file/ {printf $2;exit;}' "$XDG_CONFIG_HOME/nitrogen/bg-saved.cfg")"
+    # Fallback to ascii mode if imagemagick isn't installed.
+    type -p convert >/dev/null 2>&1 || image_backend="ascii"
 
-            elif type -p gsettings >/dev/null; then
-                # Get DE if user has disabled the function.
-                [[ -z "$de" ]] && get_de
+    case "${image_backend:=image}" in
+        "image")
+            case "$image_source" in
+                "wall"*) get_wallpaper 2>/dev/null ;;
+                "off") image_backend="off"; return ;;
+                *)
+                    if [[ -d "$image_source" ]]; then
+                        files=("${image_source%/}"/*.{png,jpg,jpeg})
+                        img="$(printf "%s" "${files[RANDOM % (${#files[@]} - 1)]}")"
+                    else
+                        img="$image_source"
+                    fi
 
-                case "$de" in
-                    "MATE"*) img="$(gsettings get org.mate.background picture-filename)" ;;
-                    *) img="$(gsettings get org.gnome.desktop.background picture-uri)" ;;
-                esac
-
-                # Strip quotes etc from the path.
-                img="${img/'file://'}"
-                img="${img//\'}"
-                img="${img//\%20/ }"
-            fi
-        ;;
-
-        "Mac OS X")
-            img="$(osascript -e 'tell application "System Events" to picture of current desktop')"
-        ;;
-
-        "Windows")
-            case "$distro" in
-                "Windows XP")
-                    img="/cygdrive/c/Documents and Settings/${USER}"
-                    img+="/Local Settings/Application Data/Microsoft"
-                    img+="/Wallpaper1.bmp"
-                ;;
-
-                "Windows"*)
-                    img="$APPDATA/Microsoft/Windows/Themes"
-                    img+="/TranscodedWallpaper.jpg"
+                    [ ! -f "$img" ] && { image_backend="ascii"; get_ascii 2>/dev/null; return; }
                 ;;
             esac
+
+            if [[ -n "$ITERM_PROFILE" ]]; then
+                image_program="iterm2"
+
+            elif [[ "$(tycat 2>/dev/null)" ]]; then
+                image_program="tycat"
+
+            else
+                image_program="w3m"
+            fi
+
+            make_thumbnail
+            display_image
         ;;
+
+        "ascii") get_ascii 2>/dev/null ;;
+        "off") ;;
     esac
-
-    # If img is an xml file don't use it.
-    [[ "${img/*\./}" == "xml" ]] && img=""
-
-    # Error msg
-    [[ -z "$img" ]] && err "Image: Wallpaper detection failed, falling back to ascii mode."
 }
 
 get_ascii() {
@@ -1921,28 +1911,86 @@ get_ascii() {
     export LC_ALL=C
 }
 
-get_image() {
-    # Fallback to ascii mode if imagemagick isn't installed.
-    type -p convert >/dev/null 2>&1 || image="ascii"
+get_w3m_img_path() {
+    if [[ -x "$w3m_img_path" ]]; then
+        return
 
-    case "$image" in
-        "wall") get_wallpaper 2>/dev/null ;;
-        "ascii") get_ascii; return ;;
-        *)
-            if [[ -d "$image" ]]; then
-                files=("${image%/}"/*.{png,jpg,jpeg})
-                img="$(printf "%s" "${files[RANDOM % (${#files[@]} - 1)]}")"
-            else
-                img="$image"
+    elif [[ -x "/usr/lib/w3m/w3mimgdisplay" ]]; then
+        w3m_img_path="/usr/lib/w3m/w3mimgdisplay"
+
+    elif [[ -x "/usr/libexec/w3m/w3mimgdisplay" ]]; then
+        w3m_img_path="/usr/libexec/w3m/w3mimgdisplay"
+
+    elif [[ -x "/usr/lib64/w3m/w3mimgdisplay" ]]; then
+        w3m_img_path="/usr/lib64/w3m/w3mimgdisplay"
+
+    elif [[ -x  "/usr/libexec64/w3m/w3mimgdisplay" ]]; then
+        w3m_img_path="/usr/libexec64/w3m/w3mimgdisplay"
+
+    else
+        image_backend="ascii"
+        err "Image: w3m-img wasn't found on your system, falling back to ascii mode."
+    fi
+}
+
+get_wallpaper() {
+    case "$os" in
+        "Linux" | "BSD")
+            if type -p feh >/dev/null && [[ -f "$HOME/.fehbg" ]]; then
+                img="$(awk -F\' '/feh/ {printf $2}' "$HOME/.fehbg")"
+
+            elif type -p nitrogen >/dev/null; then
+                img="$(awk -F'=' '/file/ {printf $2;exit;}' "$XDG_CONFIG_HOME/nitrogen/bg-saved.cfg")"
+
+            elif type -p gsettings >/dev/null; then
+                # Get DE if user has disabled the function.
+                [[ -z "$de" ]] && get_de
+
+                case "$de" in
+                    "MATE"*) img="$(gsettings get org.mate.background picture-filename)" ;;
+                    *) img="$(gsettings get org.gnome.desktop.background picture-uri)" ;;
+                esac
+
+                # Strip quotes etc from the path.
+                img="${img/'file://'}"
+                img="${img//\'}"
+                img="${img//\%20/ }"
             fi
+        ;;
+
+        "Mac OS X")
+            img="$(osascript -e 'tell application "System Events" to picture of current desktop')"
+        ;;
+
+        "Windows")
+            case "$distro" in
+                "Windows XP")
+                    img="/cygdrive/c/Documents and Settings/${USER}"
+                    img+="/Local Settings/Application Data/Microsoft"
+                    img+="/Wallpaper1.bmp"
+                ;;
+
+                "Windows"*)
+                    img="$APPDATA/Microsoft/Windows/Themes"
+                    img+="/TranscodedWallpaper.jpg"
+                ;;
+            esac
         ;;
     esac
 
+    # If img is an xml file don't use it.
+    [[ "${img/*\./}" == "xml" ]] && img=""
+
+    # Error msg
+    [[ -z "$img" ]] && err "Image: Wallpaper detection failed, falling back to ascii mode."
+}
+
+make_thumbnail() {
     if [[ -n "$TMUX" ]]; then
         printf "%b" "\033Ptmux;\033\033[14t\033\033[c\033\\"
         read_flags="-d c"
 
-    elif [[ "$image_backend" == "tycat" ]]; then
+    elif [[ "$image_program" == "tycat" ]]; then
         printf "%b" "\033}qs\000"
 
     else
@@ -1954,7 +2002,7 @@ get_image() {
     builtin read -s -t 1 ${read_flags} -r term_size
 
     # Split the string
-    if [[ "$image_backend" == "tycat" ]]; then
+    if [[ "$image_program" == "tycat" ]]; then
         term_size=(${term_size//;/ })
         term_width="$((term_size[2] * term_size[0]))"
         term_height="$((term_size[3] * term_size[1]))"
@@ -1969,7 +2017,7 @@ get_image() {
     fi
 
     # Get terminal width and height if \033[14t is unsupported.
-    if (("${#term_size}" <= 5)) && [[ "$image_backend" != "tycat" ]]; then
+    if (("${#term_size}" <= 5)) && [[ "$image_program" != "tycat" ]]; then
         if type -p xdotool >/dev/null 2>&1 && \
             [[ "$image_backend" != "iterm2" ]]; then
 
@@ -1981,7 +2029,7 @@ get_image() {
         elif type -p xwininfo >/dev/null 2>&1 && \
             type -p xdpyinfo >/dev/null 2>&1 || \
             type -p xprop >/dev/null 2>&1 && \
-            [[ "$image_backend" != "iterm2" ]]; then
+            [[ "$image_program" != "iterm2" ]]; then
 
             if type -p xdpyinfo >/dev/null 2>&1; then
                 current_window="$(xdpyinfo | grep -F "focus" | grep -E -o "0x[0-9a-f]+")"
@@ -2121,60 +2169,24 @@ get_image() {
     img="$thumbnail_dir/$imgname"
 }
 
-get_w3m_img_path() {
-    if [[ -x "$w3m_img_path" ]]; then
-        return
-
-    elif [[ -x "/usr/lib/w3m/w3mimgdisplay" ]]; then
-        w3m_img_path="/usr/lib/w3m/w3mimgdisplay"
-
-    elif [[ -x "/usr/libexec/w3m/w3mimgdisplay" ]]; then
-        w3m_img_path="/usr/libexec/w3m/w3mimgdisplay"
-
-    elif [[ -x "/usr/lib64/w3m/w3mimgdisplay" ]]; then
-        w3m_img_path="/usr/lib64/w3m/w3mimgdisplay"
-
-    elif [[ -x  "/usr/libexec64/w3m/w3mimgdisplay" ]]; then
-        w3m_img_path="/usr/libexec64/w3m/w3mimgdisplay"
-
-    else
-        image="ascii"
-        err "Image: w3m-img wasn't found on your system, falling back to ascii mode."
-    fi
-}
-
-get_image_backend() {
-    if [[ -n "$ITERM_PROFILE" ]]; then
-        image_backend="iterm2"
-
-    elif [[ "$(tycat 2>/dev/null)" ]]; then
-        image_backend="tycat"
-
-    else
-        image_backend="w3m"
-    fi
-}
-
 display_image() {
-    if [[ "$image" != "ascii" ]]; then
-        case "$image_backend" in
-            "w3m")
-                # Add a tiny delay to fix issues with images not
-                # appearing in specific terminal emulators.
-                sleep 0.05
-                printf "%b\n" "0;1;$xoffset;$yoffset;$width;$height;;;;;$img\n4;\n3;" |\
-                "$w3m_img_path" -bg "$background_color" >/dev/null & 2>&1 || padding="\033[0C"
-            ;;
+    case "$image_program" in
+        "w3m")
+            # Add a tiny delay to fix issues with images not
+            # appearing in specific terminal emulators.
+            sleep 0.05
+            printf "%b\n" "0;1;$xoffset;$yoffset;$width;$height;;;;;$img\n4;\n3;" |\
+            "$w3m_img_path" -bg "$background_color" >/dev/null & 2>&1 || padding="\033[0C"
+        ;;
 
-            "iterm2")
-                printf "%b\a\n" "\033]1337;File=width=${width}px;height=${height}px;inline=1:$(base64 < "$img")"
-            ;;
+        "iterm2")
+            printf "%b\a\n" "\033]1337;File=width=${width}px;height=${height}px;inline=1:$(base64 < "$img")"
+        ;;
 
-            "tycat")
-                tycat "$img"
-            ;;
-        esac
-    fi
+        "tycat")
+            tycat "$img"
+        ;;
+    esac
 }
 
 # SCREENSHOT
@@ -2742,7 +2754,7 @@ get_term_padding() {
 
 dynamic_prompt() {
     # Calculate image height in terminal cells.
-    if [[ "$image" != "ascii" ]]; then
+    if [[ "$image_backend" != "ascii" ]]; then
         get_term_padding 2>/dev/null
         lines="$(((height + (${border:-0} * 2) + ${yoffset:-0}) / font_height))"
     fi
@@ -3007,8 +3019,8 @@ get_args() {
 
             # Image
             --image)
-                image="$2"
-                case "$2" in "-"* | "") image="ascii" ;; esac
+                image_source="$2"
+                case "$2" in "-"* | "") image_backend="ascii" ;; esac
             ;;
 
             --image_size | --size) image_size="$2" ;;
@@ -3027,7 +3039,7 @@ get_args() {
 
             # Ascii
             --ascii)
-                image="ascii"
+                image_backend="ascii"
                 ascii="$2"
                 case "$2" in "-"* | "") ascii="distro" ;; esac
             ;;
@@ -3105,21 +3117,9 @@ main() {
     # Hide the cursor and disable line wrap
     printf "\033[?25l\033[?7l"
 
-    # Display the image
-    if [[ "$image" != "off" ]]; then
-        get_image_backend
+    get_image_backend
 
-        # Find w3mimgdisplay
-        [[ "$image_backend" == "w3m" ]] && \
-        [[ "$image" != "ascii" ]] && \
-            get_w3m_img_path
-
-        # Get the image src
-        get_image
-
-        # Display the image if enabled
-        display_image
-
+    if [[ "$image_backend" != "off" ]]; then
         # Set cursor position next to ascii art
         printf "%b" "\033[$((${lines:-0} - ${prompt_loc:-0}))A"
 
@@ -3132,12 +3132,12 @@ main() {
     print_info 2>/dev/null
 
     # Prompt calculation
-    if [[ "$image" != "off" ]]; then
+    if [[ "$image_backend" != "off" ]]; then
         dynamic_prompt
 
         # w3m-img: Draw the image a second time to fix
         # rendering issues in specific terminal emulators.
-        [[ "$image_backend" == "w3m" ]] && display_image
+        [[ "$image_program" == "w3m" ]] && display_image
     fi
 
     # Re-enable line wrap

--- a/neofetch
+++ b/neofetch
@@ -1815,18 +1815,18 @@ get_image_backend() {
                 *)
                     if [[ -d "$image_source" ]]; then
                         files=("${image_source%/}"/*.{png,jpg,jpeg})
-                        img="$(printf "%s" "${files[RANDOM % (${#files[@]} - 1)]}")"
+                        image="$(printf "%s" "${files[RANDOM % (${#files[@]} - 1)]}")"
                     else
-                        img="$image_source"
+                        image="$image_source"
                     fi
                 ;;
             esac
 
             # Fallback to ascii mode if image isn't a file.
-            if [[ ! -f "$img" ]]; then
+            if [[ ! -f "$image" ]]; then
                 image_backend="ascii"
                 get_ascii 2>/dev/null
-                err "Image: '$img', doesn't exist, falling back to ascii mode."
+                err "Image: '$image', doesn't exist, falling back to ascii mode."
                 return
             fi
 
@@ -1885,14 +1885,15 @@ get_ascii() {
             get_script_dir 2>/dev/null
 
             # If the ascii file doesn't exist fallback to text mode.
-            if [[ ! -f "$script_dir/ascii/distro/${ascii/ *}" ]]; then
+            if [[ -f "$script_dir/ascii/distro/${ascii/ *}" ]]; then
+                ascii="$script_dir/ascii/distro/${ascii/ *}"
+
+            else
                 text_padding="0"
-                image="off"
+                image_backend="off"
                 err "Ascii: Ascii file not found, falling back to text mode."
                 return
             fi
-
-            ascii="$script_dir/ascii/distro/${ascii/ *}"
         fi
     fi
 
@@ -1952,52 +1953,52 @@ get_wallpaper() {
     case "$os" in
         "Linux" | "BSD")
             if type -p feh >/dev/null && [[ -f "$HOME/.fehbg" ]]; then
-                img="$(awk -F\' '/feh/ {printf $2}' "$HOME/.fehbg")"
+                image="$(awk -F\' '/feh/ {printf $2}' "$HOME/.fehbg")"
 
             elif type -p nitrogen >/dev/null; then
-                img="$(awk -F'=' '/file/ {printf $2;exit;}' "$XDG_CONFIG_HOME/nitrogen/bg-saved.cfg")"
+                image="$(awk -F'=' '/file/ {printf $2;exit;}' "$XDG_CONFIG_HOME/nitrogen/bg-saved.cfg")"
 
             elif type -p gsettings >/dev/null; then
                 # Get DE if user has disabled the function.
                 [[ -z "$de" ]] && get_de
 
                 case "$de" in
-                    "MATE"*) img="$(gsettings get org.mate.background picture-filename)" ;;
-                    *) img="$(gsettings get org.gnome.desktop.background picture-uri)" ;;
+                    "MATE"*) image="$(gsettings get org.mate.background picture-filename)" ;;
+                    *) image="$(gsettings get org.gnome.desktop.background picture-uri)" ;;
                 esac
 
                 # Strip quotes etc from the path.
-                img="${img/'file://'}"
-                img="${img//\'}"
-                img="${img//\%20/ }"
+                image="${image/'file://'}"
+                image="${image//\'}"
+                image="${image//\%20/ }"
             fi
         ;;
 
         "Mac OS X")
-            img="$(osascript -e 'tell application "System Events" to picture of current desktop')"
+            image="$(osascript -e 'tell application "System Events" to picture of current desktop')"
         ;;
 
         "Windows")
             case "$distro" in
                 "Windows XP")
-                    img="/cygdrive/c/Documents and Settings/${USER}"
-                    img+="/Local Settings/Application Data/Microsoft"
-                    img+="/Wallpaper1.bmp"
+                    image="/cygdrive/c/Documents and Settings/${USER}"
+                    image+="/Local Settings/Application Data/Microsoft"
+                    image+="/Wallpaper1.bmp"
                 ;;
 
                 "Windows"*)
-                    img="$APPDATA/Microsoft/Windows/Themes"
-                    img+="/TranscodedWallpaper.jpg"
+                    image="$APPDATA/Microsoft/Windows/Themes"
+                    image+="/TranscodedWallpaper.jpg"
                 ;;
             esac
         ;;
     esac
 
-    # If img is an xml file don't use it.
-    [[ "${img/*\./}" == "xml" ]] && img=""
+    # If image is an xml file don't use it.
+    [[ "${image/*\./}" == "xml" ]] && image=""
 
     # Error msg
-    [[ -z "$img" ]] && err "Image: Wallpaper detection failed, falling back to ascii mode."
+    [[ ! -f "$image" ]] && err "Image: Wallpaper detection failed, falling back to ascii mode."
 }
 
 get_term_size() {
@@ -2073,7 +2074,7 @@ get_term_size() {
         fi
     fi
 
-    # If $img isn't a file fallback to ascii mode.
+    # If $image isn't a file fallback to ascii mode.
     if [[ "$term_width" ]] && ((term_width > 0)); then
         clear
         zws="​ "
@@ -2117,7 +2118,7 @@ get_image_size() {
 
         "none")
             # Get image size so that we can do a better crop
-            size="$(identify -format "%w %h" "$img")"
+            size="$(identify -format "%w %h" "$image")"
             width="${size%% *}"
             height="${size##* }"
             crop_mode="none"
@@ -2135,23 +2136,23 @@ get_image_size() {
 make_thumbnail() {
     # Name the thumbnail using variables so we can
     # use it later.
-    imgname="$crop_mode-$crop_offset-$width-$height"
+    image_name="$crop_mode-$crop_offset-$width-$height"
 
     # Check to see if the image has a file extension,
     # if it doesn't then add one.
-    case "${img##*/}" in
-        *"."*) imgname="${imgname}-${img##*/}" ;;
-        *) imgname="${imgname}-${img##*/}.jpg" ;;
+    case "${image##*/}" in
+        *"."*) image_name="${image_name}-${image##*/}" ;;
+        *) image_name="${image_name}-${image##*/}.jpg" ;;
     esac
 
     # Check to see if the thumbnail exists before we do any cropping.
-    if [[ ! -f "$thumbnail_dir/$imgname" ]]; then
+    if [[ ! -f "$thumbnail_dir/$image_name" ]]; then
         # Create the thumbnail dir if it doesn't exist.
         mkdir -p "$thumbnail_dir"
 
         # Get image size so that we can do a better crop
         if [[ -z "$size" ]]; then
-            size="$(identify -format "%w %h" "$img")"
+            size="$(identify -format "%w %h" "$image")"
             og_width="${size%% *}"
             og_height="${size##* }"
 
@@ -2163,44 +2164,44 @@ make_thumbnail() {
 
         case "$crop_mode" in
             "fit")
-                c="$(convert "$img" \
+                c="$(convert "$image" \
                     -colorspace srgb \
                     -format "%[pixel:p{0,0}]" info:)"
 
                 convert \
-                    "$img" \
+                    "$image" \
                     -trim +repage \
                     -gravity south \
                     -background "$c" \
                     -extent "$size"x"$size" \
                     -scale "$width"x"$height" \
-                    "$thumbnail_dir/$imgname"
+                    "$thumbnail_dir/$image_name"
             ;;
 
             "fill")
                 convert \
-                    "$img" \
+                    "$image" \
                     -trim +repage \
                     -scale "$width"x"$height"^ \
                     -extent "$width"x"$height" \
-                    "$thumbnail_dir/$imgname"
+                    "$thumbnail_dir/$image_name"
             ;;
 
-            "none") cp "$img" "$thumbnail_dir/$imgname" ;;
+            "none") cp "$image" "$thumbnail_dir/$image_name" ;;
             *)
                 convert \
-                    "$img" \
+                    "$image" \
                     -gravity "$crop_offset" \
                     -crop "$size"x"$size"+0+0 \
                     -quality 95 \
                     -scale "$width"x"$height" \
-                    "$thumbnail_dir/$imgname"
+                    "$thumbnail_dir/$image_name"
             ;;
         esac
     fi
 
     # The final image
-    img="$thumbnail_dir/$imgname"
+    image="$thumbnail_dir/$image_name"
 }
 
 display_image() {
@@ -2209,16 +2210,16 @@ display_image() {
             # Add a tiny delay to fix issues with images not
             # appearing in specific terminal emulators.
             sleep 0.05
-            printf "%b\n" "0;1;$xoffset;$yoffset;$width;$height;;;;;$img\n4;\n3;" |\
+            printf "%b\n" "0;1;$xoffset;$yoffset;$width;$height;;;;;$image\n4;\n3;" |\
             "$w3m_img_path" -bg "$background_color" >/dev/null & 2>&1 || text_padding="0"
         ;;
 
         "iterm2")
-            printf "%b\a\n" "\033]1337;File=width=${width}px;height=${height}px;inline=1:$(base64 < "$img")"
+            printf "%b\a\n" "\033]1337;File=width=${width}px;height=${height}px;inline=1:$(base64 < "$image")"
         ;;
 
         "tycat")
-            tycat "$img"
+            tycat "$image"
         ;;
     esac
 }
@@ -3086,7 +3087,7 @@ get_args() {
             ;;
 
             --ascii_distro)
-                image="ascii"
+                image_backend="ascii"
                 ascii_distro="$2"
                 case "$2" in "-"* | "") ascii_distro="$distro" ;; esac
             ;;
@@ -3094,7 +3095,7 @@ get_args() {
             --ascii_logo_size) ascii_logo_size="$2" ;;
             --ascii_bold) ascii_bold="$2" ;;
             --logo | -L)
-                image="ascii"
+                image_backend="ascii"
                 print_info() { info line_break; }
             ;;
 

--- a/neofetch
+++ b/neofetch
@@ -1791,13 +1791,17 @@ get_cols() {
 
         # Add newlines to the string.
         cols="${cols%%'nl'}"
-        cols="${cols//nl/\\n${padding}${zws}}"
+        cols="${cols//nl/\\n\\033[${text_padding}C${zws}}"
     fi
 }
 
 # IMAGES
 
 get_image_backend() {
+    # This function determines which image backend to use
+    # by checking for programs and etc.
+
+    # Automatically find w3m-img
     get_w3m_img_path
 
     # Fallback to ascii mode if imagemagick isn't installed.
@@ -1815,11 +1819,18 @@ get_image_backend() {
                     else
                         img="$image_source"
                     fi
-
-                    [ ! -f "$img" ] && { image_backend="ascii"; get_ascii 2>/dev/null; return; }
                 ;;
             esac
 
+            # Fallback to ascii mode if image isn't a file.
+            if [[ ! -f "$img" ]]; then
+                image_backend="ascii"
+                get_ascii 2>/dev/null
+                err "Image: '$img', doesn't exist, falling back to ascii mode."
+                return
+            fi
+
+            # Set image program.
             if [[ -n "$ITERM_PROFILE" ]]; then
                 image_program="iterm2"
 
@@ -1830,12 +1841,16 @@ get_image_backend() {
                 image_program="w3m"
             fi
 
+            get_term_size
+            get_image_size
             make_thumbnail
-            display_image
+
+            # If the backend is still set to 'image' after
+            # make_thumbnail(), then display the image.
+            [[ "$image_backend" == "image" ]] && display_image
         ;;
 
         "ascii") get_ascii 2>/dev/null ;;
-        "off") ;;
     esac
 }
 
@@ -1871,7 +1886,7 @@ get_ascii() {
 
             # If the ascii file doesn't exist fallback to text mode.
             if [[ ! -f "$script_dir/ascii/distro/${ascii/ *}" ]]; then
-                padding="\033[0C"
+                text_padding="0"
                 image="off"
                 err "Ascii: Ascii file not found, falling back to text mode."
                 return
@@ -1906,7 +1921,7 @@ get_ascii() {
     # Overwrite padding if ascii_length_force is set.
     [[ "$ascii_length_force" ]] && ascii_length="$ascii_length_force"
 
-    padding="\033[$((ascii_length + gap))C"
+    text_padding="$((ascii_length + gap))"
     printf "%b" "$print"
     export LC_ALL=C
 }
@@ -1985,7 +2000,18 @@ get_wallpaper() {
     [[ -z "$img" ]] && err "Image: Wallpaper detection failed, falling back to ascii mode."
 }
 
-make_thumbnail() {
+get_term_size() {
+    # This functions gets the current window size in
+    # pixels.
+    #
+    # We first try to use the escape sequence '\044[14t'
+    # to get the terminal window size in pixels. If this
+    # fails we then fallback to using 'xdotool' or other
+    # programs.
+
+    # Tmux has a special way of reading escape sequences
+    # so we have to use a slightly different sequence to
+    # get the terminal size.
     if [[ -n "$TMUX" ]]; then
         printf "%b" "\033Ptmux;\033\033[14t\033\033[c\033\\"
         read_flags="-d c"
@@ -1998,10 +2024,12 @@ make_thumbnail() {
         read_flags="-d c"
     fi
 
-    # The escape code above prints the output AFTER the prompt so this
+    # The escape codes above print the desired output as
+    # user input so we have to use read to store the out
+    # -put as a variable.
     builtin read -s -t 1 ${read_flags} -r term_size
 
-    # Split the string
+    # Split the string into height/width.
     if [[ "$image_program" == "tycat" ]]; then
         term_size=(${term_size//;/ })
         term_width="$((term_size[2] * term_size[0]))"
@@ -2017,46 +2045,49 @@ make_thumbnail() {
     fi
 
     # Get terminal width and height if \033[14t is unsupported.
-    if (("${#term_size}" <= 5)) && [[ "$image_program" != "tycat" ]]; then
-        if type -p xdotool >/dev/null 2>&1 && \
-            [[ "$image_backend" != "iterm2" ]]; then
-
+    if (("${#term_size}" <= 5)) && [[ "$image_program" == "w3m" ]]; then
+        if type -p xdotool >/dev/null 2>&1; then
             current_window="$(xdotool getactivewindow)"
             source <(xdotool getwindowgeometry --shell "$current_window")
             term_height="$HEIGHT"
             term_width="$WIDTH"
 
-        elif type -p xwininfo >/dev/null 2>&1 && \
-            type -p xdpyinfo >/dev/null 2>&1 || \
-            type -p xprop >/dev/null 2>&1 && \
-            [[ "$image_program" != "iterm2" ]]; then
-
+        elif type -p xwininfo >/dev/null 2>&1; then
+            # Get the focused window's ID.
             if type -p xdpyinfo >/dev/null 2>&1; then
                 current_window="$(xdpyinfo | grep -F "focus" | grep -E -o "0x[0-9a-f]+")"
             elif type -p xprop >/dev/null 2>&1; then
                 current_window="$(xprop -root | awk '/_NET_ACTIVE_WINDOW\(WINDOW\)/{print $NF}')"
             fi
 
-            term_size="$(xwininfo -id "$current_window" | awk -F ': ' '/Width|Height/ {printf $2 " "}')"
-            term_width="${term_size/ *}"
-            term_height="${term_size/${term_width}}"
+            # If the ID was found get the window size.
+            if [[ "$current_window" ]]; then
+                term_size="$(xwininfo -id "$current_window" | awk -F ': ' '/Width|Height/ {printf $2 " "}')"
+                term_width="${term_size/ *}"
+                term_height="${term_size/${term_width}}"
+            else
+                term_width="0"
+            fi
+        else
+            term_width="0"
         fi
     fi
 
     # If $img isn't a file fallback to ascii mode.
-    if [[ ! -f "$img" || -z "$term_width" ]] || (("$term_width" <= 10)); then
-        image="ascii"
-        get_ascii
-
-        # Error messages
-        [[ ! -f "$img" ]] && err "Image: \$img, isn't a file, falling back to ascii mode."
-        (("${#term_size}" <= 5)) && err "Image: Your terminal doesn't support \\\033[14t, falling back to ascii mode."
-
-        return
-    else
+    if [[ "$term_width" ]] && ((term_width > 0)); then
         clear
         zws="​ "
+    else
+        image_backend="ascii"
+        get_ascii
+        err "Image: Failed to get window size, falling back to ascii mode."
+        return
     fi
+}
+
+get_image_size() {
+    # This functions determines the size to make
+    # the thumbnail image.
 
     # Get terminal lines and columns
     term_blocks="$(stty size)"
@@ -2067,7 +2098,6 @@ make_thumbnail() {
     font_width="$((term_width / columns))"
     font_height="$((term_height / lines))"
 
-    # Image size is half of the terminal
     case "$image_size" in
         "auto")
             image_size="$((columns * font_width / 2))"
@@ -2096,25 +2126,29 @@ make_thumbnail() {
         *) image_size="${image_size/px}" ;;
     esac
 
-    # Fallback if width / height are empty.
     width="${width:-$image_size}"
     height="${height:-$image_size}"
 
-    # Padding is half the terminal width + gap
-    padding="\033[$((width / font_width + gap + xoffset/font_width))C"
+    text_padding="$((width / font_width + gap + xoffset/font_width))"
+}
 
-    # Make the directory if it doesn't exist
-    mkdir -p "$thumbnail_dir"
+make_thumbnail() {
+    # Name the thumbnail using variables so we can
+    # use it later.
+    imgname="$crop_mode-$crop_offset-$width-$height"
 
-    # Check to see if the image has a file extension, if it doesn't
-    # then add one.
+    # Check to see if the image has a file extension,
+    # if it doesn't then add one.
     case "${img##*/}" in
-        *"."*) imgname="$crop_mode-$crop_offset-$width-$height-${img##*/}" ;;
-        *) imgname="$crop_mode-$crop_offset-$width-$height-${img##*/}.jpg" ;;
+        *"."*) imgname="${imgname}-${img##*/}" ;;
+        *) imgname="${imgname}-${img##*/}.jpg" ;;
     esac
 
     # Check to see if the thumbnail exists before we do any cropping.
     if [[ ! -f "$thumbnail_dir/$imgname" ]]; then
+        # Create the thumbnail dir if it doesn't exist.
+        mkdir -p "$thumbnail_dir"
+
         # Get image size so that we can do a better crop
         if [[ -z "$size" ]]; then
             size="$(identify -format "%w %h" "$img")"
@@ -2128,7 +2162,7 @@ make_thumbnail() {
         fi
 
         case "$crop_mode" in
-            fit)
+            "fit")
                 c="$(convert "$img" \
                     -colorspace srgb \
                     -format "%[pixel:p{0,0}]" info:)"
@@ -2143,7 +2177,7 @@ make_thumbnail() {
                     "$thumbnail_dir/$imgname"
             ;;
 
-            fill)
+            "fill")
                 convert \
                     "$img" \
                     -trim +repage \
@@ -2152,7 +2186,7 @@ make_thumbnail() {
                     "$thumbnail_dir/$imgname"
             ;;
 
-            none) cp "$img" "$thumbnail_dir/$imgname" ;;
+            "none") cp "$img" "$thumbnail_dir/$imgname" ;;
             *)
                 convert \
                     "$img" \
@@ -2176,7 +2210,7 @@ display_image() {
             # appearing in specific terminal emulators.
             sleep 0.05
             printf "%b\n" "0;1;$xoffset;$yoffset;$width;$height;;;;;$img\n4;\n3;" |\
-            "$w3m_img_path" -bg "$background_color" >/dev/null & 2>&1 || padding="\033[0C"
+            "$w3m_img_path" -bg "$background_color" >/dev/null & 2>&1 || text_padding="0"
         ;;
 
         "iterm2")
@@ -2273,7 +2307,7 @@ info() {
     [[ -z "$2" ]] && string="${string/*: }"
 
     # Print the string
-    printf "%b\n" "${padding}${zws}${string}${reset} "
+    printf "%b\n" "\033[${text_padding}C${zws}${string}${reset} "
 
     # Calculate info height
     info_height="$((info_height+=1))"
@@ -2281,10 +2315,8 @@ info() {
     # Fix rendering issues with w3m and lines that
     # wrap to the next line by adding a max line
     # length.
-    if [[ "$image" != "off" && "$image" != "ascii" && "$1" != "cols" ]]; then
-        padding_num="${padding/\\033\[}"
-        output="$(printf "%.$((columns - ${padding_num/C} - gap - ${#subtitle}))s" "$output")"
-    fi
+    [[ "$image_backend" == "image" ]] && \
+        string="$(printf "%.$((columns - text_padding - gap))s" "$string")"
 }
 
 prin() {
@@ -2301,7 +2333,7 @@ prin() {
     string="$(trim "$string")"
 
     # Print the info
-    printf "%b\n" "${padding}${zws}${string}${reset} "
+    printf "%b\n" "\033[${text_padding}C${zws}${string}${reset} "
 
     # Calculate info height
     info_height="$((info_height+=1))"
@@ -2309,10 +2341,8 @@ prin() {
     # Fix rendering issues with w3m and lines that
     # wrap to the next line by adding a max line
     # length.
-    if [[ "$image" != "off" && "$image" != "ascii" ]]; then
-        padding_num="${padding/\\033\[}"
-        string="$(printf "%.$((columns - ${padding_num/C} - gap))s" "$string")"
-    fi
+    [[ "$image_backend" == "image" ]] && \
+        string="$(printf "%.$((columns - text_padding - gap))s" "$string")"
 
     # Tell info() that prin() was used.
     prin=1
@@ -3137,7 +3167,7 @@ main() {
 
         # w3m-img: Draw the image a second time to fix
         # rendering issues in specific terminal emulators.
-        [[ "$image_program" == "w3m" ]] && display_image
+        [[ "$image_backend" == "image" && "$image_program" == "w3m" ]] && display_image
     fi
 
     # Re-enable line wrap

--- a/neofetch
+++ b/neofetch
@@ -1824,24 +1824,19 @@ get_image_backend() {
 
             # Fallback to ascii mode if image isn't a file.
             if [[ ! -f "$image" ]]; then
-                image_backend="ascii"
-                get_ascii 2>/dev/null
-                err "Image: '$image', doesn't exist, falling back to ascii mode."
+                to_ascii "Image: '$image' doesn't exist, falling back to ascii mode."
                 return
             fi
 
-            # Set image program.
-            if [[ -n "$ITERM_PROFILE" ]]; then
-                image_program="iterm2"
+            get_image_program
+            get_term_size
 
-            elif [[ "$(tycat 2>/dev/null)" ]]; then
-                image_program="tycat"
-
-            else
-                image_program="w3m"
+            # Fallback to ascii mode if terminal size wasn't found.
+            if [[ -z "$term_width" ]] && ((term_width == 0)); then
+                to_ascii "Image: Failed to find terminal window size"
+                return
             fi
 
-            get_term_size
             get_image_size
             make_thumbnail
 
@@ -1854,11 +1849,23 @@ get_image_backend() {
     esac
 }
 
+get_image_program() {
+    if [[ -n "$ITERM_PROFILE" ]]; then
+        image_program="iterm2"
+
+    elif [[ "$(tycat 2>/dev/null)" ]]; then
+        image_program="tycat"
+
+    else
+        image_program="w3m"
+    fi
+}
+
 get_ascii() {
     if [[ ! -f "$ascii" || "$ascii" == "distro" ]]; then
         # Error message
         [[ "$ascii" != "distro" ]] && \
-        [[ ! -f "$ascii" ]] && err "Ascii: Ascii file not found, using distro ascii"
+        [[ ! -f "$ascii" ]] && err "Ascii: Ascii file not found, using distro ascii."
 
         # Lowercase the distro name
         if (("$version" <= 3)); then
@@ -1889,9 +1896,7 @@ get_ascii() {
                 ascii="$script_dir/ascii/distro/${ascii/ *}"
 
             else
-                text_padding="0"
-                image_backend="off"
-                err "Ascii: Ascii file not found, falling back to text mode."
+                to_off "Ascii: Ascii file not found, falling back to text mode."
                 return
             fi
         fi
@@ -2074,15 +2079,10 @@ get_term_size() {
         fi
     fi
 
-    # If $image isn't a file fallback to ascii mode.
+    # If the terminal size was found correctly
     if [[ "$term_width" ]] && ((term_width > 0)); then
         clear
         zws="​ "
-    else
-        image_backend="ascii"
-        get_ascii
-        err "Image: Failed to get window size, falling back to ascii mode."
-        return
     fi
 }
 
@@ -2211,7 +2211,7 @@ display_image() {
             # appearing in specific terminal emulators.
             sleep 0.05
             printf "%b\n" "0;1;$xoffset;$yoffset;$width;$height;;;;;$image\n4;\n3;" |\
-            "$w3m_img_path" -bg "$background_color" >/dev/null & 2>&1 || text_padding="0"
+            "$w3m_img_path" -bg "$background_color" >/dev/null & 2>&1 || to_off "Images: w3m-img failed to display the image."
         ;;
 
         "iterm2")
@@ -2222,6 +2222,20 @@ display_image() {
             tycat "$image"
         ;;
     esac
+}
+
+to_ascii() {
+    # This function makes neofetch fallback to ascii mode.
+    image_backend="ascii"
+    get_ascii 2>/dev/null
+    err "$1"
+}
+
+to_off() {
+    # This function makes neofetch fallback to off mode.
+    text_padding="0"
+    image_backend="off"
+    err "$1"
 }
 
 # SCREENSHOT
@@ -2286,7 +2300,7 @@ info() {
 
     # If the output is empty, don't print anything.
     [[ -z "${output// }" ]] && \
-        err "Info: Couldn't detect $subtitle" && return
+        err "Info: Couldn't detect $subtitle." && return
 
     case "$1" in
         title)
@@ -2674,7 +2688,7 @@ get_default_config() {
     fi
 
     if source "$default_config"; then
-        err "Config: Sourced default config ($default_config)"
+        err "Config: Sourced default config. ($default_config)"
     else
         err "Config: Default config not found, continuing..."
     fi
@@ -2684,12 +2698,12 @@ get_user_config() {
     # Check $config_file
     if [[ -f "$config_file" ]]; then
         source "$config_file"
-        err "Config: Sourced user config    ($config_file)"
+        err "Config: Sourced user config.    ($config_file)"
         return
 
     elif [[ "$config_file" == "travis" ]]; then
         source "$travis_config"
-        err "Config: Sourced user config    ($travis_config)"
+        err "Config: Sourced user config.    ($travis_config)"
         return
     fi
     mkdir -p "$XDG_CONFIG_HOME/neofetch/"
@@ -2715,7 +2729,7 @@ get_user_config() {
     fi
 
     source "$config_file"
-    err "Config: Sourced user config    ($config_file)"
+    err "Config: Sourced user config.    ($config_file)"
 }
 
 bar() {


### PR DESCRIPTION
## Description

This PR aims to clean up the image related functions.

## Changes

- Added more documentation. 
- Added `to_ascii()` and `to_off()`.
    - These functions are used when falling back to different image modes.
- Renamed `$image_backend` to `$image_program`.
- Renamed `$image` to `$image_backend`.
- Renamed `$padding` to `$text_padding`.
- Renamed `$imgname` to `$img_name`.
- Renamed `$img` to `$image`.
- Renamed `check_old_flags()` to `old_flags()` to match `old_functions()`.
- Split `get_image()` into `get_term_size()`, `get_image_size()`, `get_image_program()` and `make_thumbnail()`.

## TODO

- [ ] Testing
    - [ ] iTerm2
    - [x] Terminology
    - [x] W3m-img
- [x] Look into rewriting some of the other functions.
- [x] Review
    - Check to see if I've missed anything.
- [x] Add backwards compatibility with old configs.
    - The only incompatibility is the renaming of `$image` to `$image_backend`.



