### PR TITLE
Fix Alacritty font detection

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1619,6 +1619,7 @@ get_term_font() {
             term_font="$(awk -F ':|#' '/normal:/ {getline; print}' "${XDG_CONFIG_HOME}/alacritty/alacritty.yml")"
             term_font="${term_font/*family:}"
             term_font="${term_font/$'\n'*}"
+            term_font="${term_font/\#*}"
         ;;
 
         "Apple_Terminal")


### PR DESCRIPTION
The default configuration of Alacritty happens to include a comment, so
the output is the following:

> Terminal Font: monospace # should be "Menlo" or something on macOS.

This pull request fixes this and the output is as expected:

> Terminal Font: monospace