### PR TITLE
Makefile: Move default neofetch config to /etc/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,16 +9,18 @@ all:
 
 install:
 	$(INSTALL_DIR) $(DESTDIR)$(PREFIX)/bin
+	$(INSTALL_DIR) $(DESTDIR)/etc/neofetch
 	$(INSTALL_DIR) $(DESTDIR)$(PREFIX)/share/neofetch/ascii/distro
 	$(INSTALL_DIR) $(DESTDIR)$(PREFIX)/share/man/man1
 	$(INSTALL_PROG) neofetch $(DESTDIR)$(PREFIX)/bin/neofetch
 	$(INSTALL_FILE) neofetch.1 $(DESTDIR)$(PREFIX)/share/man/man1/neofetch.1
-	$(INSTALL_FILE) config/config $(DESTDIR)$(PREFIX)/share/neofetch/config
+	$(INSTALL_FILE) config/config $(DESTDIR)/etc/neofetch/config
 	$(INSTALL_FILE) ascii/distro/* $(DESTDIR)$(PREFIX)/share/neofetch/ascii/distro
 
 uninstall:
 	$(RM) $(DESTDIR)$(PREFIX)/bin/neofetch
 	$(RM) $(DESTDIR)$(PREFIX)/share/man/man1/neofetch.1
 	$(RM) -r $(DESTDIR)$(PREFIX)/share/neofetch
+	$(RM) -r $(DESTDIR)/etc/neofetch
 
 

--- a/neofetch
+++ b/neofetch
@@ -3262,14 +3262,11 @@ get_script_dir() {
 }
 
 get_default_config() {
-    if [[ -f "/usr/share/neofetch/config" ]]; then
-        default_config="/usr/share/neofetch/config"
+    if [[ -f "/etc/neofetch/config" ]]; then
+        default_config="/etc/neofetch/config"
 
-    elif [[ -f "/usr/local/share/neofetch/config" ]]; then
-        default_config="/usr/local/share/neofetch/config"
-
-    elif [[ -f "/data/data/com.termux/files/usr/share/neofetch/config" ]]; then
-        default_config="/data/data/com.termux/files/usr/share/neofetch/config"
+    elif [[ -f "/data/data/com.termux/files/etc/neofetch/config" ]]; then
+        default_config="/data/data/com.termux/files/etc/neofetch/config"
 
     else
         get_script_dir


### PR DESCRIPTION
## Description

This PR changes the install location for the config file to `/etc/neofetch` instead of `/usr/share/neofetch`, this way the default config file acts as a system-wide config for neofetch.

## Notes

- I'm unsure about the Makefile now, is it ok to hard-code `/etc/` without a `$(PREFIX)`?
    - Should we add a `/usr/` prefix variable and a `/etc/` variable?