### PR TITLE
OS: add Chrome OS crouton support

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -63,6 +63,13 @@ get_distro() {
                     *)      distro="$(lsb_release -sd) on Windows 10" ;;
                 esac
 
+            elif [[ "$(< /proc/version)" == *"cros"* || -f "/dev/cros_ec" ]]; then
+                case "$distro_shorthand" in
+                    "on")   distro="$(lsb_release -sir) [Chrome OS]" ;;
+                    "tiny") distro="Chrome OS" ;;
+                    *)      distro="$(lsb_release -sd) on Chrome OS" ;;
+                esac
+
             elif [[ -f "/etc/GoboLinuxVersion" ]]; then
                 case "$distro_shorthand" in
                     "on" | "tiny") distro="GoboLinux" ;;


### PR DESCRIPTION
## Description
Add support for distros installed via crouton on Chrome OS

## Screenshot
![screenshot 2017-04-24 at 1 44 45 pm](https://cloud.githubusercontent.com/assets/10568668/25353513/1c380590-28f5-11e7-9051-4ce6c3e02069.png)

![screenshot 2017-04-24 at 1 44 33 pm](https://cloud.githubusercontent.com/assets/10568668/25353522/28334bb6-28f5-11e7-983f-0420f1cd8c13.png)
