### PR TITLE
Distro: Add last fallback for Linux and Hurd if no os-release was detected

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -243,6 +243,8 @@ get_distro() {
         ;;
     esac
 
+    [[ -z "$distro" ]] && distro="$os (Unknown)"
+
     # Get architecture
     [[ "$os_arch" == "on" ]] && \
         distro+=" ${machine_arch}"


### PR DESCRIPTION
## Rationale

On LFS distros, they often lack any `os-release` file, resulting in no output (often just the architecture), this adds a last fallback in case that does happen.

This mainly affects LFS distros, but since Linux and Hurd's system are similar, I'll just add another fallback for GNU Hurd distros in case someone ~~is crazy enough to~~ make GNU Hurd From Scratch.