### PR TITLE
Fix ASCII logo not shown on openSUSE

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2584,8 +2584,13 @@ get_distro_colors() {
             set_colors 3 7 6 1 8
         ;;
 
-        *"SUSE"* | "Manjaro"* | "Deepin"* |"LMDE"* | "Chapeau"* | "Bitrig"*)
+        "Manjaro"* | "Deepin"* | "LMDE"* | "Chapeau"* | "Bitrig"*)
             set_colors 2 7
+        ;;
+
+        *"SUSE"*)
+            set_colors 2 7
+            ascii_distro="suse"
         ;;
 
         "KDE"*)

--- a/neofetch
+++ b/neofetch
@@ -2536,7 +2536,7 @@ get_distro_colors() {
 
         "antiX"*)
             set_colors 1 7 3
-            ascii_Distro="antix"
+            ascii_distro="antix"
         ;;
 
         "FreeBSD"*)


### PR DESCRIPTION
On openSUSE the ASCII logo was not shown.

![suse](https://cloud.githubusercontent.com/assets/20053197/21565060/7af5bada-ce93-11e6-8b9b-d048b0f112a2.png)

 I hope it's the right place to fix it.

There was also a typo. `ascii_Distro="antix"`
