### PR TITLE
GPU: Fix bug with sound card being detected, closes #491

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -947,7 +947,7 @@ get_cpu_usage() {
 get_gpu() {
     case "$os" in
         "Linux" | "GNU")
-            gpu="$(PATH="/sbin:$PATH" lspci -mm | awk -F '\\"|\\" \\"' '/Display|3D|VGA/ {print $3 " " $4}')"
+            gpu="$(PATH="/sbin:$PATH" lspci -mm | awk -F '\\"|\\" \\"' '/"Display|"3D|"VGA/ {print $3 " " $4}')"
 
             case "$gpu" in
                 *"advanced"*)


### PR DESCRIPTION
## Description

This updates the `lspci` `awk` command to only match `Display`, `3D` and `VGA` if there's a `"` to the left of them. This should fix issues where `Display`, `3D` and `VGA` appear in other device names. 

@konimex, can you test this on your machines? I've only got one Linux machine with integrated graphics so I'm not sure if it works with AMD/NVIDIA.

Closes #491




