### PR TITLE
General: Cleanup main

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1943,6 +1943,10 @@ get_image_backend() {
 
         "ascii") get_ascii 2>/dev/null ;;
     esac
+
+    # Set cursor position next to ascii art.
+    [[ "$image_backend" != "off" ]] && \
+        printf "%b" "\033[$((${lines:-0} - ${prompt_loc:-0}))A\033[9999999D"
 }
 
 get_ascii() {
@@ -2953,12 +2957,15 @@ get_term_padding() {
 }
 
 dynamic_prompt() {
-    if [[ "$image_backend" == "image" ]]; then
-        get_term_padding 2>/dev/null
+    case "$image_backend" in
+        "image")
+            get_term_padding 2>/dev/null
 
-        # Calculate image height in terminal cells.
-        lines="$(((height + (${border:-0} * 2) + ${yoffset:-0}) / font_height))"
-    fi
+            # Calculate image height in terminal cells.
+            lines="$(((height + (${border:-0} * 2) + ${yoffset:-0}) / font_height))"
+        ;;
+        "off") return ;;
+    esac
 
     # If the info is higher than the ascii/image place the prompt
     # based on the info height instead of the ascii/image height.
@@ -3336,42 +3343,23 @@ main() {
     get_bold
     get_distro_colors
 
-    # Restore cursor and clear screen on ctrl+c
-    trap 'printf "\033[?25h"; clear; exit' 2
-
     # If the script exits for any reason, unhide the cursor.
-    trap 'printf "\033[?25h"' EXIT
+    trap 'printf "\033[?25h\033[?7h"' EXIT
 
     # Hide the cursor and disable line wrap
     printf "\033[?25l\033[?7l"
 
     get_image_backend
-
-    if [[ "$image_backend" != "off" ]]; then
-        # Set cursor position next to ascii art
-        printf "%b" "\033[$((${lines:-0} - ${prompt_loc:-0}))A"
-
-        # Reset horizontal cursor position
-        printf "\033[9999999D"
-    fi
-
-    # Print the info
     old_functions
     get_cache_dir
     print_info 2>/dev/null
+    dynamic_prompt
 
-    # Prompt calculation
-    if [[ "$image_backend" != "off" ]]; then
-        dynamic_prompt
+    # w3m-img: Draw the image a second time to fix
+    # rendering issues in specific terminal emulators.
+    [[ "$image_backend" == "image" && "$image_program" == "w3m" ]] && display_image
 
-        # w3m-img: Draw the image a second time to fix
-        # rendering issues in specific terminal emulators.
-        [[ "$image_backend" == "image" && "$image_program" == "w3m" ]] && display_image
-    fi
-
-    # Re-enable line wrap
-    printf "%b" "\033[?7h"
-
+    # Take a screenshot
     [[ "$scrot" == "on" ]] && take_scrot
 
     # Show error messages


### PR DESCRIPTION
## Description

Move a lot of the tests in `main()` to other existing functions. This cleans up the `main()` function.
