### PR TITLE
Intel GPU Info

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1075,7 +1075,11 @@ get_gpu() {
                     ;;
 
                     *"intel"*)
-                        gpu="Intel Integrated Graphics"
+                        if [[ $(glxinfo | grep 'OpenGL renderer string: Mesa' | sed 's/ renderer.*//') = "OpenGL" ]]; then
+                            gpu="$(DRI_PRIME=1 glxinfo | grep 'OpenGL renderer' | sed '0,/^.*Intel/ s//Intel/' | sed 's/(R)//' | sed 's/\(\.* (\).*//')"
+                        else
+                            gpu="Intel Integrated Graphics"
+                        fi
                     ;;
 
                     *"virtualbox"*)


### PR DESCRIPTION
## Description

Add better support for integrated Intel GPUs


## Features

Uses glxinfo to find the OpenGL renderer when using hardware rendering to display more detailed info about integrated intel GPUs