### PR TITLE
Disk: Use -k instead of -h / -g

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1789,9 +1789,9 @@ get_disk() {
     # Get "df" flags.
     case "$os" in
         "Haiku") err "Disk doesn't work on Haiku due to the non-standard 'df'"; return ;;
-        "Mac OS X") df_flags=(-P -h) ;;
-        "AIX") df_flags=(-P -g) ;;
-        *) df_flags=(-h) ;;
+        "Mac OS X") df_flags=(-P -k) ;;
+        "AIX") df_flags=(-P -k) ;;
+        *) df_flags=(-k) ;;
     esac
 
     # Create an array called 'disks' where each element is a separate line from
@@ -1810,7 +1810,7 @@ get_disk() {
         disk_info=($disk)
         disk_perc="${disk_info[4]/'%'}"
 
-        disk="${disk_info[2]/i} / ${disk_info[1]/i} (${disk_perc}%)"
+        disk="$((${disk_info[2]}/1024/1024))G / $((${disk_info[1]}/1024/1024))G (${disk_perc}%)"
 
         # Subtitle.
         case "$disk_subtitle" in


### PR DESCRIPTION
## Description

### Rationale

In some `df` systems, `-h` is unsupported. For AIX, we can use `-g` option. However, this caused problem in IRIX and HP-UX systems, should we merge them later.

The other alternative is detecting which `df` is being used, and act depends on which `df` (or the OS itself) is being used (keep the `-h` output or use the `-k` alternative and divide them manually). [The alternative is committed into my branch of `irix`](https://github.com/konimex/neofetch/commit/514b984b9126361103814af804b62115736c70a6), if either of these alternatives get accepted, I'll push it into the IRIX PR.

### Issues

- No more fancy outputs if >999G (1.1T becoming 1126G instead)
- More error prone in calculation if < 10G
- Less accurate

### TODO

- [ ] Testing
  - [x] Linux
  - [ ] *BSDs
  - [ ] Solaris