### PR TITLE
GPU: Use readarray instead of modifying IFS

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -25,9 +25,6 @@ shopt -s nocasematch
 # Reset colors and bold.
 reset="\033[0m"
 
-# Save default IFS value.
-old_ifs="$IFS"
-
 # DETECT INFORMATION
 
 get_os() {
@@ -995,9 +992,8 @@ get_cpu_usage() {
 get_gpu() {
     case "$os" in
         "Linux")
-            IFS=$'\n'
-            gpus=($(lspci -mm | awk -F '\\"|\\" \\"' '/"Display|"3D|"VGA/ {print $3 " " $4}'))
-            IFS="$old_ifs"
+            # Read GPUs into array.
+            readarray gpus < <(lspci -mm | awk -F '\\"|\\" \\"' '/"Display|"3D|"VGA/ {print $3 " " $4}')
 
             # Number the GPUs if more than one exists.
             ((${#gpus[@]} > 1)) && gpu_num=1


### PR DESCRIPTION
## Description

`readarray` works better here since it ignores `IFS` and splits elements by newline.

@konimex, can you test this on your multi GPU system?