### PR TITLE
Info: [WIP] Add info output formats 2

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1089,6 +1089,7 @@ get_gpu() {
                 fi
 
                 subtitles+=("${1}${gpu_num}")
+                func_names+=("gpu")
                 info+=("$gpu")
             done
 
@@ -1338,9 +1339,11 @@ get_song() {
 
         if [[ "$song" != "$artist" ]]; then
             subtitles+=("Artist" "Song")
+            func_names+=("artist" "song")
             info+=("$artist" "$song")
         else
             subtitles+=("${1}")
+            func_names+=("song")
             info+=("$song")
         fi
 
@@ -1734,9 +1737,9 @@ get_disk() {
 
         # Append '(disk mount point)' to the subtitle.
         subtitles+=("${1} (${disk_sub})")
+        func_names+=("disk")
         info+=("$disk")
     done
-
     multi_line="on"
 }
 
@@ -1763,6 +1766,7 @@ get_battery() {
                 esac
 
                 subtitles+=("${1}${bat: -1}")
+                func_names+=("battery")
                 info+=("$battery")
             done
             multi_line="on"
@@ -2494,14 +2498,14 @@ scrot_program() {
 # TEXT FORMATTING
 
 info() {
-    func_names+=("${2:-$1}")
 
     # Call the function.
-    "get_${func_names[-1]}" "$1" 2>/dev/null
+    get_"${2:-${1}}" "$1" 2>/dev/null
 
     # If the function printed multiple lines of info,
     # dont append it to the array.
     if [[ -z "$multi_line" ]]; then
+        func_names+=("${2:-${1}}")
         subtitles+=("$1")
         info+=("$(trim "${!func_names[-1]}")")
     fi
@@ -2512,7 +2516,6 @@ info() {
 get_info() {
     print_info
 
-    info_format="nf"
     case "$info_format" in
         "tab")
             for i in "${!info[@]}"; do
@@ -2532,9 +2535,8 @@ get_info() {
 
         "yaml")
             for i in "${!info[@]}"; do
-                echo "${subtitles[$i]}"
-                continue
-                [[ "${info[$i]}" ]] && printf "%s\n" "${func_names[$i]}: \"${info[$i]}\""
+                [[ "${info[$i]}" && "${func_names[$i]}" != "cols" ]] && \
+                    printf "%s\n" "${func_names[$i]}: \"${info[$i]}\""
             done
         ;;
 
@@ -3892,6 +3894,10 @@ get_args() {
             ;;
 
             # Text Formatting
+            "--info_format") info_format="$2"; image_source="off" ;;
+            "--json") info_format="json"; image_source="off" ;;
+            "--yaml") info_format="yaml"; image_source="off" ;;
+            "--tab")  info_format="tab"; image_source="off" ;;
             "--underline") underline_enabled="$2" ;;
             "--underline_char") underline_char="$2" ;;
             "--bold") bold="$2" ;;

--- a/neofetch
+++ b/neofetch
@@ -300,8 +300,6 @@ get_model() {
 get_title() {
     user="${USER:-$(whoami || printf "%s" "${HOME/*\/}")}"
     hostname="${HOSTNAME:-$(hostname)}"
-    title="${title_color}${bold}${user}${at_color}@${title_color}${bold}${hostname}"
-    length="$((${#user} + ${#hostname} + 1))"
 }
 
 get_kernel() {
@@ -1090,10 +1088,11 @@ get_gpu() {
                     gpu="${gpu/Intel }"
                 fi
 
-                prin "${subtitle}${gpu_num}" "$gpu"
+                info+=("$gpu")
                 ((++gpu_num))
             done
 
+            multi_line="on"
             return
         ;;
 
@@ -1338,11 +1337,13 @@ get_song() {
         song="${song/$artist - }"
 
         if [[ "$song" != "$artist" ]]; then
-            prin "Artist" "$artist"
-            prin "Song" "$song"
+            info+=("$artist")
+            info+=("$song")
         else
-            prin "$subtitle" "$song"
+            info+=("$song")
         fi
+
+        multi_line="on"
     fi
 }
 
@@ -1731,8 +1732,9 @@ get_disk() {
         esac
 
         # Append '(disk mount point)' to the subtitle.
-        prin "${subtitle} (${disk_sub})" "$disk"
+        info+=("$disk")
     done
+    multi_line="on"
 }
 
 get_battery() {
@@ -1757,8 +1759,9 @@ get_battery() {
                     "barinfo") battery="$(bar "$capacity" 100) ${battery}" ;;
                 esac
 
-                prin "${subtitle}${bat: -1}" "$battery"
+                info+=("$battery")
             done
+            multi_line="on"
             return
         ;;
 
@@ -1930,14 +1933,11 @@ get_cols() {
         cols="${cols%%'nl'}"
         cols="${cols//nl/\\n\\033[${text_padding}C${zws}}"
 
-        printf "%b\n" "\033[${text_padding}C${zws}${cols}"
+        info+=("$cols")
         info_height="$((info_height+=block_height+2))"
     fi
 
     unset -v blocks blocks2 cols
-
-    # Tell info() that we printed manually.
-    prin=1
 }
 
 # IMAGES
@@ -2491,71 +2491,82 @@ scrot_program() {
 # TEXT FORMATTING
 
 info() {
-    # Save subtitle value.
-    subtitle="$1"
-
-    # Make sure that $prin is unset.
-    unset -v prin
+    subtitles+=("$1")
+    func_names+=("${2:-$1}")
 
     # Call the function.
     "get_${2:-$1}" 2>/dev/null
 
-    # If the get_func function called 'prin' directly, stop here.
-    [[ "$prin" ]] && return
+    # If the function printed multiple lines of info,
+    # dont append it to the array.
+    [[ -z "$multi_line" ]] && info+=("$(trim "${!2:-${!1}}")")
 
-    # Update the variable.
-    output="$(trim "${!2:-${!1}}")"
-
-    if [[ "$2" && "${output// }" ]]; then
-        length="$((${#1} + ${#output} + 2))"
-        prin "$1" "$output"
-
-    elif [[ "${output// }" ]]; then
-        [[ -z "$length" ]] && length="${#output}"
-        prin "$output"
-
-    else
-        err "Info: Couldn't detect ${1}."
-    fi
+    unset -v multi_line
 }
 
-prin() {
-    # If $2 doesn't exist we format $1 as info.
-    [[ -z "$2" ]] && local subtitle_color="$info_color"
+get_info() {
+    print_info
 
-    # Format the output.
-    string="${1//$'\033[0m'}${2:+: $2}"
-    string="$(trim "$string")"
-    string="${string/:/${reset}${colon_color}:${info_color}}"
-    string="${subtitle_color}${bold}${string}"
+    info_format="yaml"
+    case "$info_format" in
+        "tab")
+            for i in "${!info[@]}"; do
+                [[ "${info[$i]}" ]] && printf "%s\t%s\n" "${func_names[$i]}" "${info[$i]}"
+            done
+        ;;
 
-    # Print the info.
-    printf "%b\n" "${text_padding:+\033[${text_padding}C}${zws}${string}${reset} "
+        "json")
+            printf "%s\n" "{"
 
-    # Calculate info height.
-    ((++info_height))
+            for i in "${!info[@]}"; do
+                [[ "${info[$i]}" ]] && printf "\t%s\n" "\"${func_names[$i]}\": \"${info[$i]}\""
+            done
 
-    # Log that prin was used.
-    prin=1
-}
+            printf "%s\n" "}"
+        ;;
 
-get_underline() {
-    if [[ "$underline_enabled" == "on" ]]; then
-        printf -v underline "%${length}s"
-        underline="${underline_color}${underline// /$underline_char}"
-        unset -v length
-    fi
-}
+        "yaml")
+            for i in "${!info[@]}"; do
+                [[ "${info[$i]}" ]] && printf "%s\n" "${func_names[$i]}: \"${info[$i]}\""
+            done
+        ;;
 
-get_line_break() {
-    # Print it directly.
-    printf "%s\n" "${zws} "
+        *)
+            for i in "${!info[@]}"; do
+                # Line length
+                length="$((${#subtitles[$i]} + ${#info[$i]} + 2))"
 
-    # Calculate info height.
-    ((++info_height))
+                # Format the info.
+                case "${func_names[$i]}" in
+                    "title") string="${title_color}${bold}${user}${at_color}@${title_color}${bold}${hostname}" ;;
+                    "line_break") string="${zws}" ;;
+                    "cols") string="${info[$i]}" ;;
+                    "underline")
+                        if [[ "$underline_enabled" == "on" ]]; then
+                            printf -v underline "%${length}s"
+                            string="${underline_color}${underline// /$underline_char}"
+                        fi
+                    ;;
 
-    # Tell info() that we printed manually.
-    prin=1
+                    *)
+                        if [[ "${info[$i]}" ]]; then
+                            string="${subtitles[$i]}: ${info[$i]}"
+                            string="${string/:/${reset}${colon_color}:${info_color}}"
+                            string="${subtitle_color}${bold}${string}"
+                        else
+                            err "Info: Failed to detect ${func_names[$i]}"
+                            continue
+                        fi
+                    ;;
+                esac
+
+                # Print the info.
+                printf "%b\n" "${text_padding:+\033[${text_padding}C}${zws}${string}${reset} "
+                unset -v length
+                ((++info_height))
+            done
+        ;;
+    esac
 }
 
 get_bold() {
@@ -3445,7 +3456,6 @@ old_functions() {
         get_termfont() { get_term_font; termfont="$term_font"; }
         get_localip() { get_local_ip; localip="$local_ip"; }
         get_publicip() { get_public_ip; publicip="$public_ip"; }
-        get_linebreak() { get_line_break; linebreak="$line_break"; }
     fi
 
     get_birthday() { get_install_date; birthday="$install_date"; }
@@ -4005,7 +4015,9 @@ main() {
     get_image_backend
     old_functions
     get_cache_dir
-    print_info 2>/dev/null
+    get_info
+    # print_info 2>/dev/null
+
     dynamic_prompt
 
     # w3m-img: Draw the image a second time to fix

--- a/neofetch
+++ b/neofetch
@@ -1088,8 +1088,8 @@ get_gpu() {
                     gpu="${gpu/Intel }"
                 fi
 
+                subtitles+=("${1}${gpu_num}")
                 info+=("$gpu")
-                ((++gpu_num))
             done
 
             multi_line="on"
@@ -1337,9 +1337,10 @@ get_song() {
         song="${song/$artist - }"
 
         if [[ "$song" != "$artist" ]]; then
-            info+=("$artist")
-            info+=("$song")
+            subtitles+=("Artist" "Song")
+            info+=("$artist" "$song")
         else
+            subtitles+=("${1}")
             info+=("$song")
         fi
 
@@ -1732,8 +1733,10 @@ get_disk() {
         esac
 
         # Append '(disk mount point)' to the subtitle.
+        subtitles+=("${1} (${disk_sub})")
         info+=("$disk")
     done
+
     multi_line="on"
 }
 
@@ -1759,6 +1762,7 @@ get_battery() {
                     "barinfo") battery="$(bar "$capacity" 100) ${battery}" ;;
                 esac
 
+                subtitles+=("${1}${bat: -1}")
                 info+=("$battery")
             done
             multi_line="on"
@@ -2491,15 +2495,17 @@ scrot_program() {
 # TEXT FORMATTING
 
 info() {
-    subtitles+=("$1")
     func_names+=("${2:-$1}")
 
     # Call the function.
-    "get_${2:-$1}" 2>/dev/null
+    "get_${func_names[-1]}" "$1" 2>/dev/null
 
     # If the function printed multiple lines of info,
     # dont append it to the array.
-    [[ -z "$multi_line" ]] && info+=("$(trim "${!2:-${!1}}")")
+    if [[ -z "$multi_line" ]]; then
+        subtitles+=("$1")
+        info+=("$(trim "${!func_names[-1]}")")
+    fi
 
     unset -v multi_line
 }
@@ -2527,6 +2533,8 @@ get_info() {
 
         "yaml")
             for i in "${!info[@]}"; do
+                echo "${subtitles[$i]}"
+                continue
                 [[ "${info[$i]}" ]] && printf "%s\n" "${func_names[$i]}: \"${info[$i]}\""
             done
         ;;

--- a/neofetch
+++ b/neofetch
@@ -1937,11 +1937,10 @@ get_cols() {
         cols="${cols%%'nl'}"
         cols="${cols//nl/\\n\\033[${text_padding}C${zws}}"
 
-        info+=("$cols")
         info_height="$((info_height+=block_height+2))"
     fi
 
-    unset -v blocks blocks2 cols
+    unset -v blocks blocks2
 }
 
 # IMAGES
@@ -2513,7 +2512,7 @@ info() {
 get_info() {
     print_info
 
-    info_format="yaml"
+    info_format="nf"
     case "$info_format" in
         "tab")
             for i in "${!info[@]}"; do
@@ -2547,8 +2546,8 @@ get_info() {
                 # Format the info.
                 case "${func_names[$i]}" in
                     "title") string="${title_color}${bold}${user}${at_color}@${title_color}${bold}${hostname}" ;;
-                    "line_break") string="${zws}" ;;
-                    "cols") string="${info[$i]}" ;;
+                    "line_break") string="$zws" ;;
+                    "cols") string="$cols" ;;
                     "underline")
                         if [[ "$underline_enabled" == "on" ]]; then
                             printf -v underline "%${length}s"
@@ -2568,7 +2567,6 @@ get_info() {
                     ;;
                 esac
 
-                # Print the info.
                 printf "%b\n" "${text_padding:+\033[${text_padding}C}${zws}${string}${reset} "
                 unset -v length
                 ((++info_height))


### PR DESCRIPTION
## Description

This is a much simpler version of #617 and doesn't have any of the issues. This also works with the existing user's config.

## Features

- Adds `--info_format` to change the output format for the info.
- Adds `--json` to print the info in `json`.
- Adds `--yaml` to print the info in `yaml`.
- Adds `--tab` to print the info in a tab separated list`.

## Testing

Here's the basic usage:

```sh
# Output in format.
neofetch --info_format json

# Output in json.
neofetch --json

# Output in yaml.
neofetch --yaml

# Output in tab format.
neofetch --tab

# Sending output to a file
neofetch --json > neofetch.json
```

## Issues

None yet(?)

## TODO

- [ ] Cleanup
- [ ] Docs

## Note

I'm still not happy with this implementation but we'll see where it goes.