### PR TITLE
Make: Set PREFIX inside neofetch on Make

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,21 @@
 - **[@mstraube](https://github.com/mstraube)**
 - **[@Artoriuz](https://github.com/Artoriuz)**
 - **[@WilsonRU](https://github.com/WilsonRU)**
+- **[@Takeya-Yuki](https://github.com/Takeya-Yuki)**
 
 
 ## Operating System
 
 - Added support for Arch XFerience. **[@mstraube](https://github.com/mstraube)**
 - Added support for Maui. **[@mstraube](https://github.com/mstraube)**
+- Added support for KS Linux. **[@Takeya-Yuki](https://github.com/Takeya-Yuki)**
 
 
 ## General
 
 - Minimum required BASH version is now 3.2.
     - (Neofetch has always used 3.2+ features, I've just made it obvious now in the documentation.)
+- Fixed config file not being created.
 
 
 ## Images

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,11 @@ all:
 install:
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
 	mkdir -p $(DESTDIR)$(PREFIX)/share/man/man1
-	mkdir -p $(DESTDIR)$(PREFIX)/etc/neofetch
+	mkdir -p $(DESTDIR)/etc/neofetch
 	mkdir -p $(DESTDIR)$(PREFIX)/share/neofetch/ascii/distro
 	cp -p neofetch $(DESTDIR)$(PREFIX)/bin/neofetch
 	cp -p neofetch.1 $(DESTDIR)$(PREFIX)/share/man/man1/neofetch.1
-	cp -p config/config $(DESTDIR)$(PREFIX)/etc/neofetch/config
+	cp -p config/config $(DESTDIR)/etc/neofetch/config
 	cp -p ascii/distro/* $(DESTDIR)$(PREFIX)/share/neofetch/ascii/distro
 	# Set the PREFIX inside Neofetch.
 	sed -i'' -e "s|NEOFETCH_PREFIX=\"\/usr\"|NEOFETCH_PRE=\"$(PREFIX)\"|" $(DESTDIR)$(PREFIX)/bin/neofetch
@@ -19,4 +19,4 @@ uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/neofetch
 	rm -f $(DESTDIR)$(PREFIX)/share/man/man1/neofetch.1
 	rm -f -r $(DESTDIR)$(PREFIX)/share/neofetch
-	rm -f -r $(DESTDIR)$(PREFIX)/etc/neofetch
+	rm -f -r $(DESTDIR)/etc/neofetch

--- a/Makefile
+++ b/Makefile
@@ -6,15 +6,15 @@ all:
 install:
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
 	mkdir -p $(DESTDIR)$(PREFIX)/share/man/man1
-	mkdir -p $(DESTDIR)/etc/neofetch
+	mkdir -p $(DESTDIR)$(PREFIX)/etc/neofetch
 	mkdir -p $(DESTDIR)$(PREFIX)/share/neofetch/ascii/distro
 	cp -p neofetch $(DESTDIR)$(PREFIX)/bin/neofetch
 	cp -p neofetch.1 $(DESTDIR)$(PREFIX)/share/man/man1/neofetch.1
-	cp -p config/config $(DESTDIR)/etc/neofetch/config
+	cp -p config/config $(DESTDIR)$(PREFIX)/etc/neofetch/config
 	cp -p ascii/distro/* $(DESTDIR)$(PREFIX)/share/neofetch/ascii/distro
 
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/neofetch
 	rm -f $(DESTDIR)$(PREFIX)/share/man/man1/neofetch.1
 	rm -f -r $(DESTDIR)$(PREFIX)/share/neofetch
-	rm -f -r $(DESTDIR)/etc/neofetch
+	rm -f -r $(DESTDIR)$(PREFIX)/etc/neofetch

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ install:
 	cp -p neofetch.1 $(DESTDIR)$(PREFIX)/share/man/man1/neofetch.1
 	cp -p config/config $(DESTDIR)$(PREFIX)/etc/neofetch/config
 	cp -p ascii/distro/* $(DESTDIR)$(PREFIX)/share/neofetch/ascii/distro
+	# Set the PREFIX inside Neofetch.
+	sed -i'' -e "s|NEOFETCH_PREFIX=\"\/usr\"|NEOFETCH_PRE=\"$(PREFIX)\"|" $(DESTDIR)$(PREFIX)/bin/neofetch
 
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/neofetch

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ install:
 	cp -p config/config $(DESTDIR)/etc/neofetch/config
 	cp -p ascii/distro/* $(DESTDIR)$(PREFIX)/share/neofetch/ascii/distro
 	# Set the PREFIX/DESTDIR inside Neofetch.
-	sed -i'' -e "s|NEOFETCH_PREFIX=\"\/usr\"|NEOFETCH_PREFIX=\"$(PREFIX)\"|" $(DESTDIR)$(PREFIX)/bin/neofetch
+	sed -i'' -e "s|NEOFETCH_PREFIX=\"\.*\"|NEOFETCH_PREFIX=\"$(PREFIX)\"|" $(DESTDIR)$(PREFIX)/bin/neofetch
 	sed -i'' -e "s|NEOFETCH_DESTDIR=\"\"|NEOFETCH_DESTDIR=\"$(DESTDIR)\"|" $(DESTDIR)$(PREFIX)/bin/neofetch
 
 uninstall:

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ install:
 	cp -p config/config $(DESTDIR)/etc/neofetch/config
 	cp -p ascii/distro/* $(DESTDIR)$(PREFIX)/share/neofetch/ascii/distro
 	# Set the PREFIX/DESTDIR inside Neofetch.
-	sed -i'' -e "s|NEOFETCH_PREFIX=\"\.*\"|NEOFETCH_PREFIX=\"$(PREFIX)\"|" $(DESTDIR)$(PREFIX)/bin/neofetch
+	sed -i'' -e "s|NEOFETCH_PREFIX=\".*\"|NEOFETCH_PREFIX=\"$(PREFIX)\"|" $(DESTDIR)$(PREFIX)/bin/neofetch
 	sed -i'' -e "s|NEOFETCH_DESTDIR=\"\"|NEOFETCH_DESTDIR=\"$(DESTDIR)\"|" $(DESTDIR)$(PREFIX)/bin/neofetch
 
 uninstall:

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,9 @@ install:
 	cp -p neofetch.1 $(DESTDIR)$(PREFIX)/share/man/man1/neofetch.1
 	cp -p config/config $(DESTDIR)/etc/neofetch/config
 	cp -p ascii/distro/* $(DESTDIR)$(PREFIX)/share/neofetch/ascii/distro
-	# Set the PREFIX inside Neofetch.
-	sed -i'' -e "s|NEOFETCH_PREFIX=\"\/usr\"|NEOFETCH_PRE=\"$(PREFIX)\"|" $(DESTDIR)$(PREFIX)/bin/neofetch
+	# Set the PREFIX/DESTDIR inside Neofetch.
+	sed -i'' -e "s|NEOFETCH_PREFIX=\"\/usr\"|NEOFETCH_PREFIX=\"$(PREFIX)\"|" $(DESTDIR)$(PREFIX)/bin/neofetch
+	sed -i'' -e "s|NEOFETCH_DESTDIR=\"\"|NEOFETCH_DESTDIR=\"$(DESTDIR)\"|" $(DESTDIR)$(PREFIX)/bin/neofetch
 
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/neofetch

--- a/neofetch
+++ b/neofetch
@@ -3530,8 +3530,8 @@ get_full_path() {
 }
 
 get_default_config() {
-    if [[ -f "${NEOFETCH_PREFIX}/neofetch/config" ]]; then
-        default_config="${NEOFETCH_PREFIX}/neofetch/config"
+    if [[ -f "${NEOFETCH_PREFIX}/etc/neofetch/config" ]]; then
+        default_config="${NEOFETCH_PREFIX}/etc/neofetch/config"
     else
         [[ -z "$script_dir" ]] && script_dir="$(get_full_path "$0")"
         default_config="${script_dir%/*}/config/config"

--- a/neofetch
+++ b/neofetch
@@ -2300,10 +2300,10 @@ get_w3m_img_path() {
 
     elif [[ -x  "/usr/libexec64/w3m/w3mimgdisplay" ]]; then
         w3m_img_path="/usr/libexec64/w3m/w3mimgdisplay"
-    
+
     elif [[ -x "/usr/local/libexec/w3m/w3mimgdisplay" ]]; then
         w3m_img_path="/usr/local/libexec/w3m/w3mimgdisplay"
-    
+
     else
         err "Image: w3m-img wasn't found on your system"
     fi
@@ -3538,16 +3538,6 @@ get_full_path() {
 get_default_config() {
     if [[ -f "/etc/neofetch/config" ]]; then
         default_config="/etc/neofetch/config"
-
-    elif [[ -f "/usr/local/etc/neofetch/config" ]]; then
-        default_config="/usr/local/etc/neofetch/config"
-
-    elif [[ -f "/data/data/com.termux/files/usr/etc/neofetch/config" ]]; then
-        default_config="/data/data/com.termux/files/usr/etc/neofetch/config"
-
-    elif [[ -f "/boot/home/config/non-packaged/etc/neofetch/config" ]]; then
-        default_config="/boot/home/config/non-packaged/etc/neofetch/config"
-
     else
         [[ -z "$script_dir" ]] && script_dir="$(get_full_path "$0")"
         default_config="${script_dir%/*}/config/config"
@@ -3576,11 +3566,7 @@ get_user_config() {
         config_file="${XDG_CONFIG_HOME}/neofetch/config"
 
     elif [[ -f "/etc/neofetch/config" ]]; then
-        cp "/usr/share/neofetch/config" "${XDG_CONFIG_HOME}/neofetch"
-        config_file="${XDG_CONFIG_HOME}/neofetch/config"
-
-    elif [[ -f "/usr/local/etc/neofetch/config" ]]; then
-        cp "/usr/local/share/neofetch/config" "${XDG_CONFIG_HOME}/neofetch"
+        cp "/etc/neofetch/config" "${XDG_CONFIG_HOME}/neofetch"
         config_file="${XDG_CONFIG_HOME}/neofetch/config"
 
     else

--- a/neofetch
+++ b/neofetch
@@ -11,8 +11,9 @@
 # Neofetch version.
 version="3.1.0-git"
 
-# Neofetch prefix.
+# Neofetch prefix/destdir.
 NEOFETCH_PREFIX="/usr"
+NEOFETCH_DESTDIR=""
 
 bash_version="${BASH_VERSION/.*}"
 sys_locale="${LANG:-C}"
@@ -3530,8 +3531,8 @@ get_full_path() {
 }
 
 get_default_config() {
-    if [[ -f "${NEOFETCH_PREFIX}/etc/neofetch/config" ]]; then
-        default_config="${NEOFETCH_PREFIX}/etc/neofetch/config"
+    if [[ -f "${NEOFETCH_DESTDIR}/etc/neofetch/config" ]]; then
+        default_config="${NEOFETCH_DESTDIR}/etc/neofetch/config"
     else
         [[ -z "$script_dir" ]] && script_dir="$(get_full_path "$0")"
         default_config="${script_dir%/*}/config/config"

--- a/neofetch
+++ b/neofetch
@@ -11,6 +11,9 @@
 # Neofetch version.
 version="3.1.0-git"
 
+# Neofetch prefix.
+NEOFETCH_PREFIX="/usr"
+
 bash_version="${BASH_VERSION/.*}"
 sys_locale="${LANG:-C}"
 XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-${HOME}/.config}"

--- a/neofetch
+++ b/neofetch
@@ -3560,8 +3560,8 @@ get_user_config() {
     if [[ -f "${XDG_CONFIG_HOME}/neofetch/config" ]]; then
         config_file="${XDG_CONFIG_HOME}/neofetch/config"
 
-    elif [[ -f "${NEOFETCH_PREFIX}/neofetch/config" ]]; then
-        cp "${NEOFETCH_PREFIX}/neofetch/config" "${XDG_CONFIG_HOME}/neofetch"
+    elif [[ -f "${NEOFETCH_DESTDIR}/etc/neofetch/config" ]]; then
+        cp "${NEOFETCH_DESTDIR}/etc/neofetch/config" "${XDG_CONFIG_HOME}/neofetch"
         config_file="${XDG_CONFIG_HOME}/neofetch/config"
 
     else

--- a/neofetch
+++ b/neofetch
@@ -2147,17 +2147,8 @@ get_ascii() {
         [[ "$image_source" =~ \.(png|jpg|jpe|jpeg|gif)$ ]] && \
             err "Image: Source is image file but ascii backend was selected. Using distro ascii."
 
-        if [[ -d "/usr/share/neofetch/ascii/distro" ]]; then
-            ascii_dir="/usr/share/neofetch/ascii/distro"
-
-        elif [[ -d "/usr/local/share/neofetch/ascii/distro" ]]; then
-            ascii_dir="/usr/local/share/neofetch/ascii/distro"
-
-        elif [[ -d "/data/data/com.termux/files/usr/share/neofetch/ascii/distro" ]]; then
-            ascii_dir="/data/data/com.termux/files/usr/share/neofetch/ascii/distro"
-
-        elif [[ -d "/boot/home/config/non-packaged/share/neofetch/ascii/distro" ]]; then
-            ascii_dir="/boot/home/config/non-packaged/share/neofetch/ascii/distro"
+        if [[ -d "${NEOFETCH_PREFIX}/share/neofetch/ascii/distro" ]]; then
+            ascii_dir="${NEOFETCH_PREFIX}/share/neofetch/ascii/distro"
 
         else
             [[ -z "$script_dir" ]] && script_dir="$(get_full_path "$0")"
@@ -3536,8 +3527,8 @@ get_full_path() {
 }
 
 get_default_config() {
-    if [[ -f "/etc/neofetch/config" ]]; then
-        default_config="/etc/neofetch/config"
+    if [[ -f "${NEOFETCH_PREFIX}/neofetch/config" ]]; then
+        default_config="${NEOFETCH_PREFIX}/neofetch/config"
     else
         [[ -z "$script_dir" ]] && script_dir="$(get_full_path "$0")"
         default_config="${script_dir%/*}/config/config"
@@ -3565,8 +3556,8 @@ get_user_config() {
     if [[ -f "${XDG_CONFIG_HOME}/neofetch/config" ]]; then
         config_file="${XDG_CONFIG_HOME}/neofetch/config"
 
-    elif [[ -f "/etc/neofetch/config" ]]; then
-        cp "/etc/neofetch/config" "${XDG_CONFIG_HOME}/neofetch"
+    elif [[ -f "${NEOFETCH_PREFIX}/neofetch/config" ]]; then
+        cp "${NEOFETCH_PREFIX}/neofetch/config" "${XDG_CONFIG_HOME}/neofetch"
         config_file="${XDG_CONFIG_HOME}/neofetch/config"
 
     else


### PR DESCRIPTION
## Description

This PR removes the hardcoded config and ascii directories inside Neofetch and instead replaces them with a variable at the top of the script. (`$NEOFETCH_PREFIX`) (The variable defaults to `/usr/`)

The Makefile has also been updated to update this new variable inside Neofetch based on the PREFIX given to `make`.

Closes #718

## TODO

- [ ] Testing
- [ ] Simplify `sed` command if possible.

Can you guys take a look at this?

@konimex 
@rekado 