### PR TITLE
Add font detection for iTerm2 on macOS

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1663,7 +1663,7 @@ get_term_font() {
             term_font="${term_font/medium/}"
             term_font="${term_font/Medium/}"
             term_font="${term_font/CodePro/ Code Pro}"
-            term_font="${term_font/ForPowerline/ Code Pro}"
+            term_font="${term_font/ForPowerline/}"
         ;;
 
         "konsole"*)

--- a/neofetch
+++ b/neofetch
@@ -1653,6 +1653,19 @@ get_term_font() {
             term_font="$(awk -F "," '/fontFamily/ {a=$1} END{print a}' "${HOME}/.hyper.js" | awk -F "'" '{a=$2} END{print a}')"
         ;;
 
+        "iTerm2"*)
+            line="$(defaults read -app iTerm | grep -F 'Normal Font')"
+            re='"Normal Font" = "([^-" ]+).*";'
+            [[ "$line" =~ $re ]] && term_font=${BASH_REMATCH[1]}
+
+            term_font="${term_font//-/ }"
+            term_font="${term_font/Mono/ Mono}"
+            term_font="${term_font/medium/}"
+            term_font="${term_font/Medium/}"
+            term_font="${term_font/CodePro/ Code Pro}"
+            term_font="${term_font/ForPowerline/ Code Pro}"
+        ;;
+
         "konsole"*)
             # Get Process ID of current konsole window / tab
             child="$(get_ppid "$$")"


### PR DESCRIPTION
## Description

This PR adds font detection for iTerm2.

## Issues

There is a somewhat noticeable lag, possibly due to the regex. Is there any way we could speed this up a bit more?

Also this assumes that the user only has one iTerm2 profile. Unfortunately there is no way to determine which iTerm2 profile (and therefore which font) is currently being used. If the user has more than one profile, this may output the wrong font.

<img width="1280" alt="screen shot 2017-03-02 at 9 06 18 am" src="https://cloud.githubusercontent.com/assets/12901172/23510415/83666042-ff27-11e6-909b-5db141b6142b.png">