### PR TITLE
General: Add cache dir var

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2800,8 +2800,10 @@ bar() {
 }
 
 cache() {
-    mkdir -p "${cache_dir}/neofetch"
-    printf "%s" "${1/*-}=\"$2\"" > "${cache_dir}/neofetch/${1/*-}"
+    if [[ "$2" ]]; then
+        mkdir -p "${cache_dir}/neofetch"
+        printf "%s" "${1/*-}=\"$2\"" > "${cache_dir}/neofetch/${1/*-}"
+    fi
 }
 
 get_cache_dir() {

--- a/neofetch
+++ b/neofetch
@@ -2353,8 +2353,6 @@ info() {
 
     # Update the variable
     output="${2:-$1}"
-
-    # Trim whitespace
     output="$(trim "${!output}")"
 
     # If prin was used in the function, stop here.

--- a/neofetch
+++ b/neofetch
@@ -952,19 +952,19 @@ get_gpu() {
                 [[ "$gpu" =~ "intel" ]] && \
                     gpu="Intel Integrated Graphics"
 
-                cache "gpu" "$gpu" "/tmp"
+                cache "gpu" "$gpu"
             fi
         ;;
 
         "Mac OS X")
             # Use cache if it exists
-            if [[ -f "/Library/Caches/neofetch/gpu" ]]; then
-                source "/Library/Caches/neofetch/gpu"
+            if [[ -f "${cache_dir}/neofetch/gpu" ]]; then
+                source "${cache_dir}/neofetch/gpu"
             else
                 gpu="$(system_profiler SPDisplaysDataType | awk -F': ' '/^\ *Chipset Model:/ {printf $2 ", "}')"
                 gpu="${gpu//'/ $'}"
                 gpu="${gpu%,*}"
-                cache "gpu" "$gpu" "/Library/Caches/"
+                cache "gpu" "$gpu"
             fi
         ;;
 
@@ -1739,10 +1739,9 @@ get_local_ip() {
 
 get_public_ip() {
     # Use cache if available
-    if [[ -f "/tmp/neofetch/public_ip" ]]; then
-        source "/tmp/neofetch/public_ip"
-    elif [[ -f "/Library/Caches/neofetch/public_ip" ]]; then
-        source "/Library/Caches/neofetch/public_ip"
+    if [[ -f "${cache_dir}/neofetch/public_ip" ]]; then
+        source "${cache_dir}/neofetch/public_ip"
+
     else
         if type -p dig >/dev/null; then
             public_ip="$(dig +time=1 +tries=1 +short myip.opendns.com @resolver1.opendns.com)"
@@ -1758,10 +1757,7 @@ get_public_ip() {
         fi
     fi
 
-    case "$os" in
-        "Mac OS X"*) cache "public_ip" "$public_ip" "/Library/Caches" ;;
-        *) cache "public_ip" "$public_ip" "/tmp" ;;
-    esac
+    cache "public_ip" "$public_ip"
 }
 
 get_users() {
@@ -2816,8 +2812,15 @@ bar() {
 }
 
 cache() {
-    mkdir -p "$3/neofetch"
-    printf "%s" "${1/*-}=\"$2\"" > "$3/neofetch/${1/*-}"
+    mkdir -p "${cache_dir}/neofetch"
+    printf "%s" "${1/*-}=\"$2\"" > "${cache_dir}/neofetch/${1/*-}"
+}
+
+get_cache_dir() {
+    case "$os" in
+        "Mac OS X") cache_dir="/Library/Caches" ;;
+        *) cache_dir="/tmp" ;;
+    esac
 }
 
 kde_config_dir() {
@@ -3261,6 +3264,7 @@ main() {
 
     # Print the info
     old_functions
+    get_cache_dir
     print_info 2>/dev/null
 
     # Prompt calculation

--- a/neofetch
+++ b/neofetch
@@ -919,12 +919,6 @@ get_cpu_usage() {
 }
 
 get_gpu() {
-    # Use cache if it exists
-    if [[ -f "${cache_dir}/neofetch/gpu" ]]; then
-        source "${cache_dir}/neofetch/gpu"
-        return
-    fi
-
     case "$os" in
         "Linux" | "GNU")
             gpu="$(PATH="/sbin:$PATH" lspci -mm | awk -F '\\"|\\" \\"' '/Display|3D|VGA/ {print $3 " " $4}')"
@@ -1733,23 +1727,17 @@ get_local_ip() {
 }
 
 get_public_ip() {
-    # Use cache if available
-    if [[ -f "${cache_dir}/neofetch/public_ip" ]]; then
-        source "${cache_dir}/neofetch/public_ip"
+    if type -p dig >/dev/null; then
+        public_ip="$(dig +time=1 +tries=1 +short myip.opendns.com @resolver1.opendns.com)"
+       [[ "$public_ip" =~ ^\; ]] && unset public_ip
+    fi
 
-    else
-        if type -p dig >/dev/null; then
-            public_ip="$(dig +time=1 +tries=1 +short myip.opendns.com @resolver1.opendns.com)"
-           [[ "$public_ip" =~ ^\; ]] && unset public_ip
-        fi
+    if [[ -z "$public_ip" ]] && type -p curl >/dev/null; then
+        public_ip="$(curl --max-time 10 -w '\n' "$public_ip_host")"
+    fi
 
-        if [[ -z "$public_ip" ]] && type -p curl >/dev/null; then
-            public_ip="$(curl --max-time 10 -w '\n' "$public_ip_host")"
-        fi
-
-        if [[ -z "$public_ip" ]] && type -p wget >/dev/null; then
-            public_ip="$(wget -T 10 -qO- "$public_ip_host")"
-        fi
+    if [[ -z "$public_ip" ]] && type -p wget >/dev/null; then
+        public_ip="$(wget -T 10 -qO- "$public_ip_host")"
     fi
 
     cache "public_ip" "$public_ip"
@@ -2355,8 +2343,15 @@ info() {
     # $1 is the subtitle
     subtitle="$1"
 
-    # Call the function and update variable
-    "get_${2:-$1}" 2>/dev/null
+    # Use cache if it exists
+    if [[ -f "${cache_dir}/neofetch/${2}" ]]; then
+        source "${cache_dir}/neofetch/${2}"
+    else
+        # Call the function.
+        "get_${2:-$1}" 2>/dev/null
+    fi
+
+    # Update the variable
     output="${2:-$1}"
 
     # Trim whitespace

--- a/neofetch
+++ b/neofetch
@@ -919,53 +919,46 @@ get_cpu_usage() {
 }
 
 get_gpu() {
+    # Use cache if it exists
+    if [[ -f "${cache_dir}/neofetch/gpu" ]]; then
+        source "${cache_dir}/neofetch/gpu"
+        return
+    fi
+
     case "$os" in
         "Linux" | "GNU")
-            # Use cache if it exists
-            if [[ -f "/tmp/neofetch/gpu" ]]; then
-                source "/tmp/neofetch/gpu"
-            else
-                gpu="$(PATH="/sbin:$PATH" lspci -mm | awk -F '\\"|\\" \\"' '/Display|3D|VGA/ {print $3 " " $4}')"
+            gpu="$(PATH="/sbin:$PATH" lspci -mm | awk -F '\\"|\\" \\"' '/Display|3D|VGA/ {print $3 " " $4}')"
 
-                case "$gpu" in
-                    *"advanced"*)
-                        gpu="${gpu//Intel*$'\n'}"
-                        gpu="${gpu/'[AMD/ATI]' }"
-                        gpu="${gpu/'[AMD]' }"
-                        gpu="${gpu/*\[}"
-                        gpu="${gpu/\]*}"
-                        gpu="AMD $gpu"
-                    ;;
+            case "$gpu" in
+                *"advanced"*)
+                    gpu="${gpu//Intel*$'\n'}"
+                    gpu="${gpu/'[AMD/ATI]' }"
+                    gpu="${gpu/'[AMD]' }"
+                    gpu="${gpu/*\[}"
+                    gpu="${gpu/\]*}"
+                    gpu="AMD $gpu"
+                ;;
 
-                    *"nvidia"*)
-                        gpu="${gpu//Intel*$'\n'}"
-                        gpu="${gpu/*\[}"
-                        gpu="${gpu/\]*}"
-                        gpu="NVIDIA $gpu"
-                    ;;
+                *"nvidia"*)
+                    gpu="${gpu//Intel*$'\n'}"
+                    gpu="${gpu/*\[}"
+                    gpu="${gpu/\]*}"
+                    gpu="NVIDIA $gpu"
+                ;;
 
-                    *"virtualbox"*)
-                        gpu="VirtualBox Graphics Adapter"
-                    ;;
-                esac
+                *"virtualbox"*)
+                    gpu="VirtualBox Graphics Adapter"
+                ;;
+            esac
 
-                [[ "$gpu" =~ "intel" ]] && \
-                    gpu="Intel Integrated Graphics"
-
-                cache "gpu" "$gpu"
-            fi
+            [[ "$gpu" =~ "intel" ]] && \
+                gpu="Intel Integrated Graphics"
         ;;
 
         "Mac OS X")
-            # Use cache if it exists
-            if [[ -f "${cache_dir}/neofetch/gpu" ]]; then
-                source "${cache_dir}/neofetch/gpu"
-            else
-                gpu="$(system_profiler SPDisplaysDataType | awk -F': ' '/^\ *Chipset Model:/ {printf $2 ", "}')"
-                gpu="${gpu//'/ $'}"
-                gpu="${gpu%,*}"
-                cache "gpu" "$gpu"
-            fi
+            gpu="$(system_profiler SPDisplaysDataType | awk -F': ' '/^\ *Chipset Model:/ {printf $2 ", "}')"
+            gpu="${gpu//'/ $'}"
+            gpu="${gpu%,*}"
         ;;
 
         "iPhone OS")
@@ -1030,6 +1023,8 @@ get_gpu() {
         gpu="${gpu/NVIDIA}"
         gpu="${gpu/Intel}"
     fi
+
+    cache "gpu" "$gpu"
 }
 
 get_memory() {


### PR DESCRIPTION
## Description

This makes the cache function easier to use when applying it to more than one Operating System. This adds a new function called `get_cache_dir()` which sets the variable `cache_dir` according to the current Operating System.

This PR also moves the cache file check to the `info()` function directly. This means that if the cache file exists the info function isn't run at all. This change makes it so that adding caching support for all Operating Systems to an info function only takes one additional line of code. ;)

This PR also implements GPU caching for all Operating Systems and only caches the info if it's not empty.


