### PR TITLE
MPD server on another host

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1332,6 +1332,10 @@ get_song() {
             song="$(dbus-send --print-reply --dest=net.sacredchao.QuodLibet /net/sacredchao/QuodLibet net.sacredchao.QuodLibet.CurrentSong |\
                     awk -F'"' '/artist/ {getline; a=$2} /title/ {getline; t=$2} END{print a " - " t}')"
         ;;
+
+        *)
+            if type -p mpc >/dev/null; then song="$(mpc current)"; fi
+        ;;
     esac
 
     [[ "$(trim "$song")" = "-" ]] && unset -v song

--- a/neofetch
+++ b/neofetch
@@ -1334,7 +1334,7 @@ get_song() {
         ;;
 
         *)
-            if type -p mpc >/dev/null; then song="$(mpc current)"; fi
+            mpc >/dev/null 2>&1 && song="$(mpc current)"
         ;;
     esac
 


### PR DESCRIPTION
## Description

Well, if i remember correctly this issue was here in the past and now is present again.

What if i'm using mpc on my computer, to control mopidy on rpi? This commit is fixing this issue, maybe it's not good optimized, i've done my best i think. Simply neofetch doesn't display SONG when it doesn't find any player on host.

This screenshot shows output of command used to determine which player is currently opened on host.

![zrzut ekranu z 2017-01-23 22-30-39](https://cloud.githubusercontent.com/assets/9713907/22223517/9beb3086-e1bb-11e6-97b0-0cecb174a740.png)