### PR TITLE
Music: Added support for various music players

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1076,7 +1076,7 @@ get_memory() {
 
 get_song() {
     # This is absurdly long.
-    player="$(ps x | awk '!(/awk|Helper|Cache/) && /mpd|cmus|mocp|spotify|Google Play|iTunes.app|rhythmbox|banshee|amarok|deadbeef|audacious|gnome-music/ {printf $5 " " $6; exit}')"
+    player="$(ps x | awk '!(/awk|Helper|Cache/) && /mpd|cmus|mocp|spotify|Google Play|iTunes.app|rhythmbox|banshee|amarok|deadbeef|audacious|gnome-music|lollypop/ {printf $5 " " $6; exit}')"
 
     case "${player/*\/}" in
         "mpd"*)
@@ -1164,6 +1164,17 @@ get_song() {
             # Hello dbus my old friend.
             song="$(\
                 dbus-send --print-reply --dest=org.mpris.MediaPlayer2.GnomeMusic /org/mpris/MediaPlayer2 \
+                org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Metadata' |\
+                awk -F 'string "' '/string|array/ {printf "%s",$2; next}{print ""}' |\
+                awk -F '"' '/artist|title/ {printf $2 " - "}'
+            )"
+            song="${song% - }"
+        ;;
+
+        "lollypop"*)
+            # Hello dbus my old friend.
+            song="$(\
+                dbus-send --print-reply --dest=org.mpris.MediaPlayer2.Lollypop /org/mpris/MediaPlayer2 \
                 org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Metadata' |\
                 awk -F 'string "' '/string|array/ {printf "%s",$2; next}{print ""}' |\
                 awk -F '"' '/artist|title/ {printf $2 " - "}'

--- a/neofetch
+++ b/neofetch
@@ -1076,7 +1076,7 @@ get_memory() {
 
 get_song() {
     # This is absurdly long.
-    player="$(ps x | awk '!(/awk|Helper|Cache/) && /mpd|cmus|mocp|spotify|Google Play|iTunes.app|rhythmbox|banshee|amarok|deadbeef|audacious/ {printf $5 " " $6; exit}')"
+    player="$(ps x | awk '!(/awk|Helper|Cache/) && /mpd|cmus|mocp|spotify|Google Play|iTunes.app|rhythmbox|banshee|amarok|deadbeef|audacious|gnome-music/ {printf $5 " " $6; exit}')"
 
     case "${player/*\/}" in
         "mpd"*)
@@ -1158,6 +1158,17 @@ get_song() {
 
         "audacious"*)
             song="$(audtool current-song)"
+        ;;
+
+        "gnome-music"*)
+            # Hello dbus my old friend.
+            song="$(\
+                dbus-send --print-reply --dest=org.mpris.MediaPlayer2.GnomeMusic /org/mpris/MediaPlayer2 \
+                org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Metadata' |\
+                awk -F 'string "' '/string|array/ {printf "%s",$2; next}{print ""}' |\
+                awk -F '"' '/artist|title/ {printf $2 " - "}'
+            )"
+            song="${song% - }"
         ;;
 
         *) song="Not Playing" ;;


### PR DESCRIPTION
## Description

This adds support for GNOME Music and Lollypop.

### Issues

![wtf dbus](http://ptpb.pw/r7Ji.png)

My initial understanding here is in different sessions of GNOME Music, sometimes `dbus-send` produces `xesam:artist` first before `xesam:title`, sometimes it's `xesam:title` first before `xesam:artist`, resulting in this.

I wonder why don't gdbus simplify things like `qdbus` do...

NOTE: This also happened to Lollypop. So if my hypothesis is true, Spotify should be affected as well.