### PR TITLE
Info: Remove useless blocks

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2481,12 +2481,6 @@ info() {
 
     # Calculate info height
     info_height="$((info_height+=1))"
-
-    # Fix rendering issues with w3m and lines that
-    # wrap to the next line by adding a max line
-    # length.
-    [[ "$image_backend" == "image" ]] && \
-        string="$(printf "%.$((columns - text_padding - gap))s" "$string")"
 }
 
 prin() {
@@ -2507,12 +2501,6 @@ prin() {
 
     # Calculate info height
     info_height="$((info_height+=1))"
-
-    # Fix rendering issues with w3m and lines that
-    # wrap to the next line by adding a max line
-    # length.
-    [[ "$image_backend" == "image" ]] && \
-        string="$(printf "%.$((columns - text_padding - gap))s" "$string")"
 
     # Tell info() that prin() was used.
     prin=1


### PR DESCRIPTION
## Description

These blocks I'm removing don't actually do anything afaik, they update the `$string` variable **after** its been printed rendering it useless. `$string` isn't referenced anywhere outside `info()` and `prin()` either.



