### PR TITLE
Install Date: Rewrite function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ Neofetch now has an irc channel at `#neofetch` on Freenode. If you have any ques
 - Removed all `date` usage from `get_install_date()`.
 - Added a new function called `convert_time()` which takes the time stamped `ls` output and converts it to a pretty format. The function only uses bash so its much faster than calling `date`. This makes things simple and keeps the output consistent across all Operating Systems. Example: `2016-12-06 16:58:58.000000000` --> `Tue 06 Dec 2016 4:58 PM`
 - Added an option so users can choose between using 24-hour and 12-hour time format
+- `get_install_date()` will detect which `ls` program is being used instead of hardcoding them per OS.
 
 **Disk**<br \>
 

--- a/neofetch
+++ b/neofetch
@@ -1763,9 +1763,10 @@ get_install_date() {
 
     ls_prog="$(ls --version 2>&1)"
     case "$ls_prog" in
-        *"BusyBox"*) install_date="$(ls -dalcte "$install_file" | awk '{printf $10 " " $7 " " $8 " " $9}')" ;;
-        *"GNU coreutils"*) install_date="$(ls -dalct --full-time "$install_file" | awk '{printf $6 " " $7}')" ;;
-        *) install_date="$(ls -alctT "$install_file" | awk '{printf $9 " " $6 " "$7 " " $8}')" ;;
+        *"BusyBox"*) install_date="$(ls -tdce "$install_file" | awk '{printf $10 " " $7 " " $8 " " $9}')" ;;
+        *"crtime"*) install_date="$(ls -tdcE "$install_file" | awk '{printf $6 " " $7}')" ;;
+        *"GNU coreutils"*) install_date="$(ls -tcd --full-time "$install_file" | awk '{printf $6 " " $7}')" ;;
+        *) install_date="$(ls -dlctT "$install_file" | awk '{printf $9 " " $6 " "$7 " " $8}')" ;;
     esac
 
     install_date="${install_date//-/ }"

--- a/neofetch
+++ b/neofetch
@@ -1764,8 +1764,8 @@ get_install_date() {
     ls_prog="$(ls --version 2>&1)"
     case "$ls_prog" in
         *"BusyBox"*) install_date="$(ls -tdce "$install_file" | awk '{printf $10 " " $7 " " $8 " " $9}')" ;;
-        *"crtime"*) install_date="$(ls -tdcE "$install_file" | awk '{printf $6 " " $7}')" ;;
-        *"ACFHLRSZ"*) install_date="$(ls -dl "$install_file" | awk '{printf $6 " " $7}')" ;;
+        *"crtime"*) install_date="$(ls -tdcE "$install_file" | awk '{printf $6 " " $7}')" ;; # xpg4 (Solaris)
+        *"ACFHLRSZ"*) install_date="$(ls -dl "$install_file" | awk '{printf $6 " " $7}')" ;; # Toybox
         *"GNU coreutils"*) install_date="$(ls -tcd --full-time "$install_file" | awk '{printf $6 " " $7}')" ;;
         *) install_date="$(ls -dlctT "$install_file" | awk '{printf $9 " " $6 " "$7 " " $8}')" ;;
     esac

--- a/neofetch
+++ b/neofetch
@@ -1747,43 +1747,25 @@ get_users() {
 
 get_install_date() {
     case "$os" in
-        "Linux" | "iPhone OS")
-            install_date="$(ls -alct --full-time / | awk '/lost\+found|private/ {printf  $6 " " $7}')"
-        ;;
-
-        "Mac OS X")
-            install_date="$(ls -lUT /var/log/install.log | awk '{printf $9 " " $6 " " $7 " " $8}')"
-        ;;
-
+        "Linux" | "iPhone OS") install_file="/lost+found" ;;
+        "Mac OS X") install_file="/var/log/install.log" ;;
+        "Solaris") install_file="/var/sadm/system/logs/install_log" ;;
+        "Windows") install_file="/cygdrive/c/Windows/explorer.exe" ;;
+        "Haiku") install_file="/boot" ;;
         "BSD" | "MINIX")
             case "$kernel_name" in
-                "OpenBSD"* | "Bitrig"* | "MINIX")
-                    install_file="/"
-                ;;
-
-                "FreeBSD"*)
-                    install_file="/etc/hostid"
-                ;;
-
-                "NetBSD"* | "DragonFly"*)
-                    install_file="/etc/defaults/rc.conf"
-                ;;
+                "FreeBSD") install_file="/etc/hostid" ;;
+                "NetBSD" | "DragonFly"*) install_file="/etc/defaults/rc.conf" ;;
+                *) install_file="/" ;;
             esac
-
-            install_date="$(ls -alctT "$install_file" | awk '{printf $9 " " $6 " " $7 " " $8 " "}')"
         ;;
+    esac
 
-        "Windows")
-            install_date="$(ls -alct --full-time /cygdrive/c/Windows/explorer.exe | awk '{printf $8 " " $9}')"
-        ;;
-
-        "Solaris")
-            install_date="$(ls -alct --full-time /var/sadm/system/logs/install_log | awk '{printf $6 " " $7}')"
-        ;;
-
-        "Haiku")
-            install_date="$(ls -alctd --full-time /boot | awk '{printf $6 " " $7}')"
-        ;;
+    ls_prog="$(ls --version 2>&1)"
+    case "$ls_prog" in
+        *"BusyBox"*) install_date="$(ls -dalcte "$install_file" | awk '{printf $10 " " $7 " " $8 " " $9}')" ;;
+        *"GNU coreutils"*) install_date="$(ls -dalct --full-time "$install_file" | awk '{printf $6 " " $7}')" ;;
+        *) install_date="$(ls -alctT "$install_file" | awk '{printf $9 " " $6 " "$7 " " $8}')" ;;
     esac
 
     install_date="${install_date//-/ }"

--- a/neofetch
+++ b/neofetch
@@ -1765,6 +1765,7 @@ get_install_date() {
     case "$ls_prog" in
         *"BusyBox"*) install_date="$(ls -tdce "$install_file" | awk '{printf $10 " " $7 " " $8 " " $9}')" ;;
         *"crtime"*) install_date="$(ls -tdcE "$install_file" | awk '{printf $6 " " $7}')" ;;
+        *"ACFHLRSZ"*) install_date="$(ls -dl "$install_file" | awk '{printf $6 " " $7}')" ;;
         *"GNU coreutils"*) install_date="$(ls -tcd --full-time "$install_file" | awk '{printf $6 " " $7}')" ;;
         *) install_date="$(ls -dlctT "$install_file" | awk '{printf $9 " " $6 " "$7 " " $8}')" ;;
     esac


### PR DESCRIPTION
## Description

### Rationale

In Linux and Solaris, their commands are hardcoded to use GNU coreutils, so the function cannot be shown in systems without it, like Alpine (Busybox) and Oracle Solaris (xpg4). 

This PR will change the behaviour of `install_date` overall, so it will detect which `ls` program is being used: `Busybox`, `GNU coreutils`, `xpg4` (indicated by the use of `crtime` because `--version` doesn't work), Toybox (indicated by `ACFHLRSZ` because `--version` didn't provide any indication of "Toybox") or BSD ones (fallback), instead of hardcoding them per OS.

### Issues

Because I don't have a Windows (Cygwin) system, I cannot test it. As for Mac OS X, there's always Travis.

## TODO
- [ ] Testing
  - [x] Linux
    - [x] Any Linux with GNU coreutils
    - [x] Alpine Linux 
  - [x] BSD
    - [x] FreeBSD
    - [x] OpenBSD/Bitrig
    - [x] NetBSD/DragonFlyBSD
  - [x] Solaris
    - [x] OpenIndiana
    - [x] Oracle Solaris
  - [x] MINIX
  - [x] Mac OS X (Travis)
  - [ ] Windows (Cygwin)
  - [x] Haiku