### PR TITLE
General: Fixes

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3064,12 +3064,12 @@ set_text_colors() {
         info_color="$reset"
 
         # If the ascii art uses 8 as a color, make the text the fg.
-        (($1 == 8)) && title_color="$reset"
-        (($2 == 8)) && subtitle_color="$reset"
+        ((${1:-1} == 8)) && title_color="$reset"
+        ((${2:-7} == 8)) && subtitle_color="$reset"
 
         # If the second color is white use the first for the subtitle.
-        (($2 == 7)) && subtitle_color="$(color "$1")"
-        (($1 == 7)) && title_color="$reset"
+        ((${2:-7} == 7)) && subtitle_color="$(color "$1")"
+        ((${1:-1} == 7)) && title_color="$reset"
     else
         title_color="$(color "${colors[0]}")"
         at_color="$(color "${colors[1]}")"

--- a/neofetch
+++ b/neofetch
@@ -456,7 +456,7 @@ get_packages() {
                     "FreeBSD") packages="$((packages+=$(pkg info | wc -l)))" ;;
                     *)
                         packages="$((packages+=$(ls -1 /var/db/pkg | wc -l)))"
-                        (("$packages" == "0")) && packages="$((packages+=$(pkg list | wc -l)))"
+                        ((packages == 0)) && packages="$((packages+=$(pkg list | wc -l)))"
                 esac
             fi
         ;;
@@ -488,7 +488,7 @@ get_packages() {
         ;;
     esac
 
-    (("$packages" == "0")) && unset packages
+    ((packages == 0)) && unset packages
 }
 
 get_shell() {
@@ -999,7 +999,7 @@ get_gpu() {
             IFS="$old_ifs"
 
             # Number the GPUs if more than one exists.
-            (( "${#gpus[@]}" > 1 )) && gpu_num=1
+            ((${#gpus[@]} > 1)) && gpu_num=1
 
             for gpu in "${gpus[@]}"; do
                 # GPU shorthand tests.
@@ -1311,7 +1311,7 @@ get_resolution() {
             [[ "$resolution" == *"@ Hz"* ]] && \
                 resolution="${resolution//@ Hz}"
 
-            (("${scale_factor%.*}" == 2)) && \
+            ((${scale_factor%.*} == 2)) && \
                 resolution="${resolution// @/@2x @}"
 
             if [[ "$refresh_rate" == "off" ]]; then
@@ -1940,7 +1940,7 @@ get_ascii() {
         # Calculate size of ascii file in line length / line count.
         line="${line//\$\{??\}}"
         line="${line//\\\\/\\}"
-        (("${#line}" > "${ascii_length:-0}")) && ascii_length="${#line}"
+        ((${#line} > ascii_length)) && ascii_length="${#line}"
         lines="$((lines+=1))"
     done < "$ascii"
 
@@ -2018,7 +2018,7 @@ get_wallpaper() {
                         image="$(awk -F'=' '/file/ {printf $2;exit;}' "${XDG_CONFIG_HOME}/nitrogen/bg-saved.cfg")"
 
                     else
-                        image="$(gsettings get org.gnome.dimage=esktop.background picture-uri)"
+                        image="$(gsettings get org.gnome.desktop.background picture-uri)"
                         image="$(decode_url "$image")"
                     fi
                 ;;
@@ -2147,7 +2147,7 @@ get_image_size() {
             image_size="$((columns * font_width / 2))"
             term_height="$((term_height - term_height / 4))"
 
-            (("$term_height" < "$image_size")) && \
+            ((term_height < image_size)) && \
                 image_size="$term_height"
         ;;
 
@@ -2155,7 +2155,7 @@ get_image_size() {
             percent="${image_size/\%}"
             image_size="$((percent * term_width / 100))"
 
-            (("$((percent * term_height / 50))" < "$image_size")) && \
+            (((percent * term_height / 50) < image_size)) && \
                 image_size="$((percent * term_height / 100))"
         ;;
 
@@ -2202,7 +2202,7 @@ make_thumbnail() {
             # This checks to see if height is greater than width
             # so we can do a better crop of portrait images.
             size="$og_height"
-            (("$og_height" > "$og_width")) && size="$og_width"
+            ((og_height > og_width)) && size="$og_width"
         fi
 
         case "$crop_mode" in
@@ -2483,7 +2483,7 @@ trim_quotes() {
 }
 
 uppercase() {
-    (("$bash_version" >= 4)) && printf "%s" "${1^}"
+    ((bash_version >= 4)) && printf "%s" "${1^}"
 }
 
 # COLORS
@@ -3064,12 +3064,12 @@ set_text_colors() {
         info_color="$reset"
 
         # If the ascii art uses 8 as a color, make the text the fg.
-        (("$1" == 8)) && title_color="$reset"
-        (("$2" == 8)) && subtitle_color="$reset"
+        (($1 == 8)) && title_color="$reset"
+        (($2 == 8)) && subtitle_color="$reset"
 
         # If the second color is white use the first for the subtitle.
-        (("$2" == 7)) && subtitle_color="$(color "$1")"
-        (("$1" == 7)) && title_color="$reset"
+        (($2 == 7)) && subtitle_color="$(color "$1")"
+        (($1 == 7)) && title_color="$reset"
     else
         title_color="$(color "${colors[0]}")"
         at_color="$(color "${colors[1]}")"
@@ -3280,7 +3280,7 @@ dynamic_prompt() {
 
     # If the info is higher than the ascii/image place the prompt
     # based on the info height instead of the ascii/image height.
-    if (("${lines:-0}" < "${info_height:-0}")); then
+    if ((lines < info_height)); then
         printf "\n"
         return
     else
@@ -3288,7 +3288,7 @@ dynamic_prompt() {
     fi
 
     # Set the prompt location.
-    if (("$lines" < 0)); then
+    if ((lines < 0)); then
         printf "%b" "\033[${lines/-}A"
     else
         printf "%b" "\033[${lines}B"
@@ -3697,7 +3697,7 @@ get_args() {
                         "--disable") continue ;;
                         "-"*) break ;;
                         *)
-                            (("$bash_version" >= 4)) && func="${func,,}"
+                            ((bash_version >= 4)) && func="${func,,}"
                             unset -f "get_$func"
                         ;;
                     esac


### PR DESCRIPTION
## Description

- Remove unnecessary quoting and variable assignment checks.
    - We don't need to check to see if the var is empty in arithmetic tests.
    - `$` and `${}` aren't needed/
    - Removed unnecessary quoting to match other existing syntax.
- Fixed typo in GNOME section of `get_wallpaper()`.


## TODO

- [ ] Testing
