### PR TITLE
Disk: Add option to specify which disks to show

### DIFF
--- a/config/config
+++ b/config/config
@@ -316,6 +316,21 @@ public_ip_host="http://ident.me"
 #
 disk_show=('/')
 
+# Disk subtitle.
+# What to append to the Disk subtitle.
+#
+# Default: 'mount'
+# Values:  'mount', 'name'
+# Flag:    --disk_subtitle
+#
+# Example:
+# name:   'Disk (/dev/sda1): 74G / 118G (66%)'
+#         'Disk (/dev/sdb2): 74G / 118G (66%)'
+#
+# mount:  'Disk (/): 74G / 118G (66%)'
+#         'Disk (/mnt/Local Disk): 74G / 118G (66%)'
+disk_subtitle="mount"
+
 
 # Song
 

--- a/config/config
+++ b/config/config
@@ -32,7 +32,7 @@ print_info() {
     info "Memory" memory
 
     # info "CPU Usage" cpu_usage
-    # info "Disk (root)" disk
+    # info "Disk" disk
     # info "Battery" battery
     # info "Font" font
     # info "Song" song
@@ -230,6 +230,7 @@ gpu_brand="on"
 #   GPU1: Intel Integrated Graphics
 gpu_type="all"
 
+
 # Resolution
 
 
@@ -292,6 +293,28 @@ gtk3="on"
 # Values:  'url'
 # Flag:    --ip_host
 public_ip_host="http://ident.me"
+
+
+# Disk
+
+
+# Which disks to display.
+# The values can be any /dev/sdx, mount point or directory.
+# NOTE: By default we only show the disk info for '/'.
+#
+# Default: '/'
+# Values:  '/', '/dev/sdx', '/path/to/drive'.
+# Flag:    --disk_show
+#
+# Example:
+# disk_show=('/' '/dev/sdb1'):
+#      'Disk (/): 74G / 118G (66%)'
+#      'Disk (/mnt/Videos): 823G / 893G (93%)'
+#
+# disk_show=('/'):
+#      'Disk (/): 74G / 118G (66%)'
+#
+disk_show=('/')
 
 
 # Song

--- a/config/config
+++ b/config/config
@@ -299,11 +299,11 @@ public_ip_host="http://ident.me"
 
 
 # Which disks to display.
-# The values can be any /dev/sdx, mount point or directory.
+# The values can be any /dev/sdXX, mount point or directory.
 # NOTE: By default we only show the disk info for '/'.
 #
 # Default: '/'
-# Values:  '/', '/dev/sdx', '/path/to/drive'.
+# Values:  '/', '/dev/sdXX', '/path/to/drive'.
 # Flag:    --disk_show
 #
 # Example:

--- a/neofetch
+++ b/neofetch
@@ -1618,8 +1618,8 @@ get_disk() {
     # Get "df" flags.
     case "$os" in
         "Haiku") err "Disk doesn't work on Haiku due to the non-standard 'df'"; return ;;
-        "Minix") df_flags=(-h) ;;
-        *) df_flags=(-P -h) ;;
+        "Mac OS X") df_flags=(-P -h) ;;
+        *) df_flags=(-h) ;;
     esac
 
     # Create an array called 'disks' where each element is a separate line from

--- a/neofetch
+++ b/neofetch
@@ -1631,7 +1631,7 @@ get_disk() {
         { err "Disk: df failed to print the disks, make sure the disk_show array is set properly."; return; }
 
     for disk in "${disks[@]}"; do
-        # Create a second array and make each element split at whitespacw this time.
+        # Create a second array and make each element split at whitespace this time.
         disk_info=($disk)
         disk_perc="${disk_info[4]/'%'}"
 

--- a/neofetch
+++ b/neofetch
@@ -1642,6 +1642,12 @@ get_disk() {
 
         disk="${disk_info[2]/i} / ${disk_info[1]/i} (${disk_perc}%)"
 
+        # Subtitle
+        case "$disk_subtitle" in
+            "name") disk_sub="${disk_info[0]}" ;;
+            *) disk_sub="${disk_info[5]}" ;;
+        esac
+
         # Bar.
         case "$disk_display" in
             "bar") disk="$(bar "$disk_perc" "100")" ;;
@@ -1651,7 +1657,7 @@ get_disk() {
         esac
 
         # Append '(disk mount point)' to the subtitle.
-        prin "${subtitle} (${disk_info[5]})" "$disk"
+        prin "${subtitle} (${disk_sub})" "$disk"
     done
 }
 
@@ -3552,6 +3558,13 @@ INFO:
                                 Takes: '/', '/dev/sdXX', '/path/to/mount point'
 
                                 NOTE: Multiple values can be given. (--disk_show '/' '/dev/sdc1')
+
+    --disk_subtitle name/mount  What information to append to the Disk subtitle.
+
+                                'name' shows the disk's name (sda1, sda2, etc)
+
+                                'mount' shows the disk's mount point (/, /mnt/Local Disk, etc)
+
     --ip_host url               URL to query for public IP
     --song_shorthand on/off     Print the Artist/Title on separate lines
     --install_time on/off       Enable/Disable showing the time in Install Date output.
@@ -3716,6 +3729,7 @@ get_args() {
                 [[ "$cpu_temp" == "on" ]] && cpu_temp="C"
             ;;
 
+            "--disk_subtitle") disk_subtitle="$2" ;;
             "--disk_show")
                 unset disk_show
                 for arg in "$@"; do

--- a/neofetch
+++ b/neofetch
@@ -1642,6 +1642,10 @@ get_disk() {
         # Append '(disk mount point)' to the subtitle.
         prin "${subtitle} (${disk_info[5]})" "$disk"
     done
+
+    # Temporary test for mac OS.
+    df -h "${disk_show[@]:-/}"
+    exit
 }
 
 get_battery() {

--- a/neofetch
+++ b/neofetch
@@ -11,6 +11,7 @@
 bash_version="${BASH_VERSION/.*}"
 sys_locale="${LANG:-C}"
 XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-${HOME}/.config}"
+old_ifs="$IFS"
 
 # Speed up script by not using unicode.
 export LC_ALL=C
@@ -993,7 +994,9 @@ get_gpu() {
     case "$os" in
         "Linux")
             # Read GPUs into array.
-            readarray gpus < <(lspci -mm | awk -F '\\"|\\" \\"' '/"Display|"3D|"VGA/ {print $3 " " $4}')
+            IFS=$'\n'
+            gpus=($(lspci -mm | awk -F '\\"|\\" \\"' '/"Display|"3D|"VGA/ {print $3 " " $4}'))
+            IFS="$old_ifs"
 
             # Number the GPUs if more than one exists.
             ((${#gpus[@]} > 1)) && gpu_num=1
@@ -1624,7 +1627,9 @@ get_disk() {
 
     # Create an array called 'disks' where each element is a separate line from
     # df's output. We then unset the first element which removes the column titles.
-    readarray disks < <(df "${df_flags[@]}" "${disk_show[@]:-/}") && unset 'disks[0]'
+    IFS=$'\n'
+    disks=($(df "${df_flags[@]}" "${disk_show[@]:-/}")) && unset 'disks[0]'
+    IFS="$old_ifs"
 
     # Stop here if 'df' fails to print disk info.
     [[ -z "${disks[@]}" ]] && \

--- a/neofetch
+++ b/neofetch
@@ -1622,20 +1622,32 @@ get_disk() {
         *) df_flags=(-P -h) ;;
     esac
 
-    # Get the info for "/".
-    disks=($(df "${df_flags[@]}" /)) || { err "Disk: 'df' exited with error code 1"; return; }
+    # Create an array called 'disks' where each element is a separate line from
+    # df's output. We then unset the first element which removes the column titles.
+    readarray disks < <(df "${df_flags[@]}" "${disk_show[@]:-/}") && unset 'disks[0]'
 
-    # Put it all together.
-    disk_perc="${disks[11]/'%'}"
-    disk="${disks[9]/i} / ${disks[8]/i} (${disk_perc}%)"
+    # Stop here if 'df' fails to print disk info.
+    [[ -z "${disks[@]}" ]] && \
+        { err "Disk: df failed to print the disks, make sure the disk_show array is set properly."; return; }
 
-    # Bar.
-    case "$disk_display" in
-        "bar") disk="$(bar "$disk_perc" "100")" ;;
-        "infobar") disk+=" $(bar "$disk_perc" "100")" ;;
-        "barinfo") disk="$(bar "$disk_perc" "100") $disk" ;;
-        "perc") disk="${disk_perc}% $(bar "$disk_perc" "100")" ;;
-    esac
+    for disk in "${disks[@]}"; do
+        # Create a second array and make each element split at whitespacw this time.
+        disk_info=($disk)
+        disk_perc="${disk_info[4]/'%'}"
+
+        disk="${disk_info[2]/i} / ${disk_info[1]/i} (${disk_perc}%)"
+
+        # Bar.
+        case "$disk_display" in
+            "bar") disk="$(bar "$disk_perc" "100")" ;;
+            "infobar") disk+=" $(bar "$disk_perc" "100")" ;;
+            "barinfo") disk="$(bar "$disk_perc" "100") $disk" ;;
+            "perc") disk="${disk_perc}% $(bar "$disk_perc" "100")" ;;
+        esac
+
+        # Append '(disk mount point)' to the subtitle.
+        prin "${subtitle} (${disk_info[5]})" "$disk"
+    done
 }
 
 get_battery() {
@@ -3531,6 +3543,10 @@ INFO:
     --gtk3 on/off               Enable/Disable gtk3 theme/font/icons output
     --shell_path on/off         Enable/Disable showing \$SHELL path
     --shell_version on/off      Enable/Disable showing \$SHELL version
+    --disk_show value           Which disks to display.
+                                Takes: '/', '/dev/sdXX', '/path/to/mount point'
+
+                                NOTE: Multiple values can be given. (--disk_show '/' '/dev/sdc1')
     --ip_host url               URL to query for public IP
     --song_shorthand on/off     Print the Artist/Title on separate lines
     --install_time on/off       Enable/Disable showing the time in Install Date output.
@@ -3693,6 +3709,17 @@ get_args() {
             "--cpu_temp")
                 cpu_temp="$2"
                 [[ "$cpu_temp" == "on" ]] && cpu_temp="C"
+            ;;
+
+            "--disk_show")
+                unset disk_show
+                for arg in "$@"; do
+                    case "$arg" in
+                        "--disk_show") ;;
+                        "-"*) break ;;
+                        *) disk_show+=($arg)
+                    esac
+                done
             ;;
 
             "--disable")

--- a/neofetch
+++ b/neofetch
@@ -1614,17 +1614,11 @@ get_term_font() {
 
 get_disk() {
     type -p df >/dev/null 2>&1 || { err "Disk requires 'df' to function. Install 'df' to get disk info."; return; }
-
-    # Get "df" flags.
-    case "$os" in
-        "Haiku") err "Disk doesn't work on Haiku due to the non-standard 'df'"; return ;;
-        "Mac OS X") df_flags=(-P -h) ;;
-        *) df_flags=(-h) ;;
-    esac
+    [[ "$os" == "Haiku" ]] && { err "Disk doesn't work on Haiku due to the non-standard 'df'"; return; }
 
     # Create an array called 'disks' where each element is a separate line from
     # df's output. We then unset the first element which removes the column titles.
-    readarray disks < <(df "${df_flags[@]}" "${disk_show[@]:-/}") && unset 'disks[0]'
+    readarray disks < <(df -h "${disk_show[@]:-/}") && unset 'disks[0]'
 
     # Stop here if 'df' fails to print disk info.
     [[ -z "${disks[@]}" ]] && \

--- a/neofetch
+++ b/neofetch
@@ -1614,11 +1614,17 @@ get_term_font() {
 
 get_disk() {
     type -p df >/dev/null 2>&1 || { err "Disk requires 'df' to function. Install 'df' to get disk info."; return; }
-    [[ "$os" == "Haiku" ]] && { err "Disk doesn't work on Haiku due to the non-standard 'df'"; return; }
+
+    # Get "df" flags.
+    case "$os" in
+        "Haiku") err "Disk doesn't work on Haiku due to the non-standard 'df'"; return ;;
+        "Mac OS X") df_flags=(-P -h) ;;
+        *) df_flags=(-h) ;;
+    esac
 
     # Create an array called 'disks' where each element is a separate line from
     # df's output. We then unset the first element which removes the column titles.
-    readarray disks < <(df -h "${disk_show[@]:-/}") && unset 'disks[0]'
+    readarray disks < <(df "${df_flags[@]}" "${disk_show[@]:-/}") && unset 'disks[0]'
 
     # Stop here if 'df' fails to print disk info.
     [[ -z "${disks[@]}" ]] && \
@@ -1642,11 +1648,6 @@ get_disk() {
         # Append '(disk mount point)' to the subtitle.
         prin "${subtitle} (${disk_info[5]})" "$disk"
     done
-
-    # Temporary test for mac OS.
-    df -h "${disk_show[@]:-/}"
-    df -h /
-    exit
 }
 
 get_battery() {

--- a/neofetch
+++ b/neofetch
@@ -1645,6 +1645,7 @@ get_disk() {
 
     # Temporary test for mac OS.
     df -h "${disk_show[@]:-/}"
+    df -h /
     exit
 }
 

--- a/neofetch.1
+++ b/neofetch.1
@@ -90,6 +90,12 @@ Enable/Disable showing $SHELL path
 \fB\-\-shell_version\fR on/off
 Enable/Disable showing $SHELL version
 .TP
+\fB\-\-disk_show\fR value
+Which disks to display.
+Takes: '/', '/dev/sdXX', '/path/to/mount point'
+.IP
+NOTE: Multiple values can be given. (\fB\-\-disk_show\fR '/' '/dev/sdc1')
+.TP
 \fB\-\-ip_host\fR url
 URL to query for public IP
 .TP

--- a/neofetch.1
+++ b/neofetch.1
@@ -96,6 +96,13 @@ Takes: '/', '/dev/sdXX', '/path/to/mount point'
 .IP
 NOTE: Multiple values can be given. (\fB\-\-disk_show\fR '/' '/dev/sdc1')
 .TP
+\fB\-\-disk_subtitle\fR name/mount
+What information to append to the Disk subtitle.
+.IP
+\&'name' shows the disk's name (sda1, sda2, etc)
+.IP
+\&'mount' shows the disk's mount point (/, \fI\,/mnt/Local\/\fP Disk, etc)
+.TP
 \fB\-\-ip_host\fR url
 URL to query for public IP
 .TP


### PR DESCRIPTION
## Description

This PR adds a new option called `disk_show` which allows you to specify which disks you want to display in the info. (one per line).


## Features

- Display multiple disks (one per line).
- Subtitle is updated to display mount point `Disk (/)`, `Disk (/mnt/Local Disk)`.

## Issues

- The subtitle currently shows mount point, should we instead display the drive name? `/dev/sdXX` 

```sh
# Example:

# Mount point (Current behavior)
Disk (/mnt/Videos): 24G / 60G (45%)

# Drive name
Disk (/dev/sdc1): 24G / 60G (45%)
```

## TODO

- [x] Testing
    - [x] Linux
    - [x] MacOS
        - Broken in travis.
    - [x] BSD
        - [x] OpenBSD
        - [x] FreeBSD
        - [x] NetBSD
        - [x] DragonflyBSD
    - [x] MINIX 
    - [x] Windows
    - [x] Solaris

## Testing

```sh
# Example command.
neofetch --disk_show '/' '/dev/sdc1' '/mnt/Videos'

# Inside your neofetch config
disk_show=('/' '/dev/sdc1' '/mnt/Videos')
```
