### PR TITLE
General: Optimize usage of get_de(), get_wm() and get_term().

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -555,6 +555,9 @@ get_de() {
         *"xfce4"*) de="XFCE4" ;;
         *"xfce5"*) de="XFCE5" ;;
     esac
+
+    # Log that the function was run.
+    de_run=1
 }
 
 get_wm() {
@@ -579,11 +582,14 @@ get_wm() {
             ;;
         esac
     fi
+
+    # Log that the function was run.
+    wm_run=1
 }
 
 get_wm_theme() {
-    [[ -z "$wm" ]] && get_wm
-    [[ -z "$de" ]] && get_de
+    (( "$wm_run" != 1 )) && get_wm
+    (( "$de_run" != 1 )) && get_de
 
     case "$wm"  in
         "E16") wm_theme="$(awk -F "= " '/theme.name/ {print $2}' "$HOME/.e16/e_config--0.0.cfg")";;
@@ -1336,7 +1342,7 @@ get_style() {
 
     if [[ -n "$DISPLAY" && "$os" != "Mac OS X" ]]; then
         # Get DE if user has disabled the function.
-        [[ -z "$de" ]] && get_de
+        (( "$de_run" != 1 )) && get_de
 
         # Check for DE Theme.
         case "$de" in
@@ -1531,10 +1537,13 @@ get_term() {
         "gnome-terminal-") term="gnome-terminal" ;;
         *) term="${name##*/}" ;;
     esac
+
+    # Log that the function was run.
+    term_run=1
 }
 
 get_term_font() {
-    [[ -z "$term" ]] && get_term
+    (( "$term_run" != 1 )) && get_term
 
     case "$term" in
         "urxvt" | "urxvtd" | "xterm")
@@ -2033,7 +2042,7 @@ get_wallpaper() {
     case "$os" in
         "Linux" | "BSD" | "Solaris" | "GNU")
             # Get DE if user has disabled the function.
-            [[ -z "$de" ]] && get_de
+            (( "$de_run" != 1 )) && get_de
 
             case "$de" in
                 "Cinnamon"*) image="$(gsettings get org.cinnamon.desktop.background picture-uri)" ;;
@@ -2925,7 +2934,7 @@ get_term_padding() {
     #
     # Note: This issue only seems to affect
     # URxvt.
-    [[ -z "$term" ]] && get_term
+    (( "$term_run" != 1 )) && get_term
 
     case "$term" in
         "URxvt"*)


### PR DESCRIPTION
## Description

Previously if the functions failed they would still be called 3-4 times. This will speed things up on systems where `get_de()`, `get_wm()` or `get_term()` failed.




