### PR TITLE
Speed up song query for some players

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1249,9 +1249,7 @@ get_song() {
         ;;
 
         "amarok"*)
-            artist="$(qdbus org.kde.amarok /Player GetMetadata | awk -F':' '/^artist/ {print $2}')"
-            title="$(qdbus org.kde.amarok /Player GetMetadata | awk -F':' '/title/ {print $2}')"
-            song="$artist - $title"
+            song="$(qdbus org.kde.amarok /Player GetMetadata | awk -F':' '/^artist/ {a=$2} /^title/ {t=$2} END{if (a && t) print a " - " t}')"
         ;;
 
         "pragha"*)

--- a/neofetch
+++ b/neofetch
@@ -1243,9 +1243,7 @@ get_song() {
         ;;
 
         "banshee"*)
-            artist="$(banshee --query-artist | awk -F':' '{print $2}')"
-            title="$(banshee --query-title | awk -F':' '{print $2}')"
-            song="$artist - $title"
+            song="$(banshee --query-artist --query-title | awk -F':' '/^artist/ {a=$2} /^title/ {t=$2} END{if (a && t) print a " - " t}')"
         ;;
 
         "amarok"*)

--- a/neofetch
+++ b/neofetch
@@ -1223,9 +1223,7 @@ get_song() {
         "guayadeque"*)  get_song_dbus "guayadeque" ;;
 
         "cmus"*)
-            artist="$(cmus-remote -Q | grep -F "tag artist ")"
-            title="$(cmus-remote -Q | grep -F "tag title")"
-            song="${artist/tag artist} - ${title/tag title}"
+            song="$(cmus-remote -Q | awk '/tag artist/ {$1=$2=""; print; print " - "} /tag title/ {$1=$2=""; print}')"
         ;;
 
         "spotify"*)

--- a/neofetch
+++ b/neofetch
@@ -1255,9 +1255,7 @@ get_song() {
         ;;
 
         "pragha"*)
-            artist="$(pragha -c | awk -F':' '/artist/ {print $2}')"
-            title="$(pragha -c | awk -F':' '/title/ {print $2}')"
-            song="$artist - $title"
+            song="$(pragha -c | awk -F':' '/^artist/ {a=$2} /^title/ {t=$2} END{if (a && t) print a " - " t}')"
         ;;
 
         "exaile"*)


### PR DESCRIPTION
This PR speeds up song query for Pragha, Amarok and Banshee. They take half the time now. 
Most noticeable for Banshee because of it's slow query command. 

I've also changed the cmus query to avoid printing of an empty song info " - " if playback is stopped.
(Though it's only one call to `cmus-remote -Q` now, there's no significant speed increase.)