### PR TITLE
Add Arch Aqua logo ascii 

### DIFF
--- a/ascii/distro/arch_old
+++ b/ascii/distro/arch_old
@@ -1,0 +1,16 @@
+${c1}              __
+${c1}          _=(SDGJT=_
+${c1}        _GTDJHGGFCVS)
+${c1}       ,GTDJGGDTDFBGX0
+${c1}      JDJDIJHRORVFSBSVL${c2}-=+=,_
+${c1}     IJFDUFHJNXIXCDXDSV,${c2}  \"DEBL
+${c1}    [LKDSDJTDU=OUSCSBFLD.${c2}   '?ZWX,
+${c1}   ,LMDSDSWH'     \`DCBOSI${c2}     DRDS],
+${c1}   SDDFDFH'         !YEWD,${c2}   )HDROD
+${c1}  !KMDOCG            &GSU|${c2}\_GFHRGO\'
+${c1}  HKLSGP'${c2}           __${c1}\TKM0${c2}\GHRBV)'
+${c1} JSNRVW'${c2}       __+MNAEC${c1}\IOI,${c2}\BN'
+${c1} HELK['${c2}    __,=OFFXCBGHC${c1}\FD)
+${c1} ?KGHE ${c2}\_-#DASDFLSV='${c1}    'EF
+${c1} 'EHTI                    !H
+${c1}  \`0F'                    '!


### PR DESCRIPTION
## Description

From [screenfetch's ascii](https://github.com/KittyKatt/screenFetch/blob/5f15e57932292b0a750cf0a95c714f04018eeaa0/screenfetch-dev#L2565), I added the old arch logo which some might prefer over the current one.

## Features

Adds a third variant of the Arch logo. 

![imgur-2016_12_02-00 39 05](https://cloud.githubusercontent.com/assets/1613137/20817427/e9687ab6-b827-11e6-8303-031788d7efdc.png)

## Issues

Colours might be off...

## TODO

Tweak colors? Check out Arch Aqua from [here](https://www.archlinux.org/art/).