### PR TITLE
GPU: Print each GPU on a different line

### DIFF
--- a/config/config
+++ b/config/config
@@ -210,6 +210,23 @@ cpu_temp="off"
 # off: 'HD 7950'
 gpu_brand="on"
 
+# Which GPU to display
+#
+# Default: 'all'
+# Values:  'all', 'dedicated', 'integrated'
+# Flag:    --gpu_type
+#
+# Example:
+# all:
+#   GPU1: AMD HD 7950
+#   GPU2: Intel Integrated Graphics
+#
+# dedicated:
+#   GPU1: AMD HD 7950
+#
+# integrated:
+#   GPU1: Intel Integrated Graphics
+gpu_type="all"
 
 # Resolution
 

--- a/neofetch
+++ b/neofetch
@@ -969,9 +969,14 @@ get_gpu() {
             gpus=($(lspci -mm | awk -F '\\"|\\" \\"' '/"Display|"3D|"VGA/ {print $3 " " $4}'))
 
             # Number the GPUs if more than one exists.
-            (( "${#gpus[@]}" > 1 )) && gpu_num=0
+            (( "${#gpus[@]}" > 1 )) && gpu_num=1
 
             for gpu in "${gpus[@]}"; do
+                # GPU shorthand tests.
+                [[ "$gpu_show" == "dedicated" && "$gpu" =~ (i|I)ntel ]] || \
+                [[ "$gpu_show" == "integrated" && ! "$gpu" =~ (i|I)ntel ]] && \
+                    { unset -v gpu; continue; }
+
                 case "$gpu" in
                     *"advanced"*)
                         gpu="${gpu/'[AMD/ATI]' }"

--- a/neofetch
+++ b/neofetch
@@ -969,7 +969,7 @@ get_gpu() {
             gpus=($(lspci -mm | awk -F '\\"|\\" \\"' '/"Display|"3D|"VGA/ {print $3 " " $4}'))
 
             # Number the GPUs if more than one exists.
-            [[ "${#gpus[@]}" > 1 ]] && index=0
+            [[ "${#gpus[@]}" > 1 ]] && gpu_num=0
 
             for gpu in "${gpus[@]}"; do
                 case "$gpu" in
@@ -1005,8 +1005,8 @@ get_gpu() {
                     gpu="${gpu/Intel }"
                 fi
 
-                prin "GPU${index}" "$gpu"
-                index="$((index+=1))"
+                prin "GPU${gpu_num}" "$gpu"
+                gpu_num="$((gpu_num+=1))"
             done
 
             return

--- a/neofetch
+++ b/neofetch
@@ -997,9 +997,9 @@ get_gpu() {
                 esac
 
                 if [[ "$gpu_brand" == "off" ]]; then
-                    gpu="${gpu//AMD }"
-                    gpu="${gpu//NVIDIA }"
-                    gpu="${gpu//Intel }"
+                    gpu="${gpu/AMD }"
+                    gpu="${gpu/NVIDIA }"
+                    gpu="${gpu/Intel }"
                 fi
 
                 prin "GPU${index:-0}" "$gpu"
@@ -1080,9 +1080,9 @@ get_gpu() {
     esac
 
     if [[ "$gpu_brand" == "off" ]]; then
-        gpu="${gpu//AMD}"
-        gpu="${gpu//NVIDIA}"
-        gpu="${gpu//Intel}"
+        gpu="${gpu/AMD}"
+        gpu="${gpu/NVIDIA}"
+        gpu="${gpu/Intel}"
     fi
 }
 

--- a/neofetch
+++ b/neofetch
@@ -1005,7 +1005,7 @@ get_gpu() {
                     gpu="${gpu/Intel }"
                 fi
 
-                prin "GPU${gpu_num}" "$gpu"
+                prin "${subtitle}${gpu_num}" "$gpu"
                 gpu_num="$((gpu_num+=1))"
             done
 

--- a/neofetch
+++ b/neofetch
@@ -968,6 +968,9 @@ get_gpu() {
             IFS=$'\n'
             gpus=($(lspci -mm | awk -F '\\"|\\" \\"' '/"Display|"3D|"VGA/ {print $3 " " $4}'))
 
+            # Number the GPUs if more than one exists.
+            [[ "${#gpus[@]}" > 1 ]] && index=0
+
             for gpu in "${gpus[@]}"; do
                 case "$gpu" in
                     *"advanced"*)
@@ -1002,7 +1005,7 @@ get_gpu() {
                     gpu="${gpu/Intel }"
                 fi
 
-                prin "GPU${index:-0}" "$gpu"
+                prin "GPU${index}" "$gpu"
                 index="$((index+=1))"
             done
 

--- a/neofetch
+++ b/neofetch
@@ -965,35 +965,48 @@ get_cpu_usage() {
 get_gpu() {
     case "$os" in
         "Linux")
-            gpu="$(lspci -mm | awk -F '\\"|\\" \\"' '/"Display|"3D|"VGA/ {print $3 " " $4}')"
+            IFS=$'\n'
+            gpus=($(lspci -mm | awk -F '\\"|\\" \\"' '/"Display|"3D|"VGA/ {print $3 " " $4}'))
 
-            case "$gpu" in
-                *"advanced"*)
-                    gpu="${gpu//Intel*$'\n'}"
-                    gpu="${gpu/'[AMD/ATI]' }"
-                    gpu="${gpu/'[AMD]' }"
-                    gpu="${gpu/OEM }"
-                    gpu="${gpu/Advanced Micro Devices, Inc.}"
-                    gpu="${gpu/ \/ *}"
-                    gpu="${gpu/*\[}"
-                    gpu="${gpu/\]*}"
-                    gpu="AMD $gpu"
-                ;;
+            for gpu in "${gpus[@]}"; do
+                case "$gpu" in
+                    *"advanced"*)
+                        gpu="${gpu/'[AMD/ATI]' }"
+                        gpu="${gpu/'[AMD]' }"
+                        gpu="${gpu/OEM }"
+                        gpu="${gpu/Advanced Micro Devices, Inc.}"
+                        gpu="${gpu/ \/ *}"
+                        gpu="${gpu/*\[}"
+                        gpu="${gpu/\]*}"
+                        gpu="AMD $gpu"
+                    ;;
 
-                *"nvidia"*)
-                    gpu="${gpu//Intel*$'\n'}"
-                    gpu="${gpu/*\[}"
-                    gpu="${gpu/\]*}"
-                    gpu="NVIDIA $gpu"
-                ;;
+                    *"nvidia"*)
+                        gpu="${gpu/*\[}"
+                        gpu="${gpu/\]*}"
+                        gpu="NVIDIA $gpu"
+                    ;;
 
-                *"virtualbox"*)
-                    gpu="VirtualBox Graphics Adapter"
-                ;;
-            esac
+                    *"intel"*)
+                        gpu="Intel Integrated Graphics"
+                    ;;
 
-            [[ "$gpu" == *"intel"* ]] && \
-                gpu="Intel Integrated Graphics"
+                    *"virtualbox"*)
+                        gpu="VirtualBox Graphics Adapter"
+                    ;;
+                esac
+
+                if [[ "$gpu_brand" == "off" ]]; then
+                    gpu="${gpu//AMD }"
+                    gpu="${gpu//NVIDIA }"
+                    gpu="${gpu//Intel }"
+                fi
+
+                prin "GPU${index:-0}" "$gpu"
+                index="$((index+=1))"
+            done
+
+            return
         ;;
 
         "Mac OS X")
@@ -1067,9 +1080,9 @@ get_gpu() {
     esac
 
     if [[ "$gpu_brand" == "off" ]]; then
-        gpu="${gpu/AMD}"
-        gpu="${gpu/NVIDIA}"
-        gpu="${gpu/Intel}"
+        gpu="${gpu//AMD}"
+        gpu="${gpu//NVIDIA}"
+        gpu="${gpu//Intel}"
     fi
 }
 

--- a/neofetch
+++ b/neofetch
@@ -969,7 +969,7 @@ get_gpu() {
             gpus=($(lspci -mm | awk -F '\\"|\\" \\"' '/"Display|"3D|"VGA/ {print $3 " " $4}'))
 
             # Number the GPUs if more than one exists.
-            [[ "${#gpus[@]}" > 1 ]] && gpu_num=0
+            (( "${#gpus[@]}" > 1 )) && gpu_num=0
 
             for gpu in "${gpus[@]}"; do
                 case "$gpu" in

--- a/neofetch
+++ b/neofetch
@@ -973,8 +973,8 @@ get_gpu() {
 
             for gpu in "${gpus[@]}"; do
                 # GPU shorthand tests.
-                [[ "$gpu_show" == "dedicated" && "$gpu" =~ (i|I)ntel ]] || \
-                [[ "$gpu_show" == "integrated" && ! "$gpu" =~ (i|I)ntel ]] && \
+                [[ "$gpu_type" == "dedicated" && "$gpu" =~ (i|I)ntel ]] || \
+                [[ "$gpu_type" == "integrated" && ! "$gpu" =~ (i|I)ntel ]] && \
                     { unset -v gpu; continue; }
 
                 case "$gpu" in
@@ -3045,6 +3045,7 @@ INFO
     --refresh_rate on/off       Whether to display the refresh rate of each monitor
                                 Unsupported on Windows
     --gpu_brand on/off          Enable/Disable GPU brand in output. (AMD/NVIDIA/Intel)
+    --gpu_type type             Which GPU to display. (all, dedicated, integrated)
     --gtk_shorthand on/off      Shorten output of gtk theme/icons
     --gtk2 on/off               Enable/Disable gtk2 theme/font/icons output
     --gtk3 on/off               Enable/Disable gtk3 theme/font/icons output
@@ -3205,6 +3206,7 @@ get_args() {
             "--uptime_shorthand") uptime_shorthand="$2" ;;
             "--cpu_shorthand") cpu_shorthand="$2" ;;
             "--gpu_brand") gpu_brand="$2" ;;
+            "--gpu_type") gpu_type="$2" ;;
             "--refresh_rate") refresh_rate="$2" ;;
             "--gtk_shorthand") gtk_shorthand="$2" ;;
             "--gtk2") gtk2="$2" ;;

--- a/neofetch.1
+++ b/neofetch.1
@@ -68,6 +68,9 @@ Unsupported on Windows
 \fB\-\-gpu_brand\fR on/off
 Enable/Disable GPU brand in output. (AMD/NVIDIA/Intel)
 .TP
+\fB\-\-gpu_type\fR type
+Which GPU to display. (all, dedicated, integrated)
+.TP
 \fB\-\-gtk_shorthand\fR on/off
 Shorten output of gtk theme/icons
 .TP


### PR DESCRIPTION
## Description

This PR makes `get_gpu()` display each GPU on a separate line on Linux systems. 

## Features

- Each GPU is printed on a separate line.

## Issues

- None yet.

## TODO

- [x] Testing
- [x] Add option to print `all`, `dedicated` or `integrated`.

CC @konimex,, can you test this? 