### PR TITLE
Patch to make w3m image backend work on FreeBSD 12

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2292,7 +2292,10 @@ get_w3m_img_path() {
 
     elif [[ -x  "/usr/libexec64/w3m/w3mimgdisplay" ]]; then
         w3m_img_path="/usr/libexec64/w3m/w3mimgdisplay"
-
+    
+    elif [[ -x "/usr/local/libexec/w3m/w3mimgdisplay" ]]; then
+        w3m_img_path="/usr/local/libexec/w3m/w3mimgdisplay"
+    
     else
         err "Image: w3m-img wasn't found on your system"
     fi


### PR DESCRIPTION
Just an extra possible directory to search for w3m-img before outputting that it wasn't found on the system.

It fixes my issue of being unable to output images with neofetch when using it on FreeBSD 12-CURRENT. 
