### PR TITLE
Remove execution permission flag from logo files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ install:
 	$(INSTALL_PROG) neofetch $(DESTDIR)$(PREFIX)/bin/neofetch
 	$(INSTALL_FILE) neofetch.1 $(DESTDIR)$(PREFIX)/share/man/man1/neofetch.1
 	$(INSTALL_PROG) config/config $(DESTDIR)$(PREFIX)/share/neofetch/config
-	$(INSTALL_PROG) ascii/distro/* $(DESTDIR)$(PREFIX)/share/neofetch/ascii/distro
+	$(INSTALL_FILE) ascii/distro/* $(DESTDIR)$(PREFIX)/share/neofetch/ascii/distro
 
 uninstall:
 	$(RM) $(DESTDIR)$(PREFIX)/bin/neofetch


### PR DESCRIPTION
Execution permission is not required for files under
the /usr/share/neofetch/ascii/distro directory.

Signed-off-by: Nobuhiro Iwamatsu <iwamatsu@nigauri.org>