### PR TITLE
Do not detect ibus* or indicator* as player

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1291,7 +1291,7 @@ get_memory() {
 
 get_song() {
     # This is absurdly long.
-    player="$(ps x | awk '!(/ awk|Helper|Cache/) && /mpd|mopidy|cmus|mocp|spotify|Google Play|iTunes.app|rhythmbox|banshee|amarok|deadbeef|audacious|xmms2d|gnome-music|lollypop|clementine|pragha|exaile|juk|bluemindo|guayadeque|yarock|qmmp|quodlibet|deepin-music|tomahawk/ {printf $5 " " $6; exit}')"
+    player="$(ps x | awk '!(/ awk|Helper|Cache|ibus|indicator/) && /mpd|mopidy|cmus|mocp|spotify|Google Play|iTunes.app|rhythmbox|banshee|amarok|deadbeef|audacious|xmms2d|gnome-music|lollypop|clementine|pragha|exaile|juk|bluemindo|guayadeque|yarock|qmmp|quodlibet|deepin-music|tomahawk/ {printf $5 " " $6; exit}')"
 
     get_song_dbus() {
         # Multiple players use an almost identical dbus command to get the information.


### PR DESCRIPTION
## Description

This "absurdly long" command to get player is returning this on my ubuntu installation:
```sh
/usr/bin/ibus-daemon --daemonize
```

Then this after first addition (ibus) to awk
```sh
indicator-mpd
```

After this commit, player is being detected properly. In my case - spotify