### PR TITLE
Add support for Exaile music player

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1187,7 +1187,7 @@ get_memory() {
 
 get_song() {
     # This is absurdly long.
-    player="$(ps x | awk '!(/awk|Helper|Cache/) && /mpd|cmus|mocp|spotify|Google Play|iTunes.app|rhythmbox|banshee|amarok|deadbeef|audacious|xmms2d|gnome-music|lollypop|clementine|pragha/ {printf $5 " " $6; exit}')"
+    player="$(ps x | awk '!(/awk|Helper|Cache/) && /mpd|cmus|mocp|spotify|Google Play|iTunes.app|rhythmbox|banshee|amarok|deadbeef|audacious|xmms2d|gnome-music|lollypop|clementine|pragha|exaile/ {printf $5 " " $6; exit}')"
 
     get_song_dbus() {
         # Multiple players use an almost identical dbus command to get the information.
@@ -1249,6 +1249,12 @@ get_song() {
             artist="$(pragha -c | awk -F':' '/artist/ {print $2}')"
             title="$(pragha -c | awk -F':' '/title/ {print $2}')"
             song="$artist - $title"
+        ;;
+
+        "exaile"*)
+            song="$(dbus-send --print-reply --dest=org.exaile.Exaile  /org/exaile/Exaile \
+                    org.exaile.Exaile.Query | awk -F':|,' '{printf $6 " -" $4}')"
+            song="${song:3}"
         ;;
     esac
 


### PR DESCRIPTION
This PR adds song info support for Exaile.

There are also the commandline options` --get-title` and `--get-artist`, but `dbus-send` is much faster.
850ms vs 16ms on my system.