### PR TITLE
Info: Add alignment options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,6 @@
 - **[@jorgegonzalez](https://github.com/jorgegonzalez)**
 
 
-## Collaborators
-
-
 ## IRC
 
 Neofetch now has an irc channel at `#neofetch` on Freenode. If you have any questions, issues or ideas feel free to join the irc channel and I'll be happy to assist you. I know that we've already got the gitter chat but hopefully this makes things easier for those without a github account. :)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - **[@jorgegonzalez](https://github.com/jorgegonzalez)**
 
 
+## Collaborators
+
+
 ## IRC
 
 Neofetch now has an irc channel at `#neofetch` on Freenode. If you have any questions, issues or ideas feel free to join the irc channel and I'll be happy to assist you. I know that we've already got the gitter chat but hopefully this makes things easier for those without a github account. :)

--- a/config/config
+++ b/config/config
@@ -61,6 +61,7 @@ print_info() {
 # -------------
 # OS            : Arch Linux
 # Kernel        : Linux 4.9-ARCH
+# Terminal Font : Lemon
 # Uptime        : 1 hour, 41 minutes
 #
 # RIGHT
@@ -69,6 +70,7 @@ print_info() {
 # -------------
 #            OS : Arch Linux
 #        Kernel : Linux 4.9-ARCH
+# Terminal Font : Lemon
 #        Uptime : 1 hour, 41 minutes
 #
 # OFF
@@ -77,6 +79,7 @@ print_info() {
 # -------------
 # OS: Arch Linux
 # Kernel: Linux 4.9-ARCH
+# Terminal Font: Lemon
 # Uptime: 1 hour, 41 minutes
 align_info="off"
 

--- a/config/config
+++ b/config/config
@@ -80,13 +80,6 @@ print_info() {
 # Uptime: 1 hour, 41 minutes
 align_info="off"
 
-# Align amount
-# Default:  '15'
-# Values:   'num'
-# Flag:     --align_amount
-# NOTE: Raise this value if the alignment bugs out. Otherwise, leave it.
-align_amount=14
-
 
 # Kernel
 

--- a/config/config
+++ b/config/config
@@ -85,7 +85,7 @@ align_info="off"
 # Values:   'num'
 # Flag:     --align_amount
 # NOTE: Raise this value if the alignment bugs out. Otherwise, leave it.
-align_amount=15
+align_amount=14
 
 
 # Kernel

--- a/config/config
+++ b/config/config
@@ -47,6 +47,47 @@ print_info() {
 }
 
 
+# Info alignment
+
+# Align the info into columns.
+# Default:  'off'
+# Values:   'left', 'right', 'off'
+# Flag:     --align_info
+# Example:
+#
+# LEFT
+#
+# user@hostname
+# -------------
+# OS            : Arch Linux
+# Kernel        : Linux 4.9-ARCH
+# Uptime        : 1 hour, 41 minutes
+#
+# RIGHT
+#
+# user@hostname
+# -------------
+#            OS : Arch Linux
+#        Kernel : Linux 4.9-ARCH
+#        Uptime : 1 hour, 41 minutes
+#
+# OFF
+#
+# user@hostname
+# -------------
+# OS: Arch Linux
+# Kernel: Linux 4.9-ARCH
+# Uptime: 1 hour, 41 minutes
+align_info="off"
+
+# Align amount
+# Default:  '15'
+# Values:   'num'
+# Flag:     --align_amount
+# NOTE: Raise this value if the alignment bugs out. Otherwise, leave it.
+align_amount=15
+
+
 # Kernel
 
 

--- a/neofetch
+++ b/neofetch
@@ -1903,17 +1903,18 @@ get_image_backend() {
     # Fallback to ascii mode if imagemagick isn't installed.
     type -p convert >/dev/null 2>&1 || image_backend="ascii"
 
+    # If image source is ascii fallback to ascii
+    if [[ "$image_source" == "ascii" ]]; then
+        image_backend="ascii"
+        err "Image: \$image_source set to 'ascii', falling back to ascii mode. "
+        err "Image: Change \$image_source to another value to use image mode."
+    fi
+
     case "${image_backend:=image}" in
         "image")
             case "$image_source" in
                 "wall"*) get_wallpaper 2>/dev/null ;;
                 "off") image_backend="off"; return ;;
-                "ascii")
-                    to_ascii "Image: \$image_source set to 'ascii', falling back to ascii mode. "
-                    err "Image: Change \$image_source to another value to use image mode."
-                    return
-                ;;
-
                 *)
                     if [[ -d "$image_source" ]]; then
                         files=("${image_source%/}"/*.{png,jpg,jpeg})

--- a/neofetch
+++ b/neofetch
@@ -2439,6 +2439,9 @@ scrot_program() {
 # TEXT FORMATTING
 
 info() {
+    # If get_func doesn't exist, stop here.
+    ! type -p "get_${2:-$1}" >/dev/null 2>&1 && return
+
     # $1 is the subtitle
     subtitle="$1"
 
@@ -2450,7 +2453,7 @@ info() {
     "get_${2:-$1}" 2>/dev/null
 
     # If prin was used in the function, stop here.
-    [[ "$prin" ]] && { unset prin; return; }
+    [[ "$prin" ]] && { unset -v prin; return; }
 
     # Update the variable
     output="${2:-$1}"

--- a/neofetch
+++ b/neofetch
@@ -2449,20 +2449,16 @@ info() {
     # Call the function.
     "get_${2:-$1}" 2>/dev/null
 
+    # If prin was used in the function, stop here.
+    [[ "$prin" ]] && { unset prin; return; }
+
     # Update the variable
     output="${2:-$1}"
     output="$(trim "${!output}")"
 
-    # If prin was used in the function, stop here.
-    [[ "$prin" ]] && \
-        unset prin && return
-
     # If the output is empty, don't print anything.
     [[ -z "${output// }" ]] && \
-        err "Info: Couldn't detect $subtitle." && return
-
-    # Align the info
-    subtitle="$(align_info "$subtitle")"
+        { err "Info: Couldn't detect $subtitle."; return; }
 
     case "$1" in
         "title")
@@ -2474,6 +2470,9 @@ info() {
         "underline") string="${underline_color}${output}" ;;
 
         *)
+            # Align the info
+            subtitle="$(align_info "$subtitle")"
+
             string="${subtitle_color}${bold}${subtitle}${reset}"
             string+="${colon_color}: ${info_color}${output}"
             length="$((${#subtitle} +  ${#output} + 2))"

--- a/neofetch
+++ b/neofetch
@@ -2456,6 +2456,12 @@ info() {
     [[ -z "${output// }" ]] && \
         err "Info: Couldn't detect $subtitle." && return
 
+    # Align the info.
+    case "$align_info" in
+        "left")  subtitle="$(printf "%s%$((align_amount - ${#subtitle}))s" "$subtitle")" ;;
+        "right") subtitle="$(printf "%$((align_amount - ${#subtitle}))s%s" " " "$subtitle ")" ;;
+    esac
+
     case "$1" in
         "title")
             string="${title_color}${bold}${output}"
@@ -3080,6 +3086,10 @@ usage() { printf "%s" "
     --birthday_time on/off      Enable/Disable showing the time in birthday output
     --birthday_format format    Format the birthday output. (Uses 'date' cmd format)
 
+    Alignment:
+    --align_info left/right/off Align the info into columns.
+    --align_amount num          Alignment padding. Raise this if you have issues with the default.
+
     Text Formatting:
     --colors x x x x x x        Changes the text colors in this order:
                                 title, @, underline, subtitle, colon, info
@@ -3215,6 +3225,10 @@ get_args() {
                     esac
                 done
             ;;
+
+            # Alignment
+            "--align_info") align_info="$2" ;;
+            "--align_amount") align_amount="$2" ;;
 
             # Text Colors
             "--colors")

--- a/neofetch
+++ b/neofetch
@@ -2586,9 +2586,11 @@ align_info() {
 }
 
 get_subtitle_length() {
-    subtitle_length="on"
-    print_info
-    unset subtitle_length
+    if [[ "${align_info:-off}" != "$off" ]]; then
+        subtitle_length="on"
+        print_info
+        unset -v subtitle_length
+    fi
 }
 
 count_subtitle() {

--- a/neofetch
+++ b/neofetch
@@ -2440,14 +2440,16 @@ scrot_program() {
 
 info() {
     # If get_func doesn't exist, stop here.
-    ! type -p "get_${2:-$1}" >/dev/null 2>&1 && return
+    type -p "get_${2:-$1}" >/dev/null 2>&1 || return
 
     # $1 is the subtitle
     subtitle="$1"
 
     # Log the subtitle size
-    [[ "$subtitle_length" == "on" ]] && \
-        { count_subtitle "${#subtitle}"; return; }
+    if [[ "$subtitle_length" == "on" ]]; then
+        [[ "$2" ]] && count_subtitle "${#subtitle}"
+        return
+    fi
 
     # Call the function.
     "get_${2:-$1}" 2>/dev/null
@@ -2497,8 +2499,11 @@ prin() {
     string="${2:+: $2}"
 
     # Log the subtitle size
-    [[ "$subtitle_length" == "on" ]] && \
-        { count_subtitle "${#subtitle}"; return; }
+    # Log the subtitle size
+    if [[ "$subtitle_length" == "on" ]]; then
+        [[ "$2" ]] && count_subtitle "${#subtitle}"
+        return
+    fi
 
     # If $2 doesn't exist we format $1 as info
     [[ -z "$2" ]] && local subtitle_color="$info_color"
@@ -2580,7 +2585,7 @@ uppercase() {
 align_info() {
     case "$align_info" in
         "left")  printf "%s%$((subtitle_max_length - ${#1}))s" "$1 " ;;
-        "right") printf "%$((subtitle_max_length - ${#1} + 1))s%s" " " "$1 " ;;
+        "right") printf "%$((subtitle_max_length - ${#1} + 1))s%s" "" "$1 " ;;
         *) printf "%s" "$1" ;;
     esac
 }

--- a/neofetch
+++ b/neofetch
@@ -2457,11 +2457,8 @@ info() {
     [[ -z "${output// }" ]] && \
         err "Info: Couldn't detect $subtitle." && return
 
-    # Align the info.
-    case "$align_info" in
-        "left")  subtitle="$(printf "%s%$((align_amount - ${#subtitle}))s" "$subtitle")" ;;
-        "right") subtitle="$(printf "%$((align_amount - ${#subtitle}))s%s" " " "$subtitle ")" ;;
-    esac
+    # Align the info
+    subtitle="$(align_info "$subtitle")"
 
     case "$1" in
         "title")
@@ -2496,17 +2493,22 @@ info() {
 }
 
 prin() {
-    string="${1//$'\033[0m'}${2:+: $2}"
+    subtitle="${1//$'\033[0m'}"
+    string="${2:+: $2}"
 
     # If $2 doesn't exist we format $1 as info
     [[ -z "$2" ]] && local subtitle_color="$info_color"
 
-    # Format the output
-    string="${string/:/${reset}${colon_color}:${info_color}}"
-    string="${subtitle_color}${bold}${string}"
-
     # Trim whitespace
     string="$(trim "$string")"
+
+    # Align the info
+    subtitle="$(align_info "$subtitle")"
+
+    # Format the output
+    string="${subtitle}${string}"
+    string="${string/:/${reset}${colon_color}:${info_color}}"
+    string="${subtitle_color}${bold}${string}"
 
     # Print the info
     printf "%b\n" "\033[${text_padding}C${zws}${string}${reset} "
@@ -2575,6 +2577,14 @@ trim_quotes() {
 
 uppercase() {
     (("$bash_version" >= 4)) && printf "%s" "${1^}"
+}
+
+align_info() {
+    case "$align_info" in
+        "left")  printf "%s%$((align_amount - ${#1}))s" "$1 " ;;
+        "right") printf "%$((align_amount - ${#1}))s%s" " " "$1 " ;;
+        *) printf "%s" "$1" ;;
+    esac
 }
 
 # COLORS

--- a/neofetch
+++ b/neofetch
@@ -2442,6 +2442,10 @@ info() {
     # $1 is the subtitle
     subtitle="$1"
 
+    # Log the subtitle size
+    [[ "$subtitle_length" == "on" ]] && \
+        { count_subtitle "${#subtitle}"; return; }
+
     # Call the function.
     "get_${2:-$1}" 2>/dev/null
 
@@ -2495,6 +2499,10 @@ info() {
 prin() {
     subtitle="${1//$'\033[0m'}"
     string="${2:+: $2}"
+
+    # Log the subtitle size
+    [[ "$subtitle_length" == "on" ]] && \
+        { count_subtitle "${#subtitle}"; return; }
 
     # If $2 doesn't exist we format $1 as info
     [[ -z "$2" ]] && local subtitle_color="$info_color"
@@ -2581,10 +2589,21 @@ uppercase() {
 
 align_info() {
     case "$align_info" in
-        "left")  printf "%s%$((align_amount - ${#1}))s" "$1 " ;;
-        "right") printf "%$((align_amount - ${#1}))s%s" " " "$1 " ;;
+        "left")  printf "%s%$((subtitle_max_length - ${#1}))s" "$1 " ;;
+        "right") printf "%$((subtitle_max_length - ${#1} + 1))s%s" " " "$1 " ;;
         *) printf "%s" "$1" ;;
     esac
+}
+
+get_subtitle_length() {
+    subtitle_length="on"
+    print_info
+    unset subtitle_length
+}
+
+count_subtitle() {
+    (( "$1" > "${subtitle_max_length:-0}" )) && \
+        subtitle_max_length="$1"
 }
 
 # COLORS
@@ -3099,7 +3118,6 @@ usage() { printf "%s" "
 
     Alignment:
     --align_info left/right/off Align the info into columns.
-    --align_amount num          Alignment padding. Raise this if you have issues with the default.
 
     Text Formatting:
     --colors x x x x x x        Changes the text colors in this order:
@@ -3239,7 +3257,6 @@ get_args() {
 
             # Alignment
             "--align_info") align_info="$2" ;;
-            "--align_amount") align_amount="$2" ;;
 
             # Text Colors
             "--colors")
@@ -3382,6 +3399,7 @@ main() {
     get_image_backend
     old_functions
     get_cache_dir
+    get_subtitle_length
     print_info 2>/dev/null
     dynamic_prompt
 

--- a/neofetch.1
+++ b/neofetch.1
@@ -107,9 +107,6 @@ Format the birthday output. (Uses 'date' cmd format)
 .TP
 .B \--align_info 'left/right/off'
 Align the info into columns.
-.TP
-.B \--align_amount num
-Alignment padding. Raise this if you have issues with the default.
 
 .SH TEXT FORMATTING
 .TP

--- a/neofetch.1
+++ b/neofetch.1
@@ -103,6 +103,14 @@ Enable/Disable showing the time in birthday output
 .B \--birthday_format 'format'
 Format the birthday output. (Uses 'date' cmd format)
 
+.SH ALIGNMENT
+.TP
+.B \--align_info 'left/right/off'
+Align the info into columns.
+.TP
+.B \--align_amount num
+Alignment padding. Raise this if you have issues with the default.
+
 .SH TEXT FORMATTING
 .TP
 .B \--colors x x x x x x


### PR DESCRIPTION
## Description

This PR adds options to align the info output into columns! This works by specifying a max width for the subtitle `$align_amount` and then subtracting the length of the subtitle from that `${#subtitle}`.

`$align_amount` has to be hardcoded since we won't know the length of the longest subtitle when we start displaying info. The default amount works for all of the default subtitles in the config file and if there are any issues the user just has to up the value of `$align_amount`. 

This is mentioned in the config file and docs so it shouldn't be an issue.

Examples:

```sh
# LEFT

user@hostname
-------------
OS            : Arch Linux
Kernel        : Linux 4.9-ARCH
Uptime        : 1 hour, 41 minutes

# RIGHT

user@hostname
-------------
           OS : Arch Linux
       Kernel : Linux 4.9-ARCH
       Uptime : 1 hour, 41 minutes
```

## Features

- Align the info output into columns.

## Issues

- [x] `$align_amount` must be hardcoded since we don't know the max subtitle width.
- [x] `--disable` doesn't update max subtitle length.

## Testing

```sh
neofetch --align_info left
neofetch --align_info right
```

