### PR TITLE
DE: Fix WM Theme not detected on MATE

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -639,6 +639,9 @@ get_wm_theme() {
             if [[ "$de" == "Deepin" ]]; then
                 wm_theme="$(gsettings get com.deepin.wrap.gnome.desktop.wm.preferences theme)"
 
+            elif [[ "$de" == "MATE" ]]; then
+                wm_theme="$(gsettings get org.mate.Marco.general theme)"
+
             else
                 wm_theme="$(gconftool-2 -g /apps/metacity/general/theme)"
             fi


### PR DESCRIPTION
On my system MATE WM Theme wasn't detected.

```
$ LANG=C gconftool-2 -g /apps/metacity/general/theme
No value set for `/apps/metacity/general/theme'
```