### PR TITLE
WM: Add support for Spectacle on macOS

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -631,7 +631,7 @@ get_wm() {
         case "$os" in
             "Mac OS X")
                 wm="Quartz Compositor"
-                ps -x | grep -q '[S]pectacle' && wm='Spectacle'
+                ps -e | grep -q '[S]pectacle' && wm='Spectacle'
                 ps -e | grep -q "[k]wm" && wm="Kwm"
             ;;
 

--- a/neofetch
+++ b/neofetch
@@ -631,6 +631,7 @@ get_wm() {
         case "$os" in
             "Mac OS X")
                 wm="Quartz Compositor"
+                ps -x | grep -q '[S]pectacle' && wm='Spectacle'
                 ps -e | grep -q "[k]wm" && wm="Kwm"
             ;;
 


### PR DESCRIPTION
## Description

This PR adds support for the [Spectacle](https://github.com/eczarny/spectacle) window manager.

## Issues

If Spectacle and Kwm are both running, Kwm pretty much overtakes everything and Spectacle does nothing, which is why detection for it happens beforehand.

<img width="1280" alt="screen shot 2017-02-28 at 11 43 00 am" src="https://cloud.githubusercontent.com/assets/12901172/23414776/136a808e-fdab-11e6-995c-b4d4ce2e54dc.png">
