### PR TITLE
Memory: Change label to MiB from MB

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1250,7 +1250,7 @@ get_memory() {
             mem_used="$((mem_total - mem_free))"
         ;;
     esac
-    memory="${mem_used}MB / ${mem_total}MB"
+    memory="${mem_used}MiB / ${mem_total}MiB"
 
     # Bars.
     case "$memory_display" in

--- a/neofetch
+++ b/neofetch
@@ -1248,9 +1248,10 @@ get_memory() {
             mem_total="${mem_stat[11]/.*}"
             mem_free="${mem_stat[16]/.*}"
             mem_used="$((mem_total - mem_free))"
+            mem_label="MB"
         ;;
     esac
-    memory="${mem_used}MiB / ${mem_total}MiB"
+    memory="${mem_used}${mem_label:-MiB} / ${mem_total}${mem_label:-MiB}"
 
     # Bars.
     case "$memory_display" in


### PR DESCRIPTION
## Description

This PR shows `MiB` on systems that output memory in Mebibytes and `MB` on systems that output memory in Megabytes.

Closes #644 

## TODO

- [x] Show `MB` on systems that output the memory as Megabytes.

@konimex, are you happy with this change? All OS print the output in Mebibytes apart from `AIX` which displays the output as Megabytes.

AIX `svmon` manpage: https://www.ibm.com/support/knowledgecenter/ssw_aix_61/com.ibm.aix.cmds5/svmon.htm
