### PR TITLE
OS: Added support for Gentoo/FreeBSD

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3472,7 +3472,7 @@ main() {
     get_os
     get_default_config 2>/dev/null
     get_args "$@"
-    get_distro
+    get_distro 2>/dev/null
     get_bold
     get_distro_colors
 

--- a/neofetch
+++ b/neofetch
@@ -54,7 +54,7 @@ get_distro() {
 
     case "$os" in
         "Linux" | "BSD" | "MINIX")
-            if [[ "$(< /proc/version)" == *"Microsoft"* || "$(< /proc/sys/kernel/osrelease)" == *"Microsoft"* ]]; then ## ERRORS NEED TO BE SUPPRESSED!
+            if [[ "$(< /proc/version)" == *"Microsoft"* || "$(< /proc/sys/kernel/osrelease)" == *"Microsoft"* ]]; then
                 case "$distro_shorthand" in
                     "on")   distro="$(lsb_release -sir) [Windows 10]" ;;
                     "tiny") distro="Windows 10" ;;
@@ -109,11 +109,13 @@ get_distro() {
                 esac
 
                 # Workarounds for distros that go against the os-release standard.
-                [[ -z "${distro// }" ]] && distro="$(awk '/BLAG/ {print $1; exit}' /etc/*ease /usr/lib/*ease)"
-                [[ -z "${distro// }" ]] && distro="$(awk -F'=' '{print $2; exit}' /etc/*ease /usr/lib/*ease)"
+                [[ -z "${distro// }" ]] && distro="$(awk '/BLAG/ {print $1; exit}' /etc/os-release /usr/lib/os-release)"
+                [[ -z "${distro// }" ]] && distro="$(awk -F'=' '{print $2; exit}' /etc/os-release /usr/lib/os-release)"
 
             else
-                distro="$(cat /etc/*-release)" # UUOC, but using usual bash $(< *-file) returns "ambiguous redirect"
+                for release_file in /etc/*-release; do
+                    distro+="$(< "$release_file")"
+                done
                 if [[ -z "$distro" ]]; then
                     case "$distro_shorthand" in
                         "on" | "tiny") distro="$kernel_name" ;;

--- a/neofetch
+++ b/neofetch
@@ -394,7 +394,7 @@ get_packages() {
     local PATH="${PATH#:}"
 
     case "$os" in
-        "Linux" | "iPhone OS" | "Solaris")
+        "Linux" | "BSD" | "iPhone OS" | "Solaris")
             type -p pacman >/dev/null && \
                 packages="$(pacman -Qq --color never | wc -l)"
 
@@ -446,8 +446,12 @@ get_packages() {
             type -p eopkg >/dev/null && \
                 packages="$((packages+=$(eopkg list-installed | wc -l)))"
 
+            type -p pkg_info >/dev/null && \
+                packages="$((packages+=$(pkg_info | wc -l)))"
+
             if type -p pkg >/dev/null; then
                 packages="$((packages+=$(ls -1 /var/db/pkg | wc -l)))"
+                (("$packages" == "0")) && packages="$((packages+=$(pkg info | wc -l)))"
                 (("$packages" == "0")) && packages="$((packages+=$(pkg list | wc -l)))"
             fi
         ;;
@@ -464,21 +468,6 @@ get_packages() {
 
             type -p pkgin >/dev/null && \
                 packages="$((packages + $(pkgin list | wc -l)))"
-        ;;
-
-        "BSD")
-            case "$distro" in
-                # PacBSD has both pacman and pkg, but only pacman is used.
-                "PacBSD"*) packages="$(pacman -Qq --color never | wc -l)" ;;
-
-                *)
-                    if type -p pkg_info >/dev/null; then
-                        packages="$(pkg_info | wc -l)"
-                    elif type -p pkg >/dev/null; then
-                        packages="$(pkg info | wc -l)"
-                    fi
-                ;;
-            esac
         ;;
 
         "Windows")

--- a/neofetch
+++ b/neofetch
@@ -450,9 +450,12 @@ get_packages() {
                 packages="$((packages+=$(pkg_info | wc -l)))"
 
             if type -p pkg >/dev/null; then
-                packages="$((packages+=$(ls -1 /var/db/pkg | wc -l)))"
-                (("$packages" == "0")) && packages="$((packages+=$(pkg info | wc -l)))"
-                (("$packages" == "0")) && packages="$((packages+=$(pkg list | wc -l)))"
+                case "$kernel_name" in
+                    "FreeBSD") packages="$((packages+=$(pkg info | wc -l)))" ;;
+                    *)
+                        packages="$((packages+=$(ls -1 /var/db/pkg | wc -l)))"
+                        (("$packages" == "0")) && packages="$((packages+=$(pkg list | wc -l)))"
+                esac
             fi
         ;;
 

--- a/neofetch
+++ b/neofetch
@@ -53,8 +53,8 @@ get_distro() {
     [[ "$distro" ]] && return
 
     case "$os" in
-        "Linux")
-            if [[ "$(< /proc/version)" == *"Microsoft"* || "$(< /proc/sys/kernel/osrelease)" == *"Microsoft"* ]]; then
+        "Linux" | "BSD" | "MINIX")
+            if [[ "$(< /proc/version)" == *"Microsoft"* || "$(< /proc/sys/kernel/osrelease)" == *"Microsoft"* ]]; then ## ERRORS NEED TO BE SUPPRESSED!
                 case "$distro_shorthand" in
                     "on")   distro="$(lsb_release -sir) [Windows 10]" ;;
                     "tiny") distro="Windows 10" ;;
@@ -95,9 +95,9 @@ get_distro() {
             elif [[ -d "/system/app/" && -d "/system/priv-app" ]]; then
                 distro="Android $(getprop ro.build.version.release)"
 
-            else
-                # Source the os-release file.
-                for file in /etc/os-release /usr/lib/os-release /etc/*release /usr/lib/*release; do
+            elif [[ -f "/etc/os-release" || -f "/usr/lib/os-release" ]]; then
+                # Source the os-release file
+                for file in /etc/os-release /usr/lib/os-release; do
                     source "$file" 2>/dev/null && break
                 done
 
@@ -111,6 +111,21 @@ get_distro() {
                 # Workarounds for distros that go against the os-release standard.
                 [[ -z "${distro// }" ]] && distro="$(awk '/BLAG/ {print $1; exit}' /etc/*ease /usr/lib/*ease)"
                 [[ -z "${distro// }" ]] && distro="$(awk -F'=' '{print $2; exit}' /etc/*ease /usr/lib/*ease)"
+
+            else
+                distro="$(cat /etc/*-release)" # UUOC, but using usual bash $(< *-file) returns "ambiguous redirect"
+                if [[ -z "$distro" ]]; then
+                    case "$distro_shorthand" in
+                        "on" | "tiny") distro="$kernel_name" ;;
+                        *) distro="$kernel_name $kernel_version" ;;
+                    esac
+                    distro="${distro/DragonFly/DragonFlyBSD}"
+
+                    # Workarounds for FreeBSD based distros.
+                    [[ -f "/etc/pcbsd-lang" ]] && distro="PCBSD"
+                    [[ -f "/etc/rc.conf.trueos" ]] && distro="TrueOS"
+                    [[ -f "/etc/pacbsd-release" ]] && distro="PacBSD" # /etc/pacbsd-release is an empty file
+                fi
             fi
             distro="$(trim_quotes "$distro")"
         ;;
@@ -151,20 +166,6 @@ get_distro() {
 
             # "uname -m" doesn't print architecture on iOS so we force it off.
             os_arch="off"
-        ;;
-
-        "BSD" | "MINIX")
-            case "$distro_shorthand" in
-                "tiny" | "on") distro="$kernel_name" ;;
-                *) distro="$kernel_name $kernel_version" ;;
-            esac
-
-            distro="${distro/DragonFly/DragonFlyBSD}"
-
-            # Workarounds for FreeBSD based distros.
-            [[ -f "/etc/pcbsd-lang" ]] && distro="PCBSD"
-            [[ -f "/etc/trueos-lang" ]] && distro="TrueOS"
-            [[ -f "/etc/pacbsd-release" ]] && distro="PacBSD"
         ;;
 
         "Windows")


### PR DESCRIPTION
## Description

### Features

The ultimate aim of this PR is to expand Neofetch's support to Gentoo/FreeBSD. Testing will have to be done in these distros (in an installed environment, not a LiveCD):

- [x] FreeBSD / DragonFlyBSD
- [x] OpenBSD / Bitrig / NetBSD
- [ ] PacBSD
- [x] Gentoo/FreeBSD (see screenshot)
- [x] Solaris (OpenIndiana/Oracle)
- [x] Dragora

These testings are done because we're merging the package detection for Linux/Solaris and BSD. We all want accurate results for package, don't we?

### Issues

![virtualbox_freebsd gentoo_27_12_2016_20_38_17](https://cloud.githubusercontent.com/assets/15692230/21500773/d1100ae0-cc74-11e6-8d06-3929ab4bec08.png)

Also, see my comments in the diff.

### TODO

- Errors need to be suppressed.
- Cleanup `get_distro`, I think.