### PR TITLE
Info: Add alignment v2

### DIFF
--- a/config/config
+++ b/config/config
@@ -47,6 +47,43 @@ print_info() {
 }
 
 
+# Info alignment
+
+# Align the info into columns.
+# Default:  'off'
+# Values:   'left', 'right', 'off'
+# Flag:     --align_info
+# Example:
+#
+# LEFT
+#
+# user@hostname
+# -------------
+# OS            : Arch Linux
+# Kernel        : Linux 4.9-ARCH
+# Terminal Font : Lemon
+# Uptime        : 1 hour, 41 minutes
+#
+# RIGHT
+#
+# user@hostname
+# -------------
+#            OS : Arch Linux
+#        Kernel : Linux 4.9-ARCH
+# Terminal Font : Lemon
+#        Uptime : 1 hour, 41 minutes
+#
+# OFF
+#
+# user@hostname
+# -------------
+# OS: Arch Linux
+# Kernel: Linux 4.9-ARCH
+# Terminal Font: Lemon
+# Uptime: 1 hour, 41 minutes
+align_info="off"
+
+
 # Kernel
 
 

--- a/neofetch
+++ b/neofetch
@@ -2425,6 +2425,11 @@ scrot_program() {
 # TEXT FORMATTING
 
 info() {
+    # Log the subtitle size
+    type -p "get_${2:-$1}" >/dev/null 2>&1 && \
+    [[ "$subtitle_length" == "on" ]] && \
+        { count_subtitle "${#1}"; return; }
+
     # Make sure that $prin is unset.
     unset -v prin
 
@@ -2454,9 +2459,12 @@ prin() {
     # If $2 doesn't exist we format $1 as info
     [[ -z "$2" ]] && local subtitle_color="$info_color"
 
+    # Format subtitle
+    subtitle="${1//$'\033[0m'}"
+    [[ "$2" ]] && subtitle="$(align_info "$subtitle")"
+
     # Format the output
-    string="${1//$'\033[0m'}${2:+: $2}"
-    string="$(trim "$string")"
+    string="${subtitle}${2:+: $2}"
     string="${string/:/${reset}${colon_color}:${info_color}}"
     string="${subtitle_color}${bold}${string}"
 
@@ -2522,6 +2530,27 @@ trim_quotes() {
 
 uppercase() {
     (("$bash_version" >= 4)) && printf "%s" "${1^}"
+}
+
+align_info() {
+    case "$align_info" in
+        "left")  printf "%s%$((subtitle_max_length - ${#1}))s" "$1 " ;;
+        "right") printf "%$((subtitle_max_length - ${#1} + 1))s%s" "" "$1 " ;;
+        *) printf "%s" "$1" ;;
+    esac
+}
+
+get_subtitle_length() {
+    if [[ "${align_info:-off}" != "$off" ]]; then
+        subtitle_length="on"
+        print_info
+        unset -v subtitle_length
+    fi
+}
+
+count_subtitle() {
+    (( "$1" > "${subtitle_max_length:-0}" )) && \
+        subtitle_max_length="$1"
 }
 
 # COLORS
@@ -3009,7 +3038,7 @@ INFO
                                 in the output.
 
                                 NOTE: You can supply multiple args. eg. 'neofetch --disable cpu gpu disk shell'
-
+    --align_info left/right/off Align the info into columns.
     --os_arch on/off            Hide/Show OS architecture.
     --speed_type type           Change the type of cpu speed to display.
                                 Possible values: current, min, max, bios,
@@ -3236,6 +3265,7 @@ get_args() {
                     esac
                 done
             ;;
+            "--align_info") align_info="$2" ;;
 
             # Text Colors
             "--colors")
@@ -3379,6 +3409,7 @@ main() {
     get_image_backend
     old_functions
     get_cache_dir
+    get_subtitle_length
     print_info 2>/dev/null
     dynamic_prompt
 

--- a/neofetch.1
+++ b/neofetch.1
@@ -17,6 +17,8 @@ Allows you to disable an info line from appearing
 in the output.
 .IP
 NOTE: You can supply multiple args. eg. 'neofetch \fB\-\-disable\fR cpu gpu disk shell'
+.HP
+\fB\-\-align_info\fR left/right/off Align the info into columns.
 .TP
 \fB\-\-os_arch\fR on/off
 Hide/Show OS architecture.


### PR DESCRIPTION
## Description

Same PR as before but fixed merge conflicts with the new `info()` and `prin()` functions.

Examples:

```sh
# LEFT

user@hostname
-------------
OS            : Arch Linux
Kernel        : Linux 4.9-ARCH
Uptime        : 1 hour, 41 minutes

# RIGHT

user@hostname
-------------
           OS : Arch Linux
       Kernel : Linux 4.9-ARCH
       Uptime : 1 hour, 41 minutes
```

## Features

- Align the info output into columns.

## Issues

- [x] `$align_amount` must be hardcoded since we don't know the max subtitle width.
- [x] `--disable` doesn't update max subtitle length.
- [ ] This requires a 'hack' to get working.
- [ ] Max subtitle calculation doesn't check to see if function failed.

## Testing

```sh
neofetch --align_info left
neofetch --align_info right
```

Old PR: https://github.com/dylanaraps/neofetch/issues/524