### PR TITLE
Image: Add --loop to draw the image constantly

### DIFF
--- a/config/config
+++ b/config/config
@@ -504,6 +504,15 @@ image_source="ascii"
 # Values:  'dir'
 thumbnail_dir="${XDG_CACHE_HOME:-${HOME}/.cache}/thumbnails/neofetch"
 
+# Image loop
+# Setting this to on will make neofetch redraw the image constantly until
+# Ctrl+C is pressed. This fixes display issues in some terminal emulators.
+#
+# Default:  'off'
+# Values:   'on', 'off'
+# Flag:     --loop
+image_loop="off"
+
 # w3m-img path
 # Only works with the w3m backend.
 #

--- a/neofetch
+++ b/neofetch
@@ -3413,7 +3413,7 @@ get_args() {
             "--yoffset") yoffset="$2" ;;
             "--background_color" | "--bg_color") background_color="$2" ;;
             "--gap") gap="$2" ;;
-            "--loop") loop="on" ;;
+            "--loop") image_loop="on" ;;
             "--clean")
                 [[ -d "$thumbnail_dir" ]] && rm -rf "$thumbnail_dir"
                 rm -rf "/Library/Caches/neofetch/"
@@ -3515,8 +3515,9 @@ main() {
     # Show error messages.
     [[ "$verbose" == "on" ]] && printf "%b" "$err" >&2
 
-    # w3m-img: If `--loop` was used, constantly redraw the image.
-    while [[ "$loop" == "on" ]]; do display_image; sleep 1s; done
+    # If `--loop` was used, constantly redraw the image.
+    [[ "$image_backend" == "image" ]] && \
+        while [[ "$image_loop" == "on" ]]; do display_image; sleep 1s; done
 
     return 0
 }

--- a/neofetch
+++ b/neofetch
@@ -3238,6 +3238,7 @@ IMAGE:
                                 NOTE: --gap can take a negative value which will move the text closer to the left side.
 
     --clean                     Delete cached files and thumbnails.
+    --loop                      Redraw the image constantly until Ctrl+C is used. This fixes issues in some terminals emulators when using image mode.
 
 ASCII:
     --ascii value               Where to get the ascii from, Possible values:
@@ -3412,6 +3413,7 @@ get_args() {
             "--yoffset") yoffset="$2" ;;
             "--background_color" | "--bg_color") background_color="$2" ;;
             "--gap") gap="$2" ;;
+            "--loop") loop="on" ;;
             "--clean")
                 [[ -d "$thumbnail_dir" ]] && rm -rf "$thumbnail_dir"
                 rm -rf "/Library/Caches/neofetch/"
@@ -3512,6 +3514,9 @@ main() {
 
     # Show error messages.
     [[ "$verbose" == "on" ]] && printf "%b" "$err" >&2
+
+    # w3m-img: If `--loop` was used, constantly redraw the image.
+    while [[ "$loop" == "on" ]]; do display_image; sleep 1s; done
 
     return 0
 }

--- a/neofetch.1
+++ b/neofetch.1
@@ -197,6 +197,9 @@ NOTE: \fB\-\-gap\fR can take a negative value which will move the text closer to
 .TP
 \fB\-\-clean\fR
 Delete cached files and thumbnails.
+.TP
+\fB\-\-loop\fR
+Redraw the image constantly until Ctrl+C is used. This fixes issues in some terminals emulators when using image mode.
 .SS "ASCII:"
 .TP
 \fB\-\-ascii\fR value


### PR DESCRIPTION
## Description

This PR adds a new flag called `--loop` which causes the image to be redrawn constantly with a 1 second delay. 

This should hopefully fix #507.

## TODO

- [x] Add a config option.
