### PR TITLE
Add battery support for Bay Trail devices

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1833,26 +1833,24 @@ get_disk() {
 get_battery() {
     case "$os" in
         "Linux")
-            # We use 'prin' here and exit the function early so that we can
-            # do multi battery support with a single battery per line.
-            for bat in "/sys/class/power_supply/BAT"*; do
+            # We use 'prin' here so that we can do multi battery support
+            # with a single battery per line.
+            for bat in "/sys/class/power_supply/"{BAT,axp288_fuel_gauge}*; do
                 capacity="$(< "${bat}/capacity")"
                 status="$(< "${bat}/status")"
 
-                # Fix for bash on Windows 10 which includes /proc files
-                # for battery usage despite there not being a battery
-                # installed.
-                [[ -z "$capacity" ]] && return
+                if [[ "$capacity" ]]; then
+                    battery="${capacity}% [${status}]"
 
-                battery="${capacity}% [${status}]"
+                    case "$battery_display" in
+                        "bar") battery="$(bar "$capacity" 100)" ;;
+                        "infobar") battery+=" $(bar "$capacity" 100)" ;;
+                        "barinfo") battery="$(bar "$capacity" 100)${info_color} ${battery}" ;;
+                    esac
 
-                case "$battery_display" in
-                    "bar") battery="$(bar "$capacity" 100)" ;;
-                    "infobar") battery+=" $(bar "$capacity" 100)" ;;
-                    "barinfo") battery="$(bar "$capacity" 100)${info_color} ${battery}" ;;
-                esac
-
-                prin "${subtitle:+${subtitle}${bat: -1}}" "$battery"
+                    bat="${bat/*axp288_fuel_gauge}"
+                    prin "${subtitle:+${subtitle}${bat: -1}}" "$battery"
+                fi
             done
             return
         ;;


### PR DESCRIPTION
This PR adds battery support for devices that use `axp288_fuel_gauge` for the info.
Some (not sure if all) Bay Trail Laptops/Tablets for example.

Note:
The Linux battery support for Bay Trail devices wasn't so good up to kernel 4.10. 
On my Laptop it started working with 4.11-rc1. I think..
