### PR TITLE
Install Date: Add an option to use 24h or 12h in time format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ Neofetch now has an irc channel at `#neofetch` on Freenode. If you have any ques
 - Renamed `get_birthday()` -- > `get_install_date()`
 - Removed all `date` usage from `get_install_date()`.
 - Added a new function called `convert_time()` which takes the time stamped `ls` output and converts it to a pretty format. The function only uses bash so its much faster than calling `date`. This makes things simple and keeps the output consistent across all Operating Systems. Example: `2016-12-06 16:58:58.000000000` --> `Tue 06 Dec 2016 4:58 PM`
+- Added an option so users can choose between using 24-hour and 12-hour time format
 
 **Disk**<br \>
 

--- a/config/config
+++ b/config/config
@@ -324,6 +324,17 @@ song_shorthand="off"
 # off: 'Thu 14 Apr 2016'
 install_time="on"
 
+# Set time format in the output
+#
+# Default: '24h'
+# Values:  '12h', '24h'
+# Flag:    --install_time_format
+#
+# Example:
+# 12h: 'Thu 14 Apr 2016 11:50 PM'
+# 24h: 'Thu 14 Apr 2016 23:50'
+install_time_format="24h"
+
 
 # Text Colors
 

--- a/neofetch
+++ b/neofetch
@@ -3065,7 +3065,7 @@ convert_time() {
                 *) time="$((hour - 12))${min} PM" ;;
             esac
         ;;
-        *) time="${hour}${min}" ;;
+        *) time="$4" ;;
     esac
 
     # Toggle showing the time.

--- a/neofetch
+++ b/neofetch
@@ -3058,9 +3058,14 @@ convert_time() {
     esac
 
     # Convert 24 hour time to 12 hour time + AM/PM.
-    case "$hour" in
-        [0-9] | 0[0-9] | 1[0-1]) time="${hour/00/12}${min} AM" ;;
-        *) time="$((hour - 12))${min} PM" ;;
+    case "$install_time_format" in
+        "12h")
+            case "$hour" in
+                [0-9] | 0[0-9] | 1[0-1]) time="${hour/00/12}${min} AM" ;;
+                *) time="$((hour - 12))${min} PM" ;;
+            esac
+        ;;
+        *) time="${hour}${min}" ;;
     esac
 
     # Toggle showing the time.
@@ -3174,7 +3179,9 @@ INFO
     --shell_version on/off      Enable/Disable showing \$SHELL version
     --ip_host url               URL to query for public IP
     --song_shorthand on/off     Print the Artist/Title on separate lines
-    --install_time on/off      Enable/Disable showing the time in Install Date output.
+    --install_time on/off       Enable/Disable showing the time in Install Date output.
+    --install_time_format 12h/24h
+                                Set time format in Install Date to be 12 hour or 24 hour.
 
 TEXT FORMATTING
 
@@ -3337,6 +3344,7 @@ get_args() {
             "--ip_host") public_ip_host="$2" ;;
             "--song_shorthand") song_shorthand="$2" ;;
             "--install_time") install_time="$2" ;;
+            "--install_time_format") install_time_format="$2" ;;
             "--disable")
                 for func in "$@"; do
                     case "$func" in

--- a/neofetch.1
+++ b/neofetch.1
@@ -96,6 +96,9 @@ Print the Artist/Title on separate lines
 .TP
 \fB\-\-install_time\fR on/off
 Enable/Disable showing the time in Install Date output.
+.TP
+\fB\-\-install_time_format\fR 12h/24h
+Set time format in Install Date to be 12 hour or 24 hour.
 .PP
 TEXT FORMATTING
 .TP


### PR DESCRIPTION
## Description
 
### Features

This adds option where user can choose between using a 24-hour format or 12-hour format

### TODO (If accepted)

- [ ] Expand `install_date` to support other date formats
  - [ ] ISO 8601
  - [ ] UNIX Time (May require outside program, like GNU date or `perl`)