### PR TITLE
Uptime: Rewrite part of uptime

### DIFF
--- a/config/config
+++ b/config/config
@@ -92,7 +92,7 @@ os_arch="on"
 
 # Shorten the output of the uptime function
 #
-# Default: 'off'
+# Default: 'on'
 # Values:  'on', 'off', 'tiny'
 # Flag:    --uptime_shorthand
 #
@@ -100,7 +100,7 @@ os_arch="on"
 # on:   '2 days, 10 hours, 3 mins'
 # off:  '2 days, 10 hours, 3 minutes'
 # tiny: '2d 10h 3m'
-uptime_shorthand="off"
+uptime_shorthand="on"
 
 
 # Shell

--- a/neofetch
+++ b/neofetch
@@ -329,24 +329,22 @@ get_uptime() {
 
             days="$((seconds / 60 / 60 / 24)) days"
             hours="$((seconds / 60 / 60 % 24)) hours"
-            minutes="$((seconds / 60 % 60)) minutes"
+            mins="$((seconds / 60 % 60)) minutes"
 
-            case "$days" in
-                "0 days") unset days ;;
-                "1 days") days="${days/s}" ;;
-            esac
+            # Format the days, hours and minutes.
+            strip_date() {
+                case "$1" in
+                    "0 "*) unset "${1/* }" ;;
+                    "1 "*) printf "%s" "${1/s}" ;;
+                    *)     printf "%s" "$1" ;;
+                esac
+            }
 
-            case "$hours" in
-                "0 hours") unset hours ;;
-                "1 hours") hours="${hours/s}" ;;
-            esac
+            days="$(strip_date "$days")"
+            hours="$(strip_date "$hours")"
+            mins="$(strip_date "$mins")"
 
-            case "$minutes" in
-                "0 minutes") unset minutes ;;
-                "1 minutes") minutes="${minutes/s}" ;;
-            esac
-
-            uptime="${days:+$days, }${hours:+$hours, }${minutes}"
+            uptime="${days:+$days, }${hours:+$hours, }${mins}"
             uptime="${uptime%', '}"
             uptime="${uptime:-${seconds} seconds}"
         ;;


### PR DESCRIPTION
## Features

- `$minutes` --> `$mins`
    - This makes the variable the same length as the others.
- Moved the 3 duplicate case statements to a function. `strip_date()`
- Changed default `uptime_shorthand` value to `on`.
    - `on` just makes `minutes` --> `mins` in the output.
    - I've seen screenshots of people with weeks of uptime and they still have this set to `off` so the line is extremely long. This is a better default imo.


