### PR TITLE
DE: Better Desktop Environment Detection. 

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -537,9 +537,14 @@ get_de() {
         ;;
 
         *)
-            de="${XDG_CURRENT_DESKTOP/i3}"
-            de="${de/'X-'}"
-            de="${de/Budgie:GNOME/Budgie}"
+            if [[ "$XDG_CURRENT_DESKTOP" ]]; then
+                de="${XDG_CURRENT_DESKTOP/i3}"
+                de="${de/'X-'}"
+                de="${de/Budgie:GNOME/Budgie}"
+
+            elif [[ "$DESKTOP_SESSION" ]]; then
+                de="${DESKTOP_SESSION/ *}"
+            fi
         ;;
     esac
 
@@ -554,6 +559,8 @@ get_de() {
         *"MUFFIN"* | "Cinnamon") de="$(cinnamon --version)"; de="${de:-Cinnamon}" ;;
         *"xfce4"*) de="XFCE4" ;;
         *"xfce5"*) de="XFCE5" ;;
+        *"xfce"*)  de="XFCE" ;;
+        *"mate"*)  de="MATE"
     esac
 
     # Log that the function was run.

--- a/neofetch
+++ b/neofetch
@@ -544,6 +544,12 @@ get_de() {
 
             elif [[ "$DESKTOP_SESSION" ]]; then
                 de="${DESKTOP_SESSION/ *}"
+
+            elif [[ "$GOME_DESKTOP_SESSION_ID" ]]; then
+                de="GNOME"
+
+            elif [[ "$MATE_DESKTOP_SESSION_ID" ]]; then
+                de="MATE"
             fi
         ;;
     esac
@@ -560,7 +566,7 @@ get_de() {
         *"xfce4"*) de="XFCE4" ;;
         *"xfce5"*) de="XFCE5" ;;
         *"xfce"*)  de="XFCE" ;;
-        *"mate"*)  de="MATE"
+        *"mate"*)  de="MATE" ;;
     esac
 
     # Log that the function was run.


### PR DESCRIPTION
## Description

This PR adds more fallbacks for Desktop Environment detection. We now also check `$DESKTOP_SESSION`, `$MATE_DESKTOP_SESSION_ID` and `$GNOME_DESKTOP_SESSION_ID`.

This should fix MATE detection issues when MATE isn't started from a Display Manager. The `xprop` fallback doesn't work for MATE so this is necessary. 

These Environment Variables were taken from `/usr/bin/xdg-open` and we should cover all bases now when it comes to DE detection.

Closes #478 