### PR TITLE
Packages: Call wc -l once at the end, instead of multiple times. 

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -372,66 +372,70 @@ get_packages() {
     case "$os" in
         "Linux" | "iPhone OS" | "Solaris" | "GNU")
             type -p pacman >/dev/null && \
-                packages="$(pacman -Qq --color never | wc -l)"
+                packages="$(pacman -Qq --color never)\n"
 
             type -p dpkg >/dev/null && \
-                packages="$((packages+=$(dpkg --get-selections | grep -cv deinstall$)))"
+                packages+="$(dpkg --get-selections | grep -v deinstall$)\n"
 
             type -p /sbin/pkgtool >/dev/null && \
-                packages="$((packages+=$(ls -1 /var/log/packages | wc -l)))"
+                packages+="$(ls -1 /var/log/packages)\n"
 
             type -p rpm >/dev/null && \
-                packages="$((packages+=$(rpm -qa | wc -l)))"
+                packages+="$(rpm -qa)\n"
 
             type -p xbps-query >/dev/null && \
-                packages="$((packages+=$(xbps-query -l | wc -l)))"
+                packages+="$(xbps-query -l)\n"
 
             type -p pkginfo >/dev/null && \
-                packages="$((packages+=$(pkginfo -i | wc -l)))"
+                packages+="$(pkginfo -i)\n"
 
             type -p emerge >/dev/null && \
-                packages="$((packages+=$(ls -d /var/db/pkg/*/* | wc -l)))"
+                packages+="$(ls -d /var/db/pkg/*/*)\n"
 
             type -p nix-env >/dev/null && \
-                packages="$((packages+=$(ls -d -1 /nix/store/*/ | wc -l)))"
+                packages+="$(ls -d -1 /nix/store/*/)\n"
 
             type -p guix >/dev/null && \
-                packages="$((packages+=$(ls -d -1 /gnu/store/*/ | wc -l)))"
+                packages+="$(ls -d -1 /gnu/store/*/)\n"
 
             type -p apk >/dev/null && \
-                packages="$((packages+=$(apk info | wc -l)))"
+                packages+="$(apk info)\n"
 
             type -p opkg >/dev/null && \
-                packages="$((packages+=$(opkg list-installed | wc -l)))"
+                packages+="$(opkg list-installed)\n"
 
             type -p pacman-g2 >/dev/null && \
-                packages="$((packages+=$(pacman-g2 -Q | wc -l)))"
+                packages+="$(pacman-g2 -Q)\n"
 
             type -p cave >/dev/null && \
-                packages="$((packages+=$(ls -d -1 /var/db/paludis/repositories/cross-installed/*/data/* /var/db/paludis/repositories/installed/data/* | wc -l)))"
+                packages+="$(ls -d -1 /var/db/paludis/repositories/cross-installed/*/data/* /var/db/paludis/repositories/installed/data/*)\n"
 
             type -p lvu >/dev/null && \
-                packages="$((packages+=$(lvu installed | wc -l)))"
+                packages+="$(lvu installed)\n"
 
             type -p tce-status >/dev/null && \
-                packages="$((packages+=$(tce-status -i | wc -l)))"
+                packages+="$(tce-status -i)\n"
 
             type -p Compile >/dev/null && \
-                packages="$((packages+=$(ls -d -1 /Programs/*/ | wc -l)))"
+                packages+="$(ls -d -1 /Programs/*/)\n"
 
             # pisi is sometimes unavailable in Solus(?). This uses eopkg
             # instead if pisi isn't found.
             if type -p pisi >/dev/null; then
-                packages="$((packages+=$(pisi list-installed | wc -l)))"
+                packages+="$(pisi list-installed)\n"
 
             elif type -p eopkg >/dev/null; then
-                packages="$((packages+=$(eopkg list-installed | wc -l)))"
+                packages+="$(eopkg list-installed)\n"
             fi
 
             if type -p pkg >/dev/null; then
-                packages="$((packages+=$(ls -1 /var/db/pkg | wc -l)))"
-                (("$packages" == "0")) && packages="$((packages+=$(pkg list | wc -l)))"
+                packages+="$(ls -1 /var/db/pkg)\n"
+                (("$packages" == "0")) && packages+="$(pkg list)\n"
             fi
+
+            # Count the packages.
+            packages="${packages//\\n/$'\n'}"
+            packages="$(wc -l <<< "${packages//$'\n\n'}")"
         ;;
 
         "Mac OS X")

--- a/neofetch
+++ b/neofetch
@@ -372,70 +372,75 @@ get_packages() {
     case "$os" in
         "Linux" | "iPhone OS" | "Solaris" | "GNU")
             type -p pacman >/dev/null && \
-                packages="$(pacman -Qq --color never)\n"
+                packages=("$(pacman -Qq --color never)")
 
             type -p dpkg >/dev/null && \
-                packages+="$(dpkg --get-selections | grep -v deinstall$)\n"
+                packages+=("$(dpkg --get-selections | grep -v deinstall$)")
 
             type -p /sbin/pkgtool >/dev/null && \
-                packages+="$(ls -1 /var/log/packages)\n"
+                packages+=("$(ls -1 /var/log/packages)")
 
             type -p rpm >/dev/null && \
-                packages+="$(rpm -qa)\n"
+                packages+=("$(rpm -qa)")
 
             type -p xbps-query >/dev/null && \
-                packages+="$(xbps-query -l)\n"
+                packages+=("$(xbps-query -l)")
 
             type -p pkginfo >/dev/null && \
-                packages+="$(pkginfo -i)\n"
+                packages+=("$(pkginfo -i)")
 
             type -p emerge >/dev/null && \
-                packages+="$(ls -d /var/db/pkg/*/*)\n"
+                packages+=("$(ls -d /var/db/pkg/*/*)")
 
             type -p nix-env >/dev/null && \
-                packages+="$(ls -d -1 /nix/store/*/)\n"
+                packages+=("$(ls -d -1 /nix/store/*/)")
 
             type -p guix >/dev/null && \
-                packages+="$(ls -d -1 /gnu/store/*/)\n"
+                packages+=("$(ls -d -1 /gnu/store/*/)")
 
             type -p apk >/dev/null && \
-                packages+="$(apk info)\n"
+                packages+=("$(apk info)")
 
             type -p opkg >/dev/null && \
-                packages+="$(opkg list-installed)\n"
+                packages+=("$(opkg list-installed)")
 
             type -p pacman-g2 >/dev/null && \
-                packages+="$(pacman-g2 -Q)\n"
+                packages+=("$(pacman-g2 -Q)")
 
             type -p cave >/dev/null && \
-                packages+="$(ls -d -1 /var/db/paludis/repositories/cross-installed/*/data/* /var/db/paludis/repositories/installed/data/*)\n"
+                packages+=("$(ls -d -1 /var/db/paludis/repositories/cross-installed/*/data/* /var/db/paludis/repositories/installed/data/*)")
 
             type -p lvu >/dev/null && \
-                packages+="$(lvu installed)\n"
+                packages+=("$(lvu installed)")
 
             type -p tce-status >/dev/null && \
-                packages+="$(tce-status -i)\n"
+                packages+=("$(tce-status -i)")
 
             type -p Compile >/dev/null && \
-                packages+="$(ls -d -1 /Programs/*/)\n"
+                packages+=("$(ls -d -1 /Programs/*/)")
 
             # pisi is sometimes unavailable in Solus(?). This uses eopkg
             # instead if pisi isn't found.
             if type -p pisi >/dev/null; then
-                packages+="$(pisi list-installed)\n"
+                packages+=("$(pisi list-installed)")
 
             elif type -p eopkg >/dev/null; then
-                packages+="$(eopkg list-installed)\n"
+                packages+=("$(eopkg list-installed)")
             fi
 
             if type -p pkg >/dev/null; then
-                packages+="$(ls -1 /var/db/pkg)\n"
-                (("$packages" == "0")) && packages+="$(pkg list)\n"
+                packages+=("$(ls -1 /var/db/pkg)")
+                (("$packages" == "0")) && packages+=("$(pkg list)")
             fi
 
             # Count the packages.
-            packages="${packages//\\n/$'\n'}"
-            packages="$(wc -l <<< "${packages//$'\n\n'}")"
+            packages="$(wc -l <<< "${packages[@]}")"
+
+            # Due to the sum of wc -l being off by 1 per package manager
+            # we add the number of package managers to make up for it.
+            # We then remove 2 since the first and last package manager
+            # arent't affected by the off by 1 counting error.
+            packages="$((packages + ${#packages[@]} - 2))"
         ;;
 
         "Mac OS X")


### PR DESCRIPTION
## Description

When I was trying to implement package manager names I took a closer look at the packages function and noticed that we were calling `wc -l` to count the packages once per package manager. 

I started messing around with the function and came up with a way to call `wc -l` only once. We add each list of packages to an array, count the array using `wc -l` and then do some math to fix inaccuracy caused by array elements joining due to missing newlines. 

This should be way faster than the current method since we no longer pipe to an external program on a per package manager basis, we just call it once at the end. 

## Features

- Only call `wc -l` once. 

## Testing

I don't have any systems with more than one package manager installed so I faked it on my machine to test locally. I'd still like someone to test this on a real machine before I merge this to master.


