### PR TITLE
Ascii: Glob match ascii art

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1944,6 +1944,8 @@ get_ascii() {
         for art in "${ascii_dir}/${ascii_distro:0:1}"*; do
             [[ "$ascii_distro" =~ ${art/*\/} ]] && { ascii="$art"; break; }
         done
+
+        [[ ! -f "$ascii" ]] && { to_off "Ascii: Ascii file not found, falling back to off mode."; return; }
     fi
 
     # Set locale to get correct padding.

--- a/neofetch
+++ b/neofetch
@@ -1940,10 +1940,15 @@ get_ascii() {
         # Remove 'linux' from 'linux mint'.
         [[ "$ascii_distro" =~ ^linux ]] && ascii_distro="${ascii_distro/linux }"
 
+        # If _value or -value was used, dom't loop.
+        [[ "$ascii_distro" =~ (-|_) ]] && { ascii="${ascii_dir}/${ascii_distro}"; ascii_loop="off"; }
+
         # ascii_dir/first_letter (example: 'ascii_dir/m'*)
-        for art in "${ascii_dir}/${ascii_distro:0:1}"*; do
-            [[ "$ascii_distro" =~ ${art/*\/} ]] && { ascii="$art"; break; }
-        done
+        if [[ "${ascii_loop:-on}" == "on" ]]; then
+            for art in "${ascii_dir}/${ascii_distro:0:1}"*; do
+                [[ "$ascii_distro" =~ ${art/*\/} ]] && { ascii="$art"; break; }
+            done
+        fi
 
         [[ ! -f "$ascii" ]] && { to_off "Ascii: Ascii file not found, falling back to off mode."; return; }
     fi

--- a/neofetch
+++ b/neofetch
@@ -20,7 +20,7 @@ export LANG=C
 export PATH="/usr/sbin:/sbin:${PATH}"
 
 # Set no case match.
-shopt -s nocasematch
+shopt -s nocasematch nocaseglob
 
 # Reset colors and bold.
 reset="\033[0m"
@@ -1922,34 +1922,28 @@ get_ascii() {
         [[ "$ascii" != "distro" && ! -f "$ascii" ]] && \
             err "Ascii: Ascii file not found, using distro ascii."
 
-        # Lowercase the distro name so we can match it to a file.
-        if (("$bash_version" <= 3)); then
-            ascii="$(tr '[:upper:]' '[:lower:]' <<< "$ascii_distro")"
-        else
-            ascii="${ascii_distro,,}"
-        fi
+        # Find ascii art dir.
+        if [[ -d "/usr/share/neofetch/ascii/distro" ]]; then
+            ascii_dir="/usr/share/neofetch/ascii/distro"
 
-        if [[ -f "/usr/share/neofetch/ascii/distro/${ascii/ *}" ]]; then
-            ascii="/usr/share/neofetch/ascii/distro/${ascii/ *}"
+        elif [[ -d "/usr/local/share/neofetch/ascii/distro" ]]; then
+            ascii_dir="/usr/local/share/neofetch/ascii/distro"
 
-        elif [[ -f "/usr/local/share/neofetch/ascii/distro/${ascii/ *}" ]]; then
-            ascii="/usr/local/share/neofetch/ascii/distro/${ascii/ *}"
-
-        elif [[ -f "/data/data/com.termux/files/usr/share/neofetch/ascii/distro/${ascii/ *}" ]]; then
-            ascii="/data/data/com.termux/files/usr/share/neofetch/ascii/distro/${ascii/ *}"
+        elif [[ -d "/data/data/com.termux/files/usr/share/neofetch/ascii/distro" ]]; then
+            ascii_dir="/data/data/com.termux/files/usr/share/neofetch/ascii/distro"
 
         else
             get_script_dir 2>/dev/null
-
-            # If the ascii file doesn't exist fallback to text mode.
-            if [[ -f "$script_dir/ascii/distro/${ascii/ *}" ]]; then
-                ascii="$script_dir/ascii/distro/${ascii/ *}"
-
-            else
-                to_off "Ascii: Ascii file not found, falling back to text mode."
-                return
-            fi
+            ascii_dir="${script_dir}/ascii/distro"
         fi
+
+        # Remove 'linux' from 'linux mint'.
+        [[ "$ascii_distro" =~ ^linux ]] && ascii_distro="${ascii_distro/linux }"
+
+        # ascii_dir/first_letter (example: 'ascii_dir/m'*)
+        for art in "${ascii_dir}/${ascii_distro:0:1}"*; do
+            [[ "$ascii_distro" =~ ${art/*\/} ]] && { ascii="$art"; break; }
+        done
     fi
 
     # Set locale to get correct padding.

--- a/neofetch
+++ b/neofetch
@@ -2546,18 +2546,8 @@ get_distro_colors() {
             set_colors 2 1
         ;;
 
-        "Debian"* | "Ubuntu"* | "DragonFly"* | "PacBSD"* | "Oracle"* | "BlankOn"* | "DracOS"* | "Peppermint"* | "Minix"*)
+        "Debian"* | "Ubuntu"* | "DragonFly"* | "PacBSD"* | "Oracle"* | "BlankOn"* | "DracOS"* | "Peppermint"* | "Minix"* | "antiX"* | "FreeBSD"*)
             set_colors 1 7 3
-        ;;
-
-        "antiX"*)
-            set_colors 1 7 3
-            ascii_distro="antix"
-        ;;
-
-        "FreeBSD"*)
-            set_colors 1 7 3
-            ascii_distro="freebsd"
         ;;
 
         "PCBSD"* | "TrueOS"*)
@@ -2587,20 +2577,15 @@ get_distro_colors() {
             set_colors 4 3
         ;;
 
-        "NetBSD"* | "Parabola"* | "Tails"* | "BLAG"* | "Funtoo"* | "SteamOS"* | "Devuan"*)
+        "NetBSD"* | "Parabola"* | "Tails"* | "BLAG"* | "Funtoo"* | "SteamOS"* | "Devuan"* | "Gentoo"*)
             set_colors 5 7
-        ;;
-
-        "Gentoo"*)
-            set_colors 5 7
-            ascii_distro="gentoo"
         ;;
 
         "OpenBSD"* | "GuixSD"* | "Pardus"*)
             set_colors 3 7 6 1 8
         ;;
 
-        "Manjaro"* | "Deepin"* | "LMDE"* | "Chapeau"* | "Bitrig"*)
+        "Manjaro"* | "Deepin"* | "LMDE"* | "Chapeau"* | "Bitrig"* | "KDE"* | *"Mint"*)
             set_colors 2 7
         ;;
 
@@ -2609,19 +2594,9 @@ get_distro_colors() {
             ascii_distro="suse"
         ;;
 
-        "KDE"*)
-            set_colors 2 7
-            ascii_distro="kde"
-        ;;
-
         "Android"*)
             set_colors 2 7
             ascii_length_force="19"
-        ;;
-
-        *"Mint"*)
-            set_colors 2 7
-            ascii_distro="mint"
         ;;
 
         "Puppy"* | "Quirky Werewolf"* | "Precise Puppy"*)
@@ -2631,7 +2606,6 @@ get_distro_colors() {
 
         "Sparky"*)
             set_colors 1 7
-            ascii_distro="sparky"
         ;;
 
         "Trisquel"* | "NixOS"* | "Zorin"* | "Antergos"*)
@@ -2640,7 +2614,6 @@ get_distro_colors() {
 
         "MX"*)
             set_colors 4 6 7
-            ascii_distro="mx"
         ;;
 
         "Travis")
@@ -2649,7 +2622,6 @@ get_distro_colors() {
 
         "Grombyang"*)
             set_colors 4 2 1
-            ascii_distro="grombyang"
         ;;
 
         "Void"* | "Haiku"*)


### PR DESCRIPTION
## Description

The goal of this PR is to make Neofetch fuzzy match ascii art.

For example:

- `Linux Mint` --> `mint`
- `LinuxMint` --> `mint`
- `Linux Mint 17.3 x86_64` --> `mint`
- `Mint` --> `mint`

## Features

- Removes a call to `tr` on bash 3!

## Issues

- [x] `distro_small` doesn't work.
- [x] `distro_old` doesn't work.
- [x] `distro-variant` doesn't work.
- [ ] Windows 10 ascii art doesn't work.

## TODO

- [ ] Testing.
- [ ] Clean up `get_distro_colors()` since we don't need as many single cases anymore.
- [x] Add back error handling.

## Note

I'm not sure if this is the best way of doing this. A safer but more hard-coded way of fixing these issues would be adding modifications to `get_distro_colors()`. For example:

```sh
case "$ascii_distro" in
    "Arch"* | "Arch Linux"*)
        set_colors 4 7 1
        distro_file="arch"
    ;;

    "Fedora"* | "RFRemix"*)
        set_colors 4 7 1
        distro_file="fedora"
    ;;

    # This would continue for every distro.
    # ...
    # ...
esac
```

This is imo the better solution but would increase the script size a ton. The benefits are that we won't have anymore detection issues and we can further simplify the `get_ascii()` function. Removing all `tr` calls and file checks.

What do you think @iandrewt and @konimex ?