### PR TITLE
Distro: Remove lsb_release block

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -138,14 +138,6 @@ get_distro() {
                     *) distro="Red Star OS $(awk -F'[^0-9*]' '$0=$2' /etc/redstar-release)"
                 esac
 
-            elif type -p lsb_release >/dev/null; then
-                case "$distro_shorthand" in
-                    "on")   lsb_flags="-sir" ;;
-                    "tiny") lsb_flags="-si" ;;
-                    *)      lsb_flags="-sd" ;;
-                esac
-                distro="$(lsb_release $lsb_flags)"
-
             elif type -p guix >/dev/null; then
                 distro="GuixSD"
 
@@ -161,7 +153,7 @@ get_distro() {
 
             else
                 # Source the os-release file
-                for file in /etc/os-release /etc/*ease /usr/lib/*ease; do
+                for file in /etc/os-release /usr/lib/os-release /etc/*release /usr/lib/*release; do
                     source "$file" && break
                 done
 


### PR DESCRIPTION
## Description

This PR removes distro detection using `lsb_release`. I've made this change due to `lsb_release` reporting inaccurate distro information for some distros.




