### PR TITLE
Fix --ascii_distro ubuntu-studio

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3287,6 +3287,11 @@ get_distro_colors() {
             ascii_file="ubuntu_old"
         ;;
 
+        "Ubuntu-Studio")
+            set_colors 6 7
+            ascii_file="ubuntu-studio"
+        ;;
+
         "Ubuntu"*)
             set_colors 1 7 3
             ascii_file="ubuntu"


### PR DESCRIPTION
## Description

This commit makes the `--ascii_distro Ubuntu-Studio` option display the Ubuntu Studio logo.

![neofetch_ubuntu_studio](https://cloud.githubusercontent.com/assets/1559108/24884995/c46bb836-1e11-11e7-80de-6ecb2bc7b5e3.png)

The `ascii/distro` directory has an `ubuntu-studio` file, and Ubuntu-Studio is documented as an option for `--ascii_distro` in the `--help` text. Previously when I used that option, it fell back to the default Ubuntu logo.

This change adds a case for Ubuntu-Studio to set `ascii_file` and the colors.

![Another Ubuntu Studio logo](http://www.linuxinsider.com/ai/686439/ubuntu.jpg)