### PR TITLE
Misc: Use fallback values for some functions

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1173,7 +1173,16 @@ get_gpu() {
             esac
         ;;
 
-        "BSD" | "Solaris" | "MINIX" | "AIX")
+        "Windows")
+            gpu="$(wmic path Win32_VideoController get caption)"
+            gpu="${gpu//Caption}"
+        ;;
+
+        "Haiku")
+            gpu="$(listdev | grep -A2 -F 'device Display controller' | awk -F':' '/device beef/ {print $2}')"
+        ;;
+
+        *)
             case "$kernel_name" in
                 "FreeBSD"* | "DragonFly"*)
                     gpu="$(pciconf -lv | grep -B 4 -F "VGA" | grep -F "device")"
@@ -1186,15 +1195,6 @@ get_gpu() {
                     gpu="${gpu/'OpenGL renderer string: '}"
                 ;;
             esac
-        ;;
-
-        "Windows")
-            gpu="$(wmic path Win32_VideoController get caption)"
-            gpu="${gpu//Caption}"
-        ;;
-
-        "Haiku")
-            gpu="$(listdev | grep -A2 -F 'device Display controller' | awk -F':' '/device beef/ {print $2}')"
         ;;
     esac
 
@@ -1394,19 +1394,6 @@ get_song() {
 
 get_resolution() {
     case "$os" in
-        "Linux" | "BSD" | "Solaris" | "MINIX" | "AIX")
-            if type -p xrandr >/dev/null; then
-                case "$refresh_rate" in
-                    "on") resolution="$(xrandr --nograb --current | awk 'match($0,/[0-9]*\.[0-9]*\*/) {printf $1 " @ " substr($0,RSTART,RLENGTH) "Hz, "}')" ;;
-                    "off") resolution="$(xrandr --nograb --current | awk '/\*/ {printf $1 ", "}')" ;;
-                esac
-                resolution="${resolution//\*}"
-
-            elif type -p xdpyinfo >/dev/null; then
-                resolution="$(xdpyinfo | awk '/dimensions:/ {printf $2}')"
-            fi
-        ;;
-
         "Mac OS X")
             if type -p screenresolution >/dev/null; then
                 resolution="$(screenresolution get 2>&1 | awk '/Display/ {printf $6 "Hz, "}')"
@@ -1450,6 +1437,19 @@ get_resolution() {
             resolution="$(screenmode | awk -F ' |, ' '{printf $2 "x" $3 " @ " $6 $7}')"
 
             [[ "$refresh_rate" == "off" ]] && resolution="${resolution/ @*}"
+        ;;
+
+        *)
+            if type -p xrandr >/dev/null; then
+                case "$refresh_rate" in
+                    "on") resolution="$(xrandr --nograb --current | awk 'match($0,/[0-9]*\.[0-9]*\*/) {printf $1 " @ " substr($0,RSTART,RLENGTH) "Hz, "}')" ;;
+                    "off") resolution="$(xrandr --nograb --current | awk '/\*/ {printf $1 ", "}')" ;;
+                esac
+                resolution="${resolution//\*}"
+
+            elif type -p xdpyinfo >/dev/null; then
+                resolution="$(xdpyinfo | awk '/dimensions:/ {printf $2}')"
+            fi
         ;;
     esac
 
@@ -2192,7 +2192,29 @@ get_image_source() {
 
 get_wallpaper() {
     case "$os" in
-        "Linux" | "BSD" | "Solaris" | "MINIX" | "AIX")
+        "Mac OS X")
+            image="$(osascript -e 'tell application "System Events" to picture of current desktop')"
+        ;;
+
+        "Windows")
+            case "$distro" in
+                "Windows XP")
+                    case "$kernel_name" in
+                        "CYGWIN"*) image="/cygdrive/c/Documents and Settings/${USER}" ;;
+                        "MSYS2"* | "MINGW*")  image="/c/Documents and Settings/${USER}" ;;
+                    esac
+                    image+="/Local Settings/Application Data/Microsoft"
+                    image+="/Wallpaper1.bmp"
+                ;;
+
+                "Windows"*)
+                    image="$APPDATA/Microsoft/Windows/Themes"
+                    image+="/TranscodedWallpaper.jpg"
+                ;;
+            esac
+        ;;
+
+        *)
             # Get DE if user has disabled the function.
             ((de_run != 1)) && get_de
 
@@ -2222,28 +2244,6 @@ get_wallpaper() {
             # Strip un-needed info from the path.
             image="${image/'file://'}"
             image="$(trim_quotes "$image")"
-        ;;
-
-        "Mac OS X")
-            image="$(osascript -e 'tell application "System Events" to picture of current desktop')"
-        ;;
-
-        "Windows")
-            case "$distro" in
-                "Windows XP")
-                    case "$kernel_name" in
-                        "CYGWIN"*) image="/cygdrive/c/Documents and Settings/${USER}" ;;
-                        "MSYS2"* | "MINGW*")  image="/c/Documents and Settings/${USER}" ;;
-                    esac
-                    image+="/Local Settings/Application Data/Microsoft"
-                    image+="/Wallpaper1.bmp"
-                ;;
-
-                "Windows"*)
-                    image="$APPDATA/Microsoft/Windows/Themes"
-                    image+="/TranscodedWallpaper.jpg"
-                ;;
-            esac
         ;;
     esac
 


### PR DESCRIPTION
## Description

Self-explanatory.

### Rationale

A lot of OS are *NIX, and as such, will use X (unless there are some arcane new method, aside from Wayland which only supports Linux and FreeBSD atm) for graphical environment.

It would be easier to maintain those functions as we don't have to add every OS to the cases.