### PR TITLE
Scrot: Make scrot easier to use.

### DIFF
--- a/config/config
+++ b/config/config
@@ -681,16 +681,6 @@ scrot="off"
 # Flag:    --scrot_cmd
 scrot_cmd="auto"
 
-# Screenshot Directory
-# Where to save the screenshots
-#
-# Default: '~/Pictures/'
-# Values:  'dir'
-# Flag:    --scrot_dir
-#
-# Note: Neofetch won't create the directory if it doesn't exist.
-scrot_dir="$HOME/Pictures/"
-
 # Screenshot Filename
 # What to name the screenshots
 #

--- a/neofetch
+++ b/neofetch
@@ -2518,6 +2518,8 @@ to_off() {
 take_scrot() {
     scrot_program "${scrot_dir}${scrot_name}" 2>/dev/null
 
+    err "Scrot: Saved screenshot as: ${scrot_dir}${scrot_name}"
+
     [[ "$scrot_upload" == "on" ]] && scrot_upload
 }
 
@@ -2557,15 +2559,16 @@ scrot_upload() {
 
 scrot_args() {
     scrot="on"
-    case "$2" in
-        "-"* | "") ;;
-        *)
-            scrot_name="${2##*/}"
-            scrot_dir="${2/$scrot_name}"
-        ;;
-    esac
 
-    [[ -z "$@" ]] && scrot_dir="${PWD:+${PWD}/}"
+    if [[ "$2" =~ \.(png|jpg|jpe|jpeg|gif)$ ]]; then
+        scrot_name="${2##*/}"
+        scrot_dir="${2/$scrot_name}"
+
+    elif [[ -d "$2" ]]; then
+        scrot_dir="$2"
+    else
+        scrot_dir="${PWD:+${PWD}/}"
+    fi
 }
 
 scrot_program() {

--- a/neofetch
+++ b/neofetch
@@ -637,13 +637,13 @@ get_wm() {
         case "$os" in
             "Mac OS X")
                 ps_line="$(ps -e | grep -o '[S]pectacle\|[A]methyst\|[k]wm')"
-                
+
                 case "$ps_line" in
                     *"kwm"*) wm="Kwm" ;;
                     *"Amethyst"*) wm="Amethyst" ;;
                     *"Spectacle"*) wm="Spectacle" ;;
                     *) wm="Quartz Compositor" ;;
-                esac   
+                esac
             ;;
 
             "Windows")
@@ -2516,11 +2516,7 @@ to_off() {
 # SCREENSHOT
 
 take_scrot() {
-    if [[ -d "$scrot_dir" ]]; then
-        scrot_program "${scrot_dir}${scrot_name}" 2>/dev/null
-    else
-        printf "%s\n" "Screenshot: $scrot_dir doesn't exist. Edit the config file or create the directory to take screenshots."
-    fi
+    scrot_program "${scrot_dir}${scrot_name}" 2>/dev/null
 
     [[ "$scrot_upload" == "on" ]] && scrot_upload
 }
@@ -2568,6 +2564,8 @@ scrot_args() {
             scrot_dir="${2/$scrot_name}"
         ;;
     esac
+
+    [[ -z "$@" ]] && scrot_dir="${PWD:+${PWD}/}"
 }
 
 scrot_program() {

--- a/neofetch
+++ b/neofetch
@@ -3651,6 +3651,9 @@ old_options() {
 
     # Birthday was renamed to Install Date in 3.0
     [[ -n "$birthday_time" ]] && { err "Config: \$birthday_time is deprecated, use \3install_time instead."; install_time="$birthday_time"; }
+
+    # Scrot dir was removed in 3.1.0.
+    [[ -n "$scrot_dir" ]] && scrot_dir=
 }
 
 cache_uname() {


### PR DESCRIPTION
## Description

This PR makes `-s`/`--scrot` easier to use and removes the configuration needed before it would work. (Creating `~/Pictures`). 

- `neofetch -s` will save a file in the current directory named: `neofetch-$(date +%F-%I-%M-%S-${RANDOM}).png`
- `neofetch -s test.png` will save a file in the current directory called `test.png`
- `neofetch -s ~/` will save a file in `~` called `neofetch-$(date +%F-%I-%M-%S-${RANDOM}).png`
- `neofetch -s ~/test.png` will save a file in `~` called `test.png`.

Note: 

- The value of `scrot_dir` is ignored now.
- `-v` now shows where the screenshot was saved.

This closes #680.


## Issues

- [ ] None yet(?)
