### PR TITLE
Restore multicolored Arch ascii art

### DIFF
--- a/ascii/distro/arch
+++ b/ascii/distro/arch
@@ -7,9 +7,9 @@ ${c1}                   -`
              `/:-:++oooo+:
             `/++++/+++++++:
            `/++++++++++++++:
-          `/+++ooooooooooooo/`
-         ./ooosssso++osssssso+`
-        .oossssso-````/ossssss+`
+          `/+++o${c2}oooooooo${c1}oooo/`
+         ./${c2}ooosssso++osssssso${c1}+`
+${c2}        .oossssso-````/ossssss+`
        -osssssso.      :ssssssso.
       :osssssss/        osssso+++.
      /ossssssss/        +ssssooo/-


### PR DESCRIPTION
## Description

Looking at the commit history, I'm guessing this was accidentally removed? If users desire a monochrome logo, they can use the `ascii_colors=(distro)` syntax in the config file.


## Features

Multi-colored Arch distro image