### PR TITLE
Image: Fixed issue where linebreaks printed stray spaces over the image

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2376,6 +2376,7 @@ display_image() {
 
         "iterm2")
             printf "%b\a\n" "\033]1337;File=width=${width}px;height=${height}px;inline=1:$(base64 < "$image")"
+            zws=
         ;;
 
         "tycat")


### PR DESCRIPTION
[Before](https://i.imgur.com/YlZ7Fcu.jpg)

[After](https://i.imgur.com/qOmRdsG.jpg)

## Description

Linebreaks in the config file caused stray spaces to print over the image in Iterm2 on macOS Sierra.

