### PR TITLE
Ascii: Remove ascii_logo_size

### DIFF
--- a/config/config
+++ b/config/config
@@ -569,6 +569,8 @@ ascii="distro"
 #       Change this to 'arch_old' or 'ubuntu_old' to use the old logos.
 # NOTE: Ubuntu has flavor varients.
 #       Change this to 'Lubuntu', 'Xubuntu', 'Ubuntu-GNOME' or 'Ubuntu-Budgie' to use the flavors.
+# NOTE: Arch, Crux and Gentoo have a smaller logo varient.
+#       Change this to 'arch_small', 'crux_small' or 'gentoo_small' to use the small logos.
 ascii_distro="auto"
 
 # Ascii Colors
@@ -581,16 +583,6 @@ ascii_distro="auto"
 # ascii_colors=(distro)      - Ascii is colored based on Distro colors.
 # ascii_colors=(4 6 1 8 8 6) - Ascii is colored using these colors.
 ascii_colors=(distro)
-
-# Logo size
-# Arch, Crux and Gentoo have a smaller logo
-# variant. Changing the value below to small
-# will make neofetch use the small logo.
-#
-# Default: 'normal'
-# Values:  'normal', 'small'
-# Flag:    --ascii_logo_size
-ascii_logo_size="normal"
 
 # Bold ascii logo
 # Whether or not to bold the ascii logo.

--- a/config/config
+++ b/config/config
@@ -278,7 +278,7 @@ public_ip_host="http://ident.me"
 # Song
 
 
-# Print the Artist and Title on seperate lines
+# Print the Artist and Title on separate lines
 #
 # Default: 'off'
 # Values:  'on', 'off'
@@ -565,11 +565,11 @@ ascii="distro"
 # Values:  'auto', 'distro_name'
 # Flag:    --ascii_distro
 #
-# NOTE: Arch and Ubuntu have 'old' logo varients.
+# NOTE: Arch and Ubuntu have 'old' logo variants.
 #       Change this to 'arch_old' or 'ubuntu_old' to use the old logos.
-# NOTE: Ubuntu has flavor varients.
+# NOTE: Ubuntu has flavor variants.
 #       Change this to 'Lubuntu', 'Xubuntu', 'Ubuntu-GNOME' or 'Ubuntu-Budgie' to use the flavors.
-# NOTE: Arch, Crux and Gentoo have a smaller logo varient.
+# NOTE: Arch, Crux and Gentoo have a smaller logo variant.
 #       Change this to 'arch_small', 'crux_small' or 'gentoo_small' to use the small logos.
 ascii_distro="auto"
 

--- a/neofetch
+++ b/neofetch
@@ -1839,11 +1839,6 @@ get_ascii() {
             ascii="${ascii_distro,,}"
         fi
 
-        if [[ "$ascii_logo_size" == "small" ]]; then
-            ascii="${ascii/ *}_small"
-            prompt_loc="3"
-        fi
-
         if [[ -f "/usr/share/neofetch/ascii/distro/${ascii/ *}" ]]; then
             ascii="/usr/share/neofetch/ascii/distro/${ascii/ *}"
 
@@ -3068,8 +3063,10 @@ ASCII
 
                                 NOTE: Change this to 'Lubuntu', 'Xubuntu', 'Ubuntu-GNOME', 'Ubuntu-Studio' or 'Ubuntu-Budgie' to use the flavors.
 
-    --ascii_logo_size           Size of ascii logo.
-                                Supported distros: Arch, Gentoo, Crux, OpenBSD.
+                                NOTE: Arch, Crux and Gentoo have a smaller logo varient.
+
+                                NOTE: Change this to 'arch_small', 'crux_small' or 'gentoo_small' to use the small logos.
+
     --ascii_bold on/off         Whether or not to bold the ascii logo.
     -L, --logo                  Hide the info text and only show the ascii logo.
 
@@ -3253,7 +3250,6 @@ get_args() {
                 case "$2" in "-"* | "") ascii_distro="$distro" ;; esac
             ;;
 
-            "--ascii_logo_size") ascii_logo_size="$2" ;;
             "--ascii_bold") ascii_bold="$2" ;;
             "--logo" | "-L")
                 image_backend="ascii"

--- a/neofetch
+++ b/neofetch
@@ -886,7 +886,7 @@ get_cpu() {
         cpu="$cpu @ ${speed}GHz $temp"
     fi
 
-    # Remove uneeded patterns from cpu output
+    # Remove unneeded patterns from cpu output
     cpu="${cpu//(TM)}"
     cpu="${cpu//(tm)}"
     cpu="${cpu//(R)}"
@@ -1149,7 +1149,7 @@ get_song() {
 
     get_song_dbus() {
         # Multiple players use an almost identical dbus command to get the information.
-        # This function saves us including the same command throughtout the function.
+        # This function saves us including the same command throughout the function.
         song="$(\
             dbus-send --print-reply --dest=org.mpris.MediaPlayer2."${1}" /org/mpris/MediaPlayer2 \
             org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Metadata' |\
@@ -1210,7 +1210,7 @@ get_song() {
         ;;
     esac
 
-    # Display Artist and Title on seperate lines.
+    # Display Artist and Title on separate lines.
     if [[ "$song_shorthand" == "on" ]]; then
         artist="${song/ -*}"
         song="${song/$artist - }"
@@ -2131,7 +2131,7 @@ make_thumbnail() {
             og_width="${size%% *}"
             og_height="${size##* }"
 
-            # This checks to see if height is geater than width
+            # This checks to see if height is greater than width
             # so we can do a better crop of portrait images.
             size="$og_height"
             (("$og_height" > "$og_width")) && size="$og_width"
@@ -2386,7 +2386,7 @@ trim() {
     # of special characters.
     #
     # The whitespace trim doesn't work with multiline strings so we use
-    # '${1//[[:space:]]/ }' to remove newlines beofre we trim the whitespace.
+    # '${1//[[:space:]]/ }' to remove newlines before we trim the whitespace.
 
     set -f
     # shellcheck disable=2086
@@ -2989,7 +2989,7 @@ INFO
     --shell_path on/off         Enable/Disable showing \$SHELL path
     --shell_version on/off      Enable/Disable showing \$SHELL version
     --ip_host url               URL to query for public IP
-    --song_shorthand on/off     Print the Artist/Title on seperate lines
+    --song_shorthand on/off     Print the Artist/Title on separate lines
     --install_time on/off      Enable/Disable showing the time in Install Date output.
 
 TEXT FORMATTING
@@ -3055,15 +3055,15 @@ ASCII
     --ascii_colors x x x x x x  Colors to print the ascii art
     --ascii_distro distro       Which Distro's ascii art to print
 
-                                NOTE: Arch and Ubuntu have 'old' logo varients.
+                                NOTE: Arch and Ubuntu have 'old' logo variants.
 
                                 NOTE: Use 'arch_old' or 'ubuntu_old' to use the old logos.
 
-                                NOTE: Ubuntu has flavor varients.
+                                NOTE: Ubuntu has flavor variants.
 
                                 NOTE: Change this to 'Lubuntu', 'Xubuntu', 'Ubuntu-GNOME', 'Ubuntu-Studio' or 'Ubuntu-Budgie' to use the flavors.
 
-                                NOTE: Arch, Crux and Gentoo have a smaller logo varient.
+                                NOTE: Arch, Crux and Gentoo have a smaller logo variant.
 
                                 NOTE: Change this to 'arch_small', 'crux_small' or 'gentoo_small' to use the small logos.
 
@@ -3127,7 +3127,7 @@ exit 1
 }
 
 get_args() {
-    # Check the commandline flags early for '--config none/off'
+    # Check the command-line flags early for '--config none/off'
     [[ "$@" =~ --config\ ?(off|none) ]] || get_user_config 2>/dev/null
 
     while [[ "$1" ]]; do

--- a/neofetch
+++ b/neofetch
@@ -2860,6 +2860,9 @@ old_options() {
     [[ "$speed_type" == "min" ]]     && err "Config: speed_type='min' is deprecated, use speed_type='scaling_min_freq' instead."
     [[ "$speed_type" == "max" ]]     && err "Config: speed_type='max' is deprecated, use speed_type='scaling_max_freq' instead."
     [[ "$speed_type" == "bios" ]]    && err "Config: speed_type='bios' is deprecated, use speed_type='bios_limit' instead."
+
+    # Ascii_logo_size was removed in 2.1.0.
+    [[ "$ascii_logo_size" ]] && err "Config: ascii_logo_size is deprecatedm use ascii_distro='{arch,crux,gentoo}_small' instead."
 }
 
 cache_uname() {

--- a/neofetch.1
+++ b/neofetch.1
@@ -87,7 +87,7 @@ Enable/Disable showing $SHELL version
 URL to query for public IP
 .TP
 \fB\-\-song_shorthand\fR on/off
-Print the Artist/Title on seperate lines
+Print the Artist/Title on separate lines
 .TP
 \fB\-\-install_time\fR on/off
 Enable/Disable showing the time in Install Date output.
@@ -204,15 +204,15 @@ Colors to print the ascii art
 \fB\-\-ascii_distro\fR distro
 Which Distro's ascii art to print
 .IP
-NOTE: Arch and Ubuntu have 'old' logo varients.
+NOTE: Arch and Ubuntu have 'old' logo variants.
 .IP
 NOTE: Use 'arch_old' or 'ubuntu_old' to use the old logos.
 .IP
-NOTE: Ubuntu has flavor varients.
+NOTE: Ubuntu has flavor variants.
 .IP
 NOTE: Change this to 'Lubuntu', 'Xubuntu', 'Ubuntu\-GNOME', 'Ubuntu\-Studio' or 'Ubuntu\-Budgie' to use the flavors.
 .IP
-NOTE: Arch, Crux and Gentoo have a smaller logo varient.
+NOTE: Arch, Crux and Gentoo have a smaller logo variant.
 .IP
 NOTE: Change this to 'arch_small', 'crux_small' or 'gentoo_small' to use the small logos.
 .TP

--- a/neofetch.1
+++ b/neofetch.1
@@ -211,10 +211,10 @@ NOTE: Use 'arch_old' or 'ubuntu_old' to use the old logos.
 NOTE: Ubuntu has flavor varients.
 .IP
 NOTE: Change this to 'Lubuntu', 'Xubuntu', 'Ubuntu\-GNOME', 'Ubuntu\-Studio' or 'Ubuntu\-Budgie' to use the flavors.
-.TP
-\fB\-\-ascii_logo_size\fR
-Size of ascii logo.
-Supported distros: Arch, Gentoo, Crux, OpenBSD.
+.IP
+NOTE: Arch, Crux and Gentoo have a smaller logo varient.
+.IP
+NOTE: Change this to 'arch_small', 'crux_small' or 'gentoo_small' to use the small logos.
 .TP
 \fB\-\-ascii_bold\fR on/off
 Whether or not to bold the ascii logo.


### PR DESCRIPTION
## Description

This PR removed `$ascii_logo_size` in place of just using `$ascii_distro`. We're already using `$ascii_distro` for `_old` and Ubuntu variants so why not also use it for `_small` variants. 

This PR also fixes all spelling errors in our docs. I noticed I spelled `variant` wrong in this PR and decided to go through the entire script with a spell checker. :P 