### PR TITLE
Fix connection timed out with public_ip (dig)

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1700,6 +1700,7 @@ get_local_ip() {
 get_public_ip() {
     if type -p dig >/dev/null; then
         public_ip="$(dig +time=1 +tries=1 +short myip.opendns.com @resolver1.opendns.com)"
+        [[ "$public_ip" =~ ^\; ]] && unset public_ip
     fi
 
     if [[ -z "$public_ip" ]] && type -p curl >/dev/null; then


### PR DESCRIPTION
## Description

At my school (and I presume many other places with strong proxies in place) the `public_ip` function returns `;; connection timed out; no servers could be reached`.

## Features

Adds a check to see if the returned text from `dig` is a comment (starts with `;`) and unsets `public_ip`