### PR TITLE
Song: Cleanup get_song()

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1152,21 +1152,20 @@ get_song() {
     }
 
     case "${player/*\/}" in
-        "mpd"*)
-            song="$(mpc current)"
-            state="$(mpc | awk -F '\\[|\\]' '/\[/ {printf $2}')"
-        ;;
+        "mpd"*)         song="$(mpc current)" ;;
+        "mocp"*)        song="$(mocp -Q "%artist - %song")" ;;
+        "google play"*) song="$(gpmdp-remote current)" ;;
+        "rhythmbox"*)   song="$(rhythmbox-client --print-playing)" ;;
+        "deadbeef"*)    song="$(deadbeef --nowplaying '%a - %t')" ;;
+        "audacious"*)   song="$(audtool current-song)" ;;
+        "gnome-music"*) get_song_dbus "GnomeMusic" ;;
+        "lollypop"*)    get_song_dbus "Lollypop" ;;
+        "clementine"*)  get_song_dbus "clementine" ;;
 
         "cmus"*)
-            IFS=$'\n'
-            cmus=($(cmus-remote -Q | grep -F -e "tag artist " -e "tag title" -e "status" | sort))
-            song="${cmus[1]/tag artist } - ${cmus[2]/tag title }"
-            state="${cmus[0]/status }"
-        ;;
-
-        "mocp"*)
-            song="$(mocp -Q "%artist - %song")"
-            state="$(mocp -Q "%state")"
+            artist="$(cmus-remote -Q | grep -F "tag artist ")"
+            title="$(cmus-remote -Q | grep -F "tag title")"
+            song="${artist/tag artist} - ${title/tag title}"
         ;;
 
         "spotify"*)
@@ -1175,35 +1174,18 @@ get_song() {
 
                 "Mac OS X")
                     song="$(osascript -e 'tell application "Spotify" to artist of current track as string & " - " & name of current track as string')"
-                    state="$(osascript -e 'tell application "Spotify" to player state as string')"
                 ;;
             esac
         ;;
 
-        "google play"*)
-            song="$(gpmdp-remote current)"
-            state="$(gpmdp-remote status)"
-        ;;
-
         "itunes"*)
             song="$(osascript -e 'tell application "iTunes" to artist of current track as string & " - " & name of current track as string')"
-            state="$(osascript -e 'tell application "iTunes" to player state as string')"
-        ;;
-
-        "rhythmbox"*)
-            song="$(rhythmbox-client --print-playing)"
-            # Thanks dbus
-            state="$(dbus-send --print-reply --dest=org.mpris.MediaPlayer2.rhythmbox /org/mpris/MediaPlayer2 \
-                     org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string: 'PlayBackStatus' |\
-                     awk -F 'string "' '{printf $2}')"
-            state="$(trim_quotes "$state")"
         ;;
 
         "banshee"*)
             artist="$(banshee --query-artist | awk -F':' '{print $2}')"
             title="$(banshee --query-title | awk -F':' '{print $2}')"
             song="$artist - $title"
-            state="$(banshee --query-current-state | awk -F':' '{print $2}')"
         ;;
 
         "amarok"*)
@@ -1212,30 +1194,11 @@ get_song() {
             song="$artist - $title"
         ;;
 
-        "deadbeef"*)
-            song="$(deadbeef --nowplaying '%a - %t')"
-        ;;
-
-        "audacious"*)
-            song="$(audtool current-song)"
-        ;;
-
-        "gnome-music"*) get_song_dbus "GnomeMusic" ;;
-        "lollypop"*) get_song_dbus "Lollypop" ;;
-        "clementine"*) get_song_dbus "clementine" ;;
-
         "pragha"*)
             artist="$(pragha -c | awk -F':' '/artist/ {print $2}')"
             title="$(pragha -c | awk -F':' '/title/ {print $2}')"
             song="$artist - $title"
         ;;
-
-        *) song="Not Playing" ;;
-    esac
-
-    case "$state" in
-        "pau"*) song="Paused" ;;
-        "sto"*) song="Stopped" ;;
     esac
 
     # Display Artist and Title on seperate lines.

--- a/neofetch
+++ b/neofetch
@@ -1219,32 +1219,16 @@ get_song() {
             song="$(audtool current-song)"
         ;;
 
-        "gnome-music"*)
+        "gnome-music"* | "lollypop"* | "clementine"*)
+            case "$player" in
+                "gnome-music"*) player="GnomeMusic" ;;
+                "lollypop"*) player="Lollypop" ;;
+                "clementine"*) player="clementine" ;;
+            esac
+
             # Hello dbus my old friend.
             song="$(\
-                dbus-send --print-reply --dest=org.mpris.MediaPlayer2.GnomeMusic /org/mpris/MediaPlayer2 \
-                org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Metadata' |\
-                awk -F 'string "' '/string|array/ {printf "%s",$2; next}{print ""}' |\
-                awk -F '"' '/artist|title/ {printf $2 " - "}'
-            )"
-            song="${song% - }"
-        ;;
-
-        "lollypop"*)
-            # Hello dbus my old friend.
-            song="$(\
-                dbus-send --print-reply --dest=org.mpris.MediaPlayer2.Lollypop /org/mpris/MediaPlayer2 \
-                org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Metadata' |\
-                awk -F 'string "' '/string|array/ {printf "%s",$2; next}{print ""}' |\
-                awk -F '"' '/artist|title/ {printf $2 " - "}'
-            )"
-            song="${song% - }"
-        ;;
-
-        "clementine"*)
-            # dbus
-            song="$(
-                dbus-send --print-reply --dest=org.mpris.clementine /org/mpris/MediaPlayer2 \
+                dbus-send --print-reply --dest=org.mpris.MediaPlayer2."${player}" /org/mpris/MediaPlayer2 \
                 org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Metadata' |\
                 awk -F 'string "' '/string|array/ {printf "%s",$2; next}{print ""}' |\
                 awk -F '"' '/artist|title/ {printf $2 " - "}'

--- a/neofetch
+++ b/neofetch
@@ -1139,6 +1139,18 @@ get_song() {
     # This is absurdly long.
     player="$(ps x | awk '!(/awk|Helper|Cache/) && /mpd|cmus|mocp|spotify|Google Play|iTunes.app|rhythmbox|banshee|amarok|deadbeef|audacious|gnome-music|lollypop|clementine|pragha/ {printf $5 " " $6; exit}')"
 
+    get_song_dbus() {
+        # Multiple players use an almost identical dbus command to get the information.
+        # This function saves us including the same command throughtout the function.
+        song="$(\
+            dbus-send --print-reply --dest=org.mpris.MediaPlayer2."${1}" /org/mpris/MediaPlayer2 \
+            org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Metadata' |\
+            awk -F 'string "' '/string|array/ {printf "%s",$2; next}{print ""}' |\
+            awk -F '"' '/artist|title/ {printf $2 " - "}'
+        )"
+        song="${song% - }"
+    }
+
     case "${player/*\/}" in
         "mpd"*)
             song="$(mpc current)"
@@ -1159,18 +1171,7 @@ get_song() {
 
         "spotify"*)
             case "$os" in
-                "Linux")
-                    # Thanks dbus
-                    song="$(\
-                        dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 \
-                        org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Metadata' |\
-                        awk -F 'string "' '/string|array/ {printf "%s",$2; next}{print ""}' |\
-                        awk -F '"' '/artist|title/ {printf $2 " - "}'
-                    )"
-                    song="${song% - }"
-                    song="${song/'('*}"
-                    song="${song//'['*}"
-                ;;
+                "Linux") get_song_dbus "spotify" ;;
 
                 "Mac OS X")
                     song="$(osascript -e 'tell application "Spotify" to artist of current track as string & " - " & name of current track as string')"
@@ -1219,22 +1220,9 @@ get_song() {
             song="$(audtool current-song)"
         ;;
 
-        "gnome-music"* | "lollypop"* | "clementine"*)
-            case "$player" in
-                "gnome-music"*) player="GnomeMusic" ;;
-                "lollypop"*) player="Lollypop" ;;
-                "clementine"*) player="clementine" ;;
-            esac
-
-            # Hello dbus my old friend.
-            song="$(\
-                dbus-send --print-reply --dest=org.mpris.MediaPlayer2."${player}" /org/mpris/MediaPlayer2 \
-                org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Metadata' |\
-                awk -F 'string "' '/string|array/ {printf "%s",$2; next}{print ""}' |\
-                awk -F '"' '/artist|title/ {printf $2 " - "}'
-            )"
-            song="${song% - }"
-        ;;
+        "gnome-music"*) get_song_dbus "GnomeMusic" ;;
+        "lollypop"*) get_song_dbus "Lollypop" ;;
+        "clementine"*) get_song_dbus "clementine" ;;
 
         "pragha"*)
             artist="$(pragha -c | awk -F':' '/artist/ {print $2}')"


### PR DESCRIPTION
## Description

Title.

## Features

- Remove duplicate `dbus-send` commands.
- Remove state support.

## TODO

- [x] Testing
    - [x] GNOME-Music
    - [x] Lollypop
    - [x] Clementine
    - [x] Spotify
- [x] Possibly include Spotify on Linux.
    - [x] Move the `dbus` command to a function.

@konimex, can you test this out?