### PR TITLE
Scrot: Automatically detect tools

### DIFF
--- a/config/config
+++ b/config/config
@@ -629,16 +629,20 @@ ascii_bold="on"
 #          -s
 scrot="off"
 
-# Screenshot program to launch
-# If you're not using 'scrot' change this to your screenshot
-# program.
+# Screenshot Program
+# Neofetch will automatically use whatever screenshot tool
+# is installed on your system.
 #
-# Default: 'scrot -c -d 3'
-# Values:  'cmd -flags'
+# If 'neofetch -v' says that it couldn't find a screenshot
+# tool or you're using a custom tool then you can change
+# the option below to a custom command.
+#
+# Default: 'auto'
+# Values:  'auto' 'cmd -flags'
 # Flag:    --scrot_cmd
-scrot_cmd="scrot -c -d 3"
+scrot_cmd="auto"
 
-# Scrot dir
+# Screenshot Directory
 # Where to save the screenshots
 #
 # Default: '~/Pictures/'
@@ -648,7 +652,7 @@ scrot_cmd="scrot -c -d 3"
 # Note: Neofetch won't create the directory if it doesn't exist.
 scrot_dir="$HOME/Pictures/"
 
-# Scrot filename
+# Screenshot Filename
 # What to name the screenshots
 #
 # Default: 'neofetch-$(date +%F-%I-%M-%S-${RANDOM}).png'

--- a/neofetch
+++ b/neofetch
@@ -2328,7 +2328,7 @@ to_off() {
 
 take_scrot() {
     if [[ -d "$scrot_dir" ]]; then
-        scrot_program "${scrot_dir}${scrot_name}"
+        scrot_program "${scrot_dir}${scrot_name}" 2>/dev/null
     else
         printf "%s\n" "Screenshot: $scrot_dir doesn't exist. Edit the config file or create the directory to take screenshots."
     fi
@@ -2373,9 +2373,13 @@ scrot_args() {
 }
 
 scrot_program() {
+    # Detect screenshot program.
+    #
+    # We first check to see if an X server is running before
+    # falling back to OS specific screenshot tools.
     if [[ -n "$DISPLAY" ]]; then
         if [[ "$scrot_cmd" != "auto" ]] && type -p "$scrot_cmd" >/dev/null; then
-            scrot_program="scrot_cmd"
+            scrot_program="$scrot_cmd"
 
         elif type -p scrot >/dev/null; then
             scrot_program="scrot"
@@ -2396,12 +2400,17 @@ scrot_program() {
             err "Scrot: No screen capture tool found."
             return
         fi
-
-        # Take the scrot.
-        $scrot_program "$1"
-
-        err "Scrot: Screen captured using $scrot_program"
+    else
+        case "$os" in
+            "Mac OS X") scrot_program="screencapture -S" ;;
+            "Haiku") scrot_program="screenshot -s" ;;
+        esac
     fi
+
+    # Take the scrot.
+    $scrot_program "$1"
+
+    err "Scrot: Screen captured using $scrot_program"
 }
 
 # TEXT FORMATTING

--- a/neofetch
+++ b/neofetch
@@ -2328,7 +2328,7 @@ to_off() {
 
 take_scrot() {
     if [[ -d "$scrot_dir" ]]; then
-        $scrot_cmd "${scrot_dir}${scrot_name}"
+        scrot_program "${scrot_dir}${scrot_name}"
     else
         printf "%s\n" "Screenshot: $scrot_dir doesn't exist. Edit the config file or create the directory to take screenshots."
     fi
@@ -2370,6 +2370,38 @@ scrot_args() {
             scrot_dir="${2/$scrot_name}"
         ;;
     esac
+}
+
+scrot_program() {
+    if [[ -n "$DISPLAY" ]]; then
+        if [[ "$scrot_cmd" != "auto" ]] && type -p "$scrot_cmd" >/dev/null; then
+            scrot_program="scrot_cmd"
+
+        elif type -p scrot >/dev/null; then
+            scrot_program="scrot"
+
+        elif type -p maim >/dev/null; then
+            scrot_program="maim"
+
+        elif type -p import >/dev/null; then
+            scrot_program="import -window root"
+
+        elif type -p imlib2_grab >/dev/null; then
+            scrot_program="imlib2_grab"
+
+        elif type -p gnome-screenshot >/dev/null; then
+            scrot_program="gnome-screenshot -f"
+
+        else
+            err "Scrot: No screen capture tool found."
+            return
+        fi
+
+        # Take the scrot.
+        $scrot_program "$1"
+
+        err "Scrot: Screen captured using $scrot_program"
+    fi
 }
 
 # TEXT FORMATTING


### PR DESCRIPTION
## Description

This PR adds a new function called `scrot_program()` which automatically detects screenshot tools on your system. Users no longer have to specify which tool to use in their config file. 

This only supports systems with an X server, we can add support for macOS and Windows if we can figure out how to take screenshots on these machines from the commandline.

One of the tools in the `scrot_program()` function is most likely already installed so for majority of people this will be plug and play.

The `scrot_cmd` config option will still exist and still work if users want more control over which program/flags to use.

## Features

- Automatically use whatever screenshot tool is available.
- Added screenshot support to macOS
- Added screenshot support to Haiku

## Issues

- This function supports every OS but Windows. There's no builtin way on Windows to take screenshots from the command line. CYGWIN + an X server will still work on Windows.