### PR TITLE
Term: Rewrite Konsole font detection, closes #576

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1568,25 +1568,47 @@ get_term_font() {
         ;;
 
         "konsole"*)
+            get_konsole_profile() {
+                konsole_windows=($(qdbus "${1}" | awk '/Windows\//'))
+                for window in "${konsole_windows[@]}"; do
+                    konsole_session="$(qdbus "${1}" "${window}" currentSession)"
+                    if ((child == "$(qdbus "${1}" /Sessions/"${konsole_session}" processId)")); then
+                        konsole_profile="$(qdbus "${1}" /Sessions/"${konsole_session}" environment |\
+                        awk -F '=' '/KONSOLE_PROFILE_NAME/ {print $2}')"
+                        break
+                    fi
+                done
+            }
+
+            get_konsole_font() {
+                profile_path="$("${1}" --path data | awk -F':' '{print $1}')/konsole"
+
+                # Profile filename can differ from profile name, so find the filename first, take first match
+                # It's possible that we have more than one file containing the same profile name
+                profile_filename="$(grep -l "Name=${konsole_profile}" "${profile_path}"/*.profile | head -n 1)"
+                [[ "${profile_filename}" ]] && term_font="$(awk -F '=|,' '/Font=/ {print $2 " " $3}' "${profile_filename}")"
+
+                # If there are no profiles or no font is defined in the profile, Konsole falls back to system's monospace font
+                # This fails if no fixed font is defined in kdeglobals, Konsole internally uses
+                # QFontDatabase::systemFont(QFontDatabase::FixedFont) or KGlobalSettings::fixedFont() in qt4 versions
+                [[ ! "${term_font}" ]] && term_font="$(awk -F '=|,' '/fixed=/ {print $2 " " $3}' "$("${1}" --path config --locate kdeglobals)")"
+            }
+
             # Use Process ID from get_term().
             # The variable can include 'PPid:' and also whitespace
             # so we get rid of it here.
             parent="$(trim "${parent/PPid:}")"
 
-            # Get PID of current child window / tab
+            # Get Process ID of current konsole window / tab
             child="$(get_ppid "$$")"
 
-            # Get all konsole sessions of the parent (all child windows and tabs)
-            konsole_sessions=($(qdbus org.kde.konsole-"${parent}" | awk '/Sessions\//'))
+            # We could have both: org.kde.konsole-PPID and org.kde.konsole
+            get_konsole_profile "org.kde.konsole-${parent}"
+            [[ ! "${konsole_profile}" ]] && get_konsole_profile "org.kde.konsole"
 
-            # Get profile of current session (window / tab)
-            for session in "${konsole_sessions[@]}"; do
-                if ((child == "$(qdbus org.kde.konsole-"${parent}" "${session}" processId)")); then
-                    profile="$(qdbus org.kde.konsole-"${parent}" "${session}" environment | awk -F '=' '/KONSOLE_PROFILE_NAME/ {print $2}')"
-                    break
-                fi
-            done
-            term_font="$(awk -F '=|,' '/Font=/ {print $2}' "${HOME}/.local/share/konsole/${profile}".profile)"
+            # Try both: kde5 and kde4
+            [[ "$(which kf5-config)" ]] && get_konsole_font "kf5-config"
+            [[ ! "${term_font}" && "$(which kde4-config)" ]] && get_konsole_font "kde4-config"
         ;;
     esac
 }

--- a/neofetch
+++ b/neofetch
@@ -1568,47 +1568,26 @@ get_term_font() {
         ;;
 
         "konsole"*)
-            get_konsole_profile() {
-                konsole_windows=($(qdbus "${1}" | awk '/Windows\//'))
-                for window in "${konsole_windows[@]}"; do
-                    konsole_session="$(qdbus "${1}" "${window}" currentSession)"
-                    if ((child == "$(qdbus "${1}" /Sessions/"${konsole_session}" processId)")); then
-                        konsole_profile="$(qdbus "${1}" /Sessions/"${konsole_session}" environment |\
-                        awk -F '=' '/KONSOLE_PROFILE_NAME/ {print $2}')"
-                        break
-                    fi
-                done
-            }
-
-            get_konsole_font() {
-                profile_path="$("${1}" --path data | awk -F':' '{print $1}')/konsole"
-
-                # Profile filename can differ from profile name, so find the filename first, take first match
-                # It's possible that we have more than one file containing the same profile name
-                profile_filename="$(grep -l "Name=${konsole_profile}" "${profile_path}"/*.profile | head -n 1)"
-                [[ "${profile_filename}" ]] && term_font="$(awk -F '=|,' '/Font=/ {print $2 " " $3}' "${profile_filename}")"
-
-                # If there are no profiles or no font is defined in the profile, Konsole falls back to system's monospace font
-                # This fails if no fixed font is defined in kdeglobals, Konsole internally uses
-                # QFontDatabase::systemFont(QFontDatabase::FixedFont) or KGlobalSettings::fixedFont() in qt4 versions
-                [[ ! "${term_font}" ]] && term_font="$(awk -F '=|,' '/fixed=/ {print $2 " " $3}' "$("${1}" --path config --locate kdeglobals)")"
-            }
-
-            # Use Process ID from get_term().
-            # The variable can include 'PPid:' and also whitespace
-            # so we get rid of it here.
-            parent="$(trim "${parent/PPid:}")"
-
             # Get Process ID of current konsole window / tab
             child="$(get_ppid "$$")"
 
-            # We could have both: org.kde.konsole-PPID and org.kde.konsole
-            get_konsole_profile "org.kde.konsole-${parent}"
-            [[ ! "${konsole_profile}" ]] && get_konsole_profile "org.kde.konsole"
+            konsole_instances=($(qdbus | grep 'org.kde.konsole'))
 
-            # Try both: kde5 and kde4
-            [[ "$(which kf5-config)" ]] && get_konsole_font "kf5-config"
-            [[ ! "${term_font}" && "$(which kde4-config)" ]] && get_konsole_font "kde4-config"
+            for i in "${konsole_instances[@]}"; do
+                konsole_sessions=($(qdbus "${i}" | grep '/Sessions/'))
+                for session in "${konsole_sessions[@]}"; do
+                    if ((child == "$(qdbus "${i}" "${session}" processId)")); then
+                        profile="$(qdbus "${i}" "${session}" environment | awk -F '=' '/KONSOLE_PROFILE_NAME/ {print $2}')"
+                        break
+                    fi
+                done
+                [[ "$profile" ]] && break
+            done
+
+            # We could have two profile files for the same profile name, take first match
+            profile_filename="$(grep -l "Name=${profile}" "${HOME}"/.local/share/konsole/*.profile)"
+            profile_filename="${profile_filename/$'\n'*}"
+            [[ "$profile_filename" ]] && term_font="$(awk -F '=|,' '/Font=/ {print $2 " " $3}' "$profile_filename")"
         ;;
     esac
 }


### PR DESCRIPTION
I've rewritten the font detection for Konsole. It now
- works for `org.kde.konsole` and `org.kde-konsole-$PPID`
- works if the profile filename differs from the profile name
- doesn't use hardcoded config file paths
- works for KDE5 and KDE4

Tested on Arch, Kubuntu, openSUSE, Slackware, KDE neon.

Note:
With Konsole versions affected by https://bugs.kde.org/show_bug.cgi?id=358083 (I think..)
it's possible that we have two profile files containing the same profile name.

I noticed this behavior (with a new created user) on Kubuntu 16.04:
Starting Konsole -> edit current profile -> close konsole -> restart it -> edit current profile
Produced two differnt profile files with the same profile name in it.

That's the only situation I was able to produce two different profile files containing the same profile name.
But it's possible. So we have to make sure we get a valid filename from the grep command. ( head -n 1 )

Issues:
Detecting the fallback font fails if no fixed font is defined in kdeglobals.
This is the case on fresh installations or for new created users for example.

Konsole internally uses `QFontDatabase::systemFont(QFontDatabase::FixedFont)`
or `KGlobalSettings::fixedFont()` in qt4 versions.

The font settings are written to kdeglobals once the user changes fonts in the KDE System-Settings GUI.

So if the user doesn't edit a profile or the system fonts, no font will be detected.
I'm afraid there is not much we can do..

Maybe someone else knows a way to get the fixed Qt system font without writing (e.g. C++ or python) small helper programs? I couldn't find any existing commands.