### PR TITLE
CPU: Added cpu_temp support for BSDs

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -787,6 +787,20 @@ get_cpu() {
 
             # Get cpu cores
             cores="$(sysctl -n hw.ncpu)"
+
+            # Get cpu temp
+            if [[ "$cpu_temp" == "on" ]]; then
+                case "$distro" in
+                    "FreeBSD"* | "PacBSD"* | "DragonFly"* | "PCBSD"*)
+                        temp="$(sysctl -n dev.cpu.0.temperature)"
+                        temp="[${temp/C/°C}]"
+                    ;;
+                    "OpenBSD"* | "Bitrig"*)
+                        temp="$(sysctl -n hw.sensors.lm0.temp0)"
+                        temp="[${temp/ degC/°C}]"
+                    ;;
+                esac
+            fi
         ;;
 
         "Solaris")
@@ -2934,7 +2948,9 @@ usage() { printf "%s" "
                                 NOTE: 'physical' doesn't work on BSD.
     --cpu_speed on/off          Hide/Show cpu speed.
     --cpu_temp on/off           Hide/Show cpu temperature.
-                                NOTE This only works on linux.
+                                NOTE: This only works on Linux and BSD.
+                                NOTE: For FreeBSD-based systems, you need to enable coretemp
+                                      kernel module.
     --distro_shorthand on/off   Shorten the output of distro (tiny, on, off)
                                 NOTE: This option won't work in Windows (Cygwin)
     --kernel_shorthand on/off   Shorten the output of kernel

--- a/neofetch.1
+++ b/neofetch.1
@@ -48,7 +48,9 @@ Hide/Show cpu speed.
 .B \--cpu_temp 'on/off'
 Hide/Show cpu temperature.
 .br
-NOTE This only works on linux.
+NOTE: This only works on Linux and BSD.
+.br
+NOTE: For FreeBSD-based systems, you need to enable coretemp kernel module.
 .TP
 .B \--distro_shorthand 'on/off'
 Shorten the output of distro (tiny, on, off)


### PR DESCRIPTION
## Description

### Features

This adds `cpu_temp` support for BSD distros (except NetBSD, because it already emulates Linux's CPU detection)

### Issues

In FreeBSD-based systems, a kernel module (`coretemp`) must be loaded to show the temps. The warning has been added in the manpage.




