### PR TITLE
Config: Remove executable permission from config files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ install:
 	$(INSTALL_DIR) $(DESTDIR)$(PREFIX)/share/man/man1
 	$(INSTALL_PROG) neofetch $(DESTDIR)$(PREFIX)/bin/neofetch
 	$(INSTALL_FILE) neofetch.1 $(DESTDIR)$(PREFIX)/share/man/man1/neofetch.1
-	$(INSTALL_PROG) config/config $(DESTDIR)$(PREFIX)/share/neofetch/config
+	$(INSTALL_FILE) config/config $(DESTDIR)$(PREFIX)/share/neofetch/config
 	$(INSTALL_FILE) ascii/distro/* $(DESTDIR)$(PREFIX)/share/neofetch/ascii/distro
 
 uninstall:


### PR DESCRIPTION
## Description

This removes the execute permissions when we install the config file. BASH can source scripts that aren't set as executable so this works just fine.

