### PR TITLE
Images: Add new image backends.

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2380,6 +2380,12 @@ display_image() {
             text_padding="$((columns / 2 + gap))"
             zws=
         ;;
+
+        "caca")
+            img2txt -W "$((width / font_width))" -H "$((height / font_height))" --gamma=0.6 "$image" || to_off "Images: catimg failed to display the image."
+            text_padding="$((columns / 2 + gap))"
+            zws=
+        ;;
     esac
 }
 

--- a/neofetch
+++ b/neofetch
@@ -2357,6 +2357,7 @@ make_thumbnail() {
 }
 
 display_image() {
+    image_program="catimg"
     case "$image_program" in
         "w3m")
             # Add a tiny delay to fix issues with images not
@@ -2372,6 +2373,12 @@ display_image() {
 
         "tycat")
             tycat "$image" || to_off "Images: tycat failed to display the image."
+        ;;
+
+        "catimg")
+            catimg -w "$columns" "$image" || to_off "Images: catimg failed to display the image."
+            text_padding="$((columns / 2 + gap))"
+            zws=
         ;;
     esac
 }
@@ -2548,7 +2555,7 @@ get_underline() {
 
 get_line_break() {
     # Print it directly.
-    printf "%s\n" "${zws} "
+    printf "%s\n" "${zws}"
 
     # Calculate info height.
     ((++info_height))


### PR DESCRIPTION
## Description

This adds image backends for:

- [catimg](https://github.com/posva/catimg)
- [libcaca](http://caca.zoy.org/wiki/libcaca)

**NOTE:** 

- This PR currently hard-codes image backend to `catimg` for testing purposes.
- This won't be merged until the image related stuff is finished from #613.

## catimg

![2017-01-14-153205_580x380_scrot](https://cloud.githubusercontent.com/assets/6799467/21952387/c00b1ab6-da6e-11e6-91e5-0f6dd4cf4a7e.png)

![2017-01-14-160315_515x360_scrot](https://cloud.githubusercontent.com/assets/6799467/21952520/513ef85a-da73-11e6-9411-be5465574db9.png)

## libcaca

![2017-01-14-154309_545x350_scrot](https://cloud.githubusercontent.com/assets/6799467/21952428/703d6604-da70-11e6-8f8d-ba6aefd1d3c2.png)

![2017-01-14-160554_505x340_scrot](https://cloud.githubusercontent.com/assets/6799467/21952524/7905b0d6-da73-11e6-8064-9d4f7e23b0d3.png)
