### PR TITLE
[macOS] Always charging bug

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1709,7 +1709,11 @@ get_battery() {
 
         "Mac OS X")
             battery="$(pmset -g batt | grep -o '[0-9]*%')"
-            battery_state="$(pmset -g batt | awk 'NR==2 {print $3}')"
+            state="$(pmset -g batt | awk '/;/ {print $4}')"
+            if [ "$state" == "charging;" ];
+            then
+              battery_state="charging"
+            fi
         ;;
 
         "Windows")

--- a/neofetch
+++ b/neofetch
@@ -1710,10 +1710,7 @@ get_battery() {
         "Mac OS X")
             battery="$(pmset -g batt | grep -o '[0-9]*%')"
             state="$(pmset -g batt | awk '/;/ {print $4}')"
-            if [ "$state" == "charging;" ];
-            then
-              battery_state="charging"
-            fi
+            [[ "$state" == "charging;" ]] && battery_state="charging"
         ;;
 
         "Windows")


### PR DESCRIPTION
## Description

Battery would display as "charging" every time on the last few versions of Neofetch. This patch fixes that.