### PR TITLE
Info: Added function to display locale.

### DIFF
--- a/config/config
+++ b/config/config
@@ -37,7 +37,7 @@ print_info() {
     # info "Public IP" public_ip
     # info "Users" users
     # info "Install Date" install_date
-    # info "Locale" locale
+    # info "Locale" locale # This only works on glibc systems.
 
     info line_break
     info cols

--- a/config/config
+++ b/config/config
@@ -37,6 +37,7 @@ print_info() {
     # info "Public IP" public_ip
     # info "Users" users
     # info "Install Date" install_date
+    # info "Locale" locale
 
     info line_break
     info cols

--- a/neofetch
+++ b/neofetch
@@ -637,13 +637,13 @@ get_wm() {
         case "$os" in
             "Mac OS X")
                 ps_line="$(ps -e | grep -o '[S]pectacle\|[A]methyst\|[k]wm')"
-                
+
                 case "$ps_line" in
                     *"kwm"*) wm="Kwm" ;;
                     *"Amethyst"*) wm="Amethyst" ;;
                     *"Spectacle"*) wm="Spectacle" ;;
                     *) wm="Quartz Compositor" ;;
-                esac   
+                esac
             ;;
 
             "Windows")
@@ -1991,6 +1991,10 @@ get_install_date() {
     install_date="${install_date%:*}"
     install_date=($install_date)
     install_date="$(convert_time "${install_date[@]}")"
+}
+
+get_locale() {
+    locale="$sys_locale"
 }
 
 get_cols() {


### PR DESCRIPTION
## Description

Adds a new, disabled by default info function to display the system locale. The output is just the value of `$LANG` and is set to `C` if empty.

Output: `Locale: en_US.UTF-8`

Closes: #679 