### PR TITLE
General: Delete most of info() and instead call prin()

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3331,4 +3331,3 @@ main() {
 }
 
 main "$@"
-# Print it immediatly since it's a special function.

--- a/neofetch
+++ b/neofetch
@@ -2425,9 +2425,6 @@ scrot_program() {
 # TEXT FORMATTING
 
 info() {
-    # $1 is the subtitle
-    subtitle="$1"
-
     # Call the function.
     "get_${2:-$1}" 2>/dev/null
 
@@ -2435,61 +2432,54 @@ info() {
     output="${2:-$1}"
     output="$(trim "${!output}")"
 
-    # If prin was used in the function, stop here.
-    [[ "$prin" ]] && \
-        unset prin && return
-
     # If the output is empty, don't print anything.
     [[ -z "${output// }" ]] && \
-        err "Info: Couldn't detect $subtitle." && return
+        { err "Info: Couldn't detect ${1}."; return; }
 
     case "$1" in
         "title")
             string="${title_color}${bold}${output}"
             string="${string/@/${at_color}@${title_color}${bold}}"
             length="${#output}"
+            prin "$string"
         ;;
 
-        "underline") string="${underline_color}${output}" ;;
+        "underline")
+            string="${underline_color}${output}"
+            prin "$string"
+        ;;
 
         *)
-            string="${subtitle_color}${bold}${subtitle}${reset}"
-            string+="${colon_color}: ${info_color}${output}"
-            length="$((${#subtitle} +  ${#output} + 2))"
+            if [[ "$2" && "${output// }" ]]; then
+                length="$((${#1} + ${#output} + 2))"
+                prin "$1" "$output"
+
+            elif [[ "${output// }" ]]; then
+                length="${#output}"
+                prin "$output"
+            fi
         ;;
     esac
-
-    # If there's no subtitle don't print one
-    [[ -z "$2" ]] && string="${string/*: }"
-
-    # Print the string
-    printf "%b\n" "\033[${text_padding}C${zws}${string}${reset} "
-
-    # Calculate info height
-    info_height="$((info_height+=1))"
 }
 
 prin() {
-    string="${1//$'\033[0m'}${2:+: $2}"
+    subtitle="${1//$'\033[0m'}"
+    string="${2:+: $2}"
 
     # If $2 doesn't exist we format $1 as info
     [[ -z "$2" ]] && local subtitle_color="$info_color"
 
     # Format the output
+    string="$(trim "$string")"
+    string="${subtitle}${string}"
     string="${string/:/${reset}${colon_color}:${info_color}}"
     string="${subtitle_color}${bold}${string}"
-
-    # Trim whitespace
-    string="$(trim "$string")"
 
     # Print the info
     printf "%b\n" "\033[${text_padding}C${zws}${string}${reset} "
 
     # Calculate info height
     info_height="$((info_height+=1))"
-
-    # Tell info() that prin() was used.
-    prin=1
 }
 
 get_underline() {

--- a/neofetch
+++ b/neofetch
@@ -273,7 +273,11 @@ get_model() {
 }
 
 get_title() {
-    title="${USER:-$(whoami || printf "%s" "${HOME/*\/}")}@${HOSTNAME:-$(hostname)}"
+    # Get the info.
+    user="${USER:-$(whoami || printf "%s" "${HOME/*\/}")}"
+    hostname="${HOSTNAME:-$(hostname)}"
+    title="${title_color}${bold}${user}${at_color}@${title_color}${bold}${hostname}"
+    length="$((${#user} + ${#hostname} + 1))"
 }
 
 get_kernel() {
@@ -2437,23 +2441,10 @@ info() {
         prin "$1" "$output"
 
     elif [[ "${output// }" ]]; then
-        case "$1" in
-            "title")
-                string="${title_color}${bold}${output}"
-                string="${string/@/${at_color}@${title_color}${bold}}"
-            ;;
+        [[ -z "$length" ]] && length="${#output}"
+        prin "$output"
 
-            "underline")
-                string="${underline_color}${output}"
-            ;;
-
-            *) string="$output" ;;
-        esac
-
-        length="${#output}"
-        prin "$string"
     else
-
         err "Info: Couldn't detect ${1}."
     fi
 }
@@ -2478,7 +2469,8 @@ prin() {
 get_underline() {
     if [[ "$underline_enabled" == "on" ]]; then
         underline="$(printf %"$length"s)"
-        underline="${underline// /$underline_char}"
+        underline="${underline_color}${underline// /$underline_char}"
+        unset -v length
     fi
 }
 
@@ -3339,3 +3331,4 @@ main() {
 }
 
 main "$@"
+# Print it immediatly since it's a special function.

--- a/neofetch
+++ b/neofetch
@@ -2432,7 +2432,7 @@ info() {
     "get_${2:-$1}" 2>/dev/null
 
     # If the get_func function called 'prin' directly, stop here.
-    (( "$prin" == 1 )) && return
+    [[ "$prin" ]] && return
 
     # Update the variable
     output="$(trim "${!2:-${!1}}")"

--- a/neofetch
+++ b/neofetch
@@ -1270,7 +1270,6 @@ get_song() {
         else
             prin "$subtitle" "$song"
         fi
-        unset song
     fi
 }
 
@@ -1680,8 +1679,6 @@ get_battery() {
 
                 prin "${subtitle}${bat: -1}" "$battery"
             done
-
-            unset battery
             return
         ;;
 
@@ -2429,12 +2426,17 @@ scrot_program() {
 # TEXT FORMATTING
 
 info() {
+    # Make sure that $prin is unset.
+    unset -v prin
+
     # Call the function.
     "get_${2:-$1}" 2>/dev/null
 
+    # If the get_func function called 'prin' directly, stop here.
+    (( "$prin" == 1 )) && return
+
     # Update the variable
-    output="${2:-$1}"
-    output="$(trim "${!output}")"
+    output="$(trim "${!2:-${!1}}")"
 
     if [[ "$2" && "${output// }" ]]; then
         length="$((${#1} + ${#output} + 2))"
@@ -2464,6 +2466,9 @@ prin() {
 
     # Calculate info height
     info_height="$((info_height+=1))"
+
+    # Log that prin was used.
+    prin=1
 }
 
 get_underline() {

--- a/neofetch
+++ b/neofetch
@@ -2459,14 +2459,11 @@ info() {
 }
 
 prin() {
-    subtitle="${1//$'\033[0m'}"
-    string="${2:+: $2}"
-
     # If $2 doesn't exist we format $1 as info
     [[ -z "$2" ]] && local subtitle_color="$info_color"
 
     # Format the output
-    string="${subtitle}${string}"
+    string="${1//$'\033[0m'}${2:+: $2}"
     string="$(trim "$string")"
     string="${string/:/${reset}${colon_color}:${info_color}}"
     string="${subtitle_color}${bold}${string}"

--- a/neofetch
+++ b/neofetch
@@ -273,7 +273,6 @@ get_model() {
 }
 
 get_title() {
-    # Get the info.
     user="${USER:-$(whoami || printf "%s" "${HOME/*\/}")}"
     hostname="${HOSTNAME:-$(hostname)}"
     title="${title_color}${bold}${user}${at_color}@${title_color}${bold}${hostname}"

--- a/neofetch
+++ b/neofetch
@@ -2432,34 +2432,30 @@ info() {
     output="${2:-$1}"
     output="$(trim "${!output}")"
 
-    # If the output is empty, don't print anything.
-    [[ -z "${output// }" ]] && \
-        { err "Info: Couldn't detect ${1}."; return; }
+    if [[ "$2" && "${output// }" ]]; then
+        length="$((${#1} + ${#output} + 2))"
+        prin "$1" "$output"
 
-    case "$1" in
-        "title")
-            string="${title_color}${bold}${output}"
-            string="${string/@/${at_color}@${title_color}${bold}}"
-            length="${#output}"
-            prin "$string"
-        ;;
+    elif [[ "${output// }" ]]; then
+        case "$1" in
+            "title")
+                string="${title_color}${bold}${output}"
+                string="${string/@/${at_color}@${title_color}${bold}}"
+            ;;
 
-        "underline")
-            string="${underline_color}${output}"
-            prin "$string"
-        ;;
+            "underline")
+                string="${underline_color}${output}"
+            ;;
 
-        *)
-            if [[ "$2" && "${output// }" ]]; then
-                length="$((${#1} + ${#output} + 2))"
-                prin "$1" "$output"
+            *) string="$output" ;;
+        esac
 
-            elif [[ "${output// }" ]]; then
-                length="${#output}"
-                prin "$output"
-            fi
-        ;;
-    esac
+        length="${#output}"
+        prin "$string"
+    else
+
+        err "Info: Couldn't detect ${1}."
+    fi
 }
 
 prin() {
@@ -2470,8 +2466,8 @@ prin() {
     [[ -z "$2" ]] && local subtitle_color="$info_color"
 
     # Format the output
-    string="$(trim "$string")"
     string="${subtitle}${string}"
+    string="$(trim "$string")"
     string="${string/:/${reset}${colon_color}:${info_color}}"
     string="${subtitle_color}${bold}${string}"
 


### PR DESCRIPTION
## Description

This PR removes almost all of the duplication between `info()` and `prin()` by making `info()` use `prin()` to do the formatting of the output.

This PR also moves the formatting for `get_title()` to `get_title()` and the formatting for `get_underline()` to `get_underline()`. `info()` and `prin()` are now general functions with no special exceptions for functions.

## Issues

- [ ] none yet.

## TODO

- [x] Look at ways to reduce the size further.
- [ ] Testing

