### PR TITLE
Fix paths for "proper" Haiku installation

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2030,6 +2030,9 @@ get_ascii() {
 
         elif [[ -d "/data/data/com.termux/files/usr/share/neofetch/ascii/distro" ]]; then
             ascii_dir="/data/data/com.termux/files/usr/share/neofetch/ascii/distro"
+            
+        elif [[ -d "/boot/home/config/non-packaged/share/neofetch/ascii/distro" ]]; then
+            ascii_dir="/boot/home/config/non-packaged/share/neofetch/ascii/distro"
 
         else
             [[ -z "$script_dir" ]] && script_dir="$(get_full_path "$0")"
@@ -3312,6 +3315,9 @@ get_default_config() {
 
     elif [[ -f "/data/data/com.termux/files/etc/neofetch/config" ]]; then
         default_config="/data/data/com.termux/files/etc/neofetch/config"
+    
+    elif [[ -f "/boot/home/config/non-packaged/etc/neofetch/config" ]]; then
+        default_config="/boot/home/config/non-packaged/etc/neofetch/config"
 
     else
         [[ -z "$script_dir" ]] && script_dir="$(get_full_path "$0")"


### PR DESCRIPTION
## Description

Adds support for `neofetch` when installed on Haiku with `PREFIX=/boot/home/config/non-packaged make install` (as is convention)

## Features

`neofetch` now properly loads ASCII art and default configs when installed "properly" on Haiku (without being packaged).

## Issues

Would probably be better to have a `$PREFIX` variable defined somewhere, to be pre-populated by running `PREFIX=/foo/bar/baz make install`.  Not entirely sure how feasible or desirable that would be versus this sort of one-off case.

## TODO

See "Issues".
