### PR TITLE
Disk: Rewrite get_disk()

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1552,6 +1552,8 @@ get_disk() {
     # Convert Terabytes to Gigabytes.
     if [[ "$disk_display" != "off" ]]; then
         disk_used="${disk_used/\.}"
+        disk_used="${disk_used/G}"
+        disk_total="${disk_total/G}"
         disk_total="${disk_total/\.}"
 
         [[ "${disk_used: -1}" == "T" ]] && \

--- a/neofetch
+++ b/neofetch
@@ -1542,8 +1542,8 @@ get_disk() {
     # Get the info for /
     disks=($(df -P -h /)) || { err "Disk: 'df' exited with error code 1"; return; }
 
-    disk_used="${disks[9]}"
-    disk_total="${disks[8]}"
+    disk_used="${disks[9]/i}"
+    disk_total="${disks[8]/i}"
     disk_total_per="(${disks[11]})"
 
     # Put it all together

--- a/neofetch
+++ b/neofetch
@@ -1550,10 +1550,14 @@ get_disk() {
     (( "${#disk_used}"  == 6 )) && disk_used="${disk_used:0:1}.${disk_used:1:1}TB"
     (( "${#disk_total}" == 6 )) && disk_total="${disk_total:0:1}.${disk_total:1:1}TB"
 
-    disk_total_per="${disks[11]}"
+    # Get the filesystem type
+    disk_type="[$(awk '$2 == "/" {printf $3; exit}' /etc/fstab)]"
+
+    # Get the usage percentage
+    disk_total_per="(${disks[11]})"
 
     # Put it all together
-    disk="${disk_used} / ${disk_total} (${disk_total_per})"
+    disk="${disk_used} / ${disk_total} ${disk_total_per} ${disk_type}"
 
     # Bar
     case "$disk_display" in

--- a/neofetch
+++ b/neofetch
@@ -1539,15 +1539,8 @@ get_term_font() {
 get_disk() {
     type -p df >/dev/null 2>&1 || { err "Disk requires 'df' to function. Install 'df' to get disk info."; return; }
 
-    # Split the info
-    case "$os" in
-        "Haiku") return ;;
-        "Mac OS X") df_flags=(-P -h /) ;;
-        *) df_flags=(-h /) ;;
-    esac
-
     # Get the info for /
-    disks=($(df "${df_flags[@]}")) || { err "Disk: 'df' exited with error code 1"; return; }
+    disks=($(df -P -h /)) || { err "Disk: 'df' exited with error code 1"; return; }
 
     disk_used="${disks[9]}"
     disk_total="${disks[8]}"

--- a/neofetch
+++ b/neofetch
@@ -1543,9 +1543,20 @@ get_disk() {
     disks=($(df -h /)) || { err "Disk: 'df' exited with error code 1"; return; }
 
     # Split the info
-    disk_used="${disks[9]}"
-    disk_total="${disks[8]}"
-    disk_total_per="(${disks[11]})"
+    case "$os" in
+        "Haiku") return ;;
+        "Mac OS X")
+            disk_used="${disks[10]}"
+            disk_total="${disks[9]}"
+            disk_total_per="(${disks[12]})"
+        ;;
+
+        *)
+            disk_used="${disks[9]}"
+            disk_total="${disks[8]}"
+            disk_total_per="(${disks[11]})"
+        ;;
+    esac
 
     # Put it all together
     disk="${disk_used} / ${disk_total} ${disk_total_per}"

--- a/neofetch
+++ b/neofetch
@@ -1539,19 +1539,19 @@ get_term_font() {
 get_disk() {
     type -p df >/dev/null 2>&1 || { err "Disk requires 'df' to function. Install 'df' to get disk info."; return; }
 
-    # Get the info for /
-    disks=($(df -h /)) || { err "Disk: 'df' exited with error code 1"; return; }
-
     # Split the info
     case "$os" in
         "Haiku") return ;;
-        "Mac OS X") ;;
-        *)
-            disk_used="${disks[9]}"
-            disk_total="${disks[8]}"
-            disk_total_per="(${disks[11]})"
-        ;;
+        "Mac OS X") df_flags=(-P -h /) ;;
+        *) df_flags=(-h /) ;;
     esac
+
+    # Get the info for /
+    disks=($(df "${df_flags[@]}")) || { err "Disk: 'df' exited with error code 1"; return; }
+
+    disk_used="${disks[9]}"
+    disk_total="${disks[8]}"
+    disk_total_per="(${disks[11]})"
 
     # Put it all together
     disk="${disk_used} / ${disk_total} ${disk_total_per}"

--- a/neofetch
+++ b/neofetch
@@ -1538,6 +1538,7 @@ get_term_font() {
 
 get_disk() {
     type -p df >/dev/null 2>&1 || { err "Disk requires 'df' to function. Install 'df' to get disk info."; return; }
+    [[ "$os" == "Haiku" ]] && { err "Disk doesn't work on Haiku due to the non-standard 'df'"; return; }
 
     # Get the info for /
     disks=($(df -P -h /)) || { err "Disk: 'df' exited with error code 1"; return; }
@@ -1549,26 +1550,12 @@ get_disk() {
     # Put it all together
     disk="${disk_used} / ${disk_total} ${disk_total_per}"
 
-    # Convert Terabytes to Gigabytes.
-    if [[ "$disk_display" != "off" ]]; then
-        disk_used="${disk_used/\.}"
-        disk_used="${disk_used/G}"
-        disk_total="${disk_total/G}"
-        disk_total="${disk_total/\.}"
-
-        [[ "${disk_used: -1}" == "T" ]] && \
-            disk_used="$((${disk_used/T} * 100))"
-
-        [[ "${disk_total: -1}" == "T" ]] && \
-            disk_total="$((${disk_total/T} * 100))"
-    fi
-
     # Bar
     case "$disk_display" in
-        "bar") disk="$(bar "${disk_used/'.'*}" "${disk_total/'.'*}")" ;;
-        "infobar") disk+=" $(bar "${disk_used/'.'*}" "${disk_total/'.'*}")" ;;
-        "barinfo") disk="$(bar "${disk_used/'.'*}" "${disk_total/'.'*}") $disk" ;;
-        "perc") disk="$disk_total_per $(bar "${disk_used/'.'*}" "${disk_total/'.'*}")" ;;
+        "bar") disk="$(bar "${disk_total_per/'%'}" "100")" ;;
+        "infobar") disk+=" $(bar "${disk_total_per/'%'}" "100")" ;;
+        "barinfo") disk="$(bar "${disk_total_per/'%'}" "100") $disk" ;;
+        "perc") disk="$disk_total_per $(bar "$disk_total_per" "100")" ;;
     esac
 }
 

--- a/neofetch
+++ b/neofetch
@@ -22,6 +22,11 @@ shopt -s nocasematch
 # Reset colors/bold
 reset="\033[0m"
 
+echo; echo
+df -h
+echo; echo
+exit
+
 # DETECT INFORMATION
 
 get_os() {
@@ -1545,11 +1550,7 @@ get_disk() {
     # Split the info
     case "$os" in
         "Haiku") return ;;
-        "Mac OS X")
-            disk_used="${disks[10]}"
-            disk_total="${disks[9]}"
-            disk_total_per="(${disks[12]})"
-        ;;
+        "Mac OS X") ;;
 
         *)
             disk_used="${disks[9]}"

--- a/neofetch
+++ b/neofetch
@@ -1540,31 +1540,34 @@ get_disk() {
     type -p df >/dev/null 2>&1 || { err "Disk requires 'df' to function. Install 'df' to get disk info."; return; }
 
     # Get the info for /
-    disks=($(df /))
+    disks=($(df -h /))
 
     # Split the info
-    disk_used="$((disks[9]  / 1024 / 1024))GB"
-    disk_total="$((disks[8] / 1024 / 1024))GB"
-
-    # Handle TB values
-    (( "${#disk_used}"  == 6 )) && disk_used="${disk_used:0:1}.${disk_used:1:1}TB"
-    (( "${#disk_total}" == 6 )) && disk_total="${disk_total:0:1}.${disk_total:1:1}TB"
-
-    # Get the filesystem type
-    disk_type="[$(awk '$2 == "/" {printf $3; exit}' /etc/fstab)]"
-
-    # Get the usage percentage
+    disk_used="${disks[9]}"
+    disk_total="${disks[8]}"
     disk_total_per="(${disks[11]})"
 
     # Put it all together
-    disk="${disk_used} / ${disk_total} ${disk_total_per} ${disk_type}"
+    disk="${disk_used} / ${disk_total} ${disk_total_per}"
+
+    # Convert Terabytes to Gigabytes.
+    if [[ "$disk_display" != "off" ]]; then
+        disk_used="${disk_used/\.}"
+        disk_total="${disk_total/\.}"
+
+        [[ "${disk_used: -1}" == "T" ]] && \
+            disk_used="$((${disk_used/T} * 100))"
+
+        [[ "${disk_total: -1}" == "T" ]] && \
+            disk_total="$((${disk_total/T} * 100))"
+    fi
 
     # Bar
     case "$disk_display" in
-        "bar") disk="$(bar "${disk_used//[a-z]}" "${disk_total//[a-z]}")" ;;
-        "infobar") disk+=" $(bar "${disk_used//[a-z]}" "${disk_total//[a-z]}")" ;;
-        "barinfo") disk="$(bar "${disk_used//[a-z]}" "${disk_total//[a-z]}") $disk" ;;
-        "perc") disk="$disk_total_per $(bar "${disk_used//[a-z]}" "${disk_total//[a-z]}")" ;;
+        "bar") disk="$(bar "${disk_used/'.'*}" "${disk_total/'.'*}")" ;;
+        "infobar") disk+=" $(bar "${disk_used/'.'*}" "${disk_total/'.'*}")" ;;
+        "barinfo") disk="$(bar "${disk_used/'.'*}" "${disk_total/'.'*}") $disk" ;;
+        "perc") disk="$disk_total_per $(bar "${disk_used/'.'*}" "${disk_total/'.'*}")" ;;
     esac
 }
 

--- a/neofetch
+++ b/neofetch
@@ -1540,7 +1540,7 @@ get_disk() {
     type -p df >/dev/null 2>&1 || { err "Disk requires 'df' to function. Install 'df' to get disk info."; return; }
 
     # Get the info for /
-    disks=($(df -h /))
+    disks=($(df -h /)) || { err "Disk: 'df' exited with error code 1"; return; }
 
     # Split the info
     disk_used="${disks[9]}"

--- a/neofetch
+++ b/neofetch
@@ -1539,63 +1539,28 @@ get_term_font() {
 get_disk() {
     type -p df >/dev/null 2>&1 || { err "Disk requires 'df' to function. Install 'df' to get disk info."; return; }
 
-    # df flags
-    case "$os" in
-        "Linux" | "iPhone OS" | "Windows" | "GNU")
-            df_flags=(-h -l --total)
-            df_dir="total"
+    # Get the info for /
+    disks=($(df /))
 
-            case "$distro" in
-                "OpenWRT"*) df_flags=(-h); df_dir="rootfs" ;;
-                "Android"*) return ;;
-            esac
-        ;;
+    # Split the info
+    disk_used="$((disks[9]  / 1024 / 1024))GB"
+    disk_total="$((disks[8] / 1024 / 1024))GB"
 
-        "Mac OS X" | "BSD" | "Haiku")
-            case "$distro" in
-                "FreeBSD"* | *"OS X"* | "Mac"*)
-                    df_flags=(-l -H /)
-                    df_dir="/"
-                ;;
+    # Handle TB values
+    (( "${#disk_used}"  == 6 )) && disk_used="${disk_used:0:1}.${disk_used:1:1}TB"
+    (( "${#disk_total}" == 6 )) && disk_total="${disk_total:0:1}.${disk_total:1:1}TB"
 
-                *) return ;;
-            esac
-        ;;
-    esac
-
-    # Get the disk info
-    disk="$(df "${df_flags[@]}" | awk -v dir="$df_dir" '$0 ~ dir {print $2 ":" $3 ":" $5}')"
-
-    # Format the output
-    disk_used="${disk#*:}"
-    disk_used="${disk_used%%:*}"
-    disk_total="${disk%%:*}"
-    disk_total_per="${disk#*:*:}"
+    disk_total_per="${disks[11]}"
 
     # Put it all together
-    disk="${disk_used} / ${disk_total} (${disk_total_per})"
+    disk="${disk_used:+${disk_used} / }${disk_total} ${disk_total_per:+(${disk_total_per})}"
 
-    # Add info bar
-    disk_used="${disk_used/G}"
-    disk_total="${disk_total/G}"
-
-    # Convert Terabytes to Gigabytes.
-    if [[ "$disk_display" != "off" ]]; then
-        disk_used="${disk_used/\.}"
-        disk_total="${disk_total/\.}"
-
-        [[ "${disk_used: -1}" == "T" ]] && \
-            disk_used="$((${disk_used/T} * 100))"
-
-        [[ "${disk_total: -1}" == "T" ]] && \
-            disk_total="$((${disk_total/T} * 100))"
-    fi
-
+    # Bar
     case "$disk_display" in
-        "bar") disk="$(bar "${disk_used/'.'*}" "${disk_total/'.'*}")" ;;
-        "infobar") disk+=" $(bar "${disk_used/'.'*}" "${disk_total/'.'*}")" ;;
-        "barinfo") disk="$(bar "${disk_used/'.'*}" "${disk_total/'.'*}") $disk" ;;
-        "perc") disk="$disk_total_per $(bar "${disk_used/'.'*}" "${disk_total/'.'*}")" ;;
+        "bar") disk="$(bar "${disk_used//[a-z]}" "${disk_total//[a-z]}")" ;;
+        "infobar") disk+=" $(bar "${disk_used//[a-z]}" "${disk_total//[a-z]}")" ;;
+        "barinfo") disk="$(bar "${disk_used//[a-z]}" "${disk_total//[a-z]}") $disk" ;;
+        "perc") disk="$disk_total_per $(bar "${disk_used//[a-z]}" "${disk_total//[a-z]}")" ;;
     esac
 }
 

--- a/neofetch
+++ b/neofetch
@@ -1543,19 +1543,16 @@ get_disk() {
     # Get the info for /
     disks=($(df -P -h /)) || { err "Disk: 'df' exited with error code 1"; return; }
 
-    disk_used="${disks[9]/i}"
-    disk_total="${disks[8]/i}"
-    disk_total_per="(${disks[11]})"
-
     # Put it all together
-    disk="${disk_used} / ${disk_total} ${disk_total_per}"
+    disk_perc="${disks[11]/'%'}"
+    disk="${disks[9]/i} / ${disks[8]/i} (${disk_perc}%)"
 
     # Bar
     case "$disk_display" in
-        "bar") disk="$(bar "${disk_total_per/'%'}" "100")" ;;
-        "infobar") disk+=" $(bar "${disk_total_per/'%'}" "100")" ;;
-        "barinfo") disk="$(bar "${disk_total_per/'%'}" "100") $disk" ;;
-        "perc") disk="$disk_total_per $(bar "$disk_total_per" "100")" ;;
+        "bar") disk="$(bar "$disk_perc" "100")" ;;
+        "infobar") disk+=" $(bar "$disk_perc" "100")" ;;
+        "barinfo") disk="$(bar "$disk_perc" "100") $disk" ;;
+        "perc") disk="${disk_perc}% $(bar "$disk_perc" "100")" ;;
     esac
 }
 

--- a/neofetch
+++ b/neofetch
@@ -22,11 +22,6 @@ shopt -s nocasematch
 # Reset colors/bold
 reset="\033[0m"
 
-echo; echo
-df -h
-echo; echo
-exit
-
 # DETECT INFORMATION
 
 get_os() {
@@ -1551,7 +1546,6 @@ get_disk() {
     case "$os" in
         "Haiku") return ;;
         "Mac OS X") ;;
-
         *)
             disk_used="${disks[9]}"
             disk_total="${disks[8]}"

--- a/neofetch
+++ b/neofetch
@@ -1553,7 +1553,7 @@ get_disk() {
     disk_total_per="${disks[11]}"
 
     # Put it all together
-    disk="${disk_used:+${disk_used} / }${disk_total} ${disk_total_per:+(${disk_total_per})}"
+    disk="${disk_used} / ${disk_total} (${disk_total_per})"
 
     # Bar
     case "$disk_display" in


### PR DESCRIPTION
## Description

This PR aims to make the disk function as portable as possible. To make this possible we're now only displaying the information for the `/` partition. The old behavior will be re-implemented if we can figure out how to do so without issues on all versions of `df`.

Closes #542 

## Features

- Rewrote function from scratch.
    - The function is `40` lines smaller than before and works on all versions of `df` \[1\]
- We only show the `root (/)` partition now.
- Removed all percentage calculation since `df` already provides us with the percentage.
- We're using the same `df` flags across all Operating Systems now. 
    - No more ugly case statements or per distro hardcoding of `df` flags.

\[1\] The function doesn't work on Haiku since their `df` is wildly non-standard. (The output format and flags are 100% different from all of the other `df` versions floating around.) 

## Issues

None (?)

## TODO

- [x] Testing
    - [x] Linux | GNU | iOS
    - [x] macOS
    - [x] Windows
    - [x] BSD
        - [x] OpenBSD
        - [x] FreeBSD
        - [x] NetBSD
        - [x] DragonflyBSD
    - [ ] Haiku
    - [x] Solaris