### PR TITLE
General: Neofetch now understands relative paths

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2017,7 +2017,7 @@ get_ascii() {
 
         else
             [[ -z "$script_dir" ]] && script_dir="$(get_full_path "$0")"
-            ascii_dir="${script_dir}/ascii/distro"
+            ascii_dir="${script_dir%/*}/ascii/distro"
         fi
 
         image_source="${ascii_dir}/${ascii_file}"
@@ -2059,7 +2059,7 @@ get_ascii() {
 
 get_image_source() {
     case "$image_source" in
-        "auto" | "wall"*)
+        "auto" | "wallpaper")
             get_wallpaper 2>/dev/null
         ;;
 
@@ -3258,7 +3258,7 @@ get_full_path() {
     # For example "Pictures/Wallpapers" --> "/home/dylan/Pictures/Wallpapers"
 
     # If the file exists in the current directory, stop here.
-    [[ -f "${PWD}/${1/*\/}" ]] && { printf "%s\n" "${PWD}/${1/*\/}"; return; }
+    [[ -f "${PWD}/${1%/*}" ]] && { printf "%s\n" "${PWD}/${1%/*}"; return; }
 
     if ! cd "${1%/*}"; then
         err "Error: Directory '${1%/*}' doesn't exist or is inaccessible"
@@ -3290,8 +3290,8 @@ get_default_config() {
 
     else
         [[ -z "$script_dir" ]] && script_dir="$(get_full_path "$0")"
-        default_config="${script_dir}/config/config"
-        travis_config="${script_dir}/config/travis"
+        default_config="${script_dir%/*}/config/config"
+        travis_config="${script_dir%/*}/config/travis"
     fi
 
     if source "$default_config"; then
@@ -3333,7 +3333,7 @@ get_user_config() {
     else
         [[ -z "$script_dir" ]] && script_dir="$(get_full_path "$0")"
 
-        cp "${script_dir}/config/config" "${XDG_CONFIG_HOME}/neofetch"
+        cp "${script_dir%/*}/config/config" "${XDG_CONFIG_HOME}/neofetch"
         config_file="${XDG_CONFIG_HOME}/neofetch/config"
     fi
 
@@ -4000,7 +4000,10 @@ get_args() {
             "--config")
                 case "$2" in
                     "none" | "off" | "") ;;
-                    *) config_file="$2"; get_user_config 2>/dev/null ;;
+                    *)
+                        config_file="$(get_full_path "$2")"
+                        get_user_config 2>/dev/null
+                    ;;
                 esac
             ;;
             "-v") verbose="on" ;;

--- a/neofetch
+++ b/neofetch
@@ -3261,8 +3261,8 @@ get_full_path() {
     [[ -f "${PWD}/${1/*\/}" ]] && { printf "%s\n" "${PWD}/${1/*\/}"; return; }
 
     if ! cd "${1%/*}"; then
-        printf "%s\n" "Error: Directory '${1%/*}' doesn't exist or is inaccessible"
-        printf "%s\n" "       Check that the directory exists or try another directory."
+        err "Error: Directory '${1%/*}' doesn't exist or is inaccessible"
+        err "       Check that the directory exists or try another directory."
         exit 1
     fi
 

--- a/neofetch
+++ b/neofetch
@@ -2016,7 +2016,7 @@ get_ascii() {
             ascii_dir="/data/data/com.termux/files/usr/share/neofetch/ascii/distro"
 
         else
-            get_script_dir 2>/dev/null
+            [[ -z "$script_dir" ]] && script_dir="$(get_full_path "$0")"
             ascii_dir="${script_dir}/ascii/distro"
         fi
 
@@ -2064,6 +2064,9 @@ get_image_source() {
         ;;
 
         *)
+            # Get the absolute path.
+            image_source="$(get_full_path "$image_source")"
+
             if [[ -d "$image_source" ]]; then
                 shopt -s nullglob
                 files=("${image_source%/}"/*.{png,jpg,jpeg,jpe,gif})
@@ -3250,22 +3253,32 @@ err() {
     err+="$(color 1)[!]\033[0m $1\n"
 }
 
-get_script_dir() {
-    [[ "$script_dir" ]] && return
+get_full_path() {
+    # This function finds the absolute path from a relative one.
+    # For example "Pictures/Wallpapers" --> "/home/dylan/Pictures/Wallpapers"
 
-    # Use $0 to get the script's physical path.
-    cd "${0%/*}" || exit
-    script_dir="${0##*/}"
+    # If the file exists in the current directory, stop here.
+    [[ -f "${PWD}/${1/*\/}" ]] && { printf "%s\n" "${PWD}/${1/*\/}"; return; }
+
+    if ! cd "${1%/*}"; then
+        printf "%s\n" "Error: Directory '${1%/*}' doesn't exist or is inaccessible"
+        printf "%s\n" "       Check that the directory exists or try another directory."
+        exit 1
+    fi
+
+    local full_dir="${1##*/}"
 
     # Iterate down a (possible) chain of symlinks.
-    while [[ -L "$script_dir" ]]; do
-        script_dir="$(readlink "$script_dir")"
-        cd "${script_dir%/*}" || exit
-        script_dir="${script_dir##*/}"
+    while [[ -L "$full_dir" ]]; do
+        full_dir="$(readlink "$full_dir")"
+        cd "${full_dir%/*}" || exit
+        full_dir="${full_dir##*/}"
     done
 
     # Final directory.
-    script_dir="$(pwd -P)"
+    full_dir="$(pwd -P)/${1/*\/}"
+
+    [[ -e "$full_dir" ]] && printf "%s\n" "$full_dir"
 }
 
 get_default_config() {
@@ -3276,7 +3289,7 @@ get_default_config() {
         default_config="/data/data/com.termux/files/etc/neofetch/config"
 
     else
-        get_script_dir
+        [[ -z "$script_dir" ]] && script_dir="$(get_full_path "$0")"
         default_config="${script_dir}/config/config"
         travis_config="${script_dir}/config/travis"
     fi
@@ -3318,7 +3331,7 @@ get_user_config() {
         config_file="${XDG_CONFIG_HOME}/neofetch/config"
 
     else
-        get_script_dir
+        [[ -z "$script_dir" ]] && script_dir="$(get_full_path "$0")"
 
         cp "${script_dir}/config/config" "${XDG_CONFIG_HOME}/neofetch"
         config_file="${XDG_CONFIG_HOME}/neofetch/config"


### PR DESCRIPTION
## Description

Neofetch now understands relative paths when specifying image files, ascii files and directories.

For example:

```sh
neofetch --w3m ~/Pictures/Wallpapers/10.jpg
neofetch --w3m ~/Pictures/Wallpapers/

cd Pictures
neofetch --w3m Wallpapers/10.jpg
neofetch --w3m Wallpapers/

cd Wallpapers
neofetch --w3m 10.jpg
neofetch --w3m .

cd ..
neofetch --w3m ../test.png
neofetch --w3m ../
```

## TODO

- [x] Expand this to `--config`.