### PR TITLE
Fix song_shorthand, use dbus for audacious

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1281,9 +1281,9 @@ get_song() {
         "google play"*) song="$(gpmdp-remote current)" ;;
         "rhythmbox"*)   song="$(rhythmbox-client --print-playing)" ;;
         "deadbeef"*)    song="$(deadbeef --nowplaying-tf  '%artist% - %title%')" ;;
-        "audacious"*)   song="$(audtool current-song)" ;;
         "xmms2d"*)      song="$(xmms2 current -f '${artist} - ${title}')" ;;
         "qmmp"*)        song="$(qmmp --nowplaying '%p - %t')" ;;
+        "audacious"*)   get_song_dbus "audacious" ;;
         "gnome-music"*) get_song_dbus "GnomeMusic" ;;
         "lollypop"*)    get_song_dbus "Lollypop" ;;
         "clementine"*)  get_song_dbus "clementine" ;;

--- a/neofetch
+++ b/neofetch
@@ -1337,7 +1337,7 @@ get_song() {
         ;;
     esac
 
-    [[ "$(trim "$song")" = "-" ]] && unset -v song
+    [[ "$(trim "$song")" == "-" ]] && unset -v song
 
     # Display Artist and Title on separate lines.
     if [[ "$song_shorthand" == "on" ]]; then

--- a/neofetch
+++ b/neofetch
@@ -1340,7 +1340,7 @@ get_song() {
     [[ "$(trim "$song")" == "-" ]] && unset -v song
 
     # Display Artist and Title on separate lines.
-    if [[ "$song_shorthand" == "on" ]]; then
+    if [[ "$song_shorthand" == "on" && "$song" ]]; then
         artist="${song/ -*}"
         song="${song/$artist - }"
 


### PR DESCRIPTION
## Description

- Fix typo in comparsion
- Use `get_song_dbus` for audacious since audtool returns `Artist - Album - Title`
- Don't print if `$song` is emtpy and `song_shorthand` is on (#638)