### PR TITLE
Song: enforce order artist - title in get_song_dbus()

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1200,9 +1200,8 @@ get_song() {
             dbus-send --print-reply --dest=org.mpris.MediaPlayer2."${1}" /org/mpris/MediaPlayer2 \
             org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' string:'Metadata' |\
             awk -F 'string "' '/string|array/ {printf "%s",$2; next}{print ""}' |\
-            awk -F '"' '/artist|title/ {printf $2 " - "}'
+            awk -F '"' '/artist/ {a=$2} /title/ {t=$2} END{print a " - " t}'
         )"
-        song="${song% - }"
     }
 
     case "${player/*\/}" in


### PR DESCRIPTION
Some players report title before artist. That leads to song = titel - artist.
This PR makes sure it's always artist - title
