### PR TITLE
Cols: Remove $start + $end in favor of ${block_range[@]}

### DIFF
--- a/config/config
+++ b/config/config
@@ -372,8 +372,7 @@ underline_char="-"
 
 
 # Color block range
-# Start/End refer to the range of colors
-# to print in the blocks.
+# The range of colors to print.
 #
 # Default:  '0', '7'
 # Values:   'num'
@@ -381,13 +380,12 @@ underline_char="-"
 #
 # Example:
 #
-# Display colors 0-7 in the blocks.
+# Display colors 0-7 in the blocks.  (8 colors)
 # neofetch --block_range 0 7
 #
-# Display colors 0-15 in the blocks.
+# Display colors 0-15 in the blocks. (16 colors)
 # neofetch --block_range 0 15
-start=0
-end=7
+block_range=(0 7)
 
 # Toggle color blocks
 #

--- a/neofetch
+++ b/neofetch
@@ -1805,6 +1805,10 @@ get_cols() {
         # Convert the width to space chars.
         printf -v block_width "%${block_width}s"
 
+        # Set variables.
+        start="${block_range[0]}"
+        end="${block_range[1]}"
+
         # Generate the string.
         for ((start; start<=end; start++)); do
             case "$start" in
@@ -2825,6 +2829,9 @@ get_user_config() {
 
     source "$config_file"
     err "Config: Sourced user config.    (${config_file})"
+
+    # Check for deprecated options.
+    old_options
 }
 
 bar() {
@@ -2972,6 +2979,9 @@ old_options() {
 
     # Ascii_logo_size was removed in 2.1.0.
     [[ "$ascii_logo_size" ]] && err "Config: ascii_logo_size is deprecated, use ascii_distro='{arch,crux,gentoo}_small' instead."
+
+    # $start and $end were replaced with ${block_range[@]} in 2.1.0.
+    [[ "$start" && "$end" ]] && { err "Config: \$start and \$end are deprecated, use block_range=(0 7) instead."; block_range=("$start" "$end"); }
 }
 
 cache_uname() {
@@ -3121,7 +3131,7 @@ COLOR BLOCKS
     --color_blocks on/off       Enable/Disable the color blocks
     --block_width num           Width of color blocks in spaces
     --block_height num          Height of color blocks in lines
-    --block_range start end     Range of colors to print as blocks
+    --block_range num num       Range of colors to print as blocks
 
 BARS
 
@@ -3301,7 +3311,7 @@ get_args() {
 
             # Color Blocks
             "--color_blocks") color_blocks="$2" ;;
-            "--block_range") start="$2"; end="$3" ;;
+            "--block_range") block_range=("$2" "$3") ;;
             "--block_width") block_width="$2" ;;
             "--block_height") block_height="$2" ;;
 
@@ -3408,7 +3418,6 @@ main() {
     get_os
     get_default_config 2>/dev/null
     get_args "$@"
-    old_options
     get_distro
     get_bold
     get_distro_colors

--- a/neofetch.1
+++ b/neofetch.1
@@ -123,7 +123,7 @@ Width of color blocks in spaces
 \fB\-\-block_height\fR num
 Height of color blocks in lines
 .TP
-\fB\-\-block_range\fR start end
+\fB\-\-block_range\fR num num
 Range of colors to print as blocks
 .PP
 BARS


### PR DESCRIPTION
## Description

This PR removes `$start` and `$end` and merges them into an array called `block_range`. `start` + `end` are vague and don't match the other color block options. It also doesn't make sense to split them up,

This PR also fixes a bug with `old_options()`

NOTE: This PR also adds handling in case the user's config is out of date.