### PR TITLE
Model: Add support for Hackintosh

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -243,7 +243,7 @@ get_model() {
         ;;
 
         "Mac OS X") 
-            if [[ $(kextstat | grep "FakeSMC") != "" ]]; then
+            if [[ "$(kextstat | grep "FakeSMC")" ]]; then
                 model="Hackintosh (SMBIOS: $(sysctl -n hw.model))"
             else
                 model="$(sysctl -n hw.model)"

--- a/neofetch
+++ b/neofetch
@@ -242,7 +242,13 @@ get_model() {
             fi
         ;;
 
-        "Mac OS X") model="$(sysctl -n hw.model)" ;;
+        "Mac OS X") 
+            if [[ $(kextstat | grep "FakeSMC") != "" ]]; then
+                model="Hackintosh (SMBIOS: $(sysctl -n hw.model))"
+            else
+                model="$(sysctl -n hw.model)"
+            fi
+        ;;
         "iPhone OS")
             case "$machine_arch" in
                 "iPad1,1") model="iPad" ;;


### PR DESCRIPTION
## Description
This PR adds support for detecting if the macOS is running on a PC (Hackintosh)

Since FakeSMC.kext is a mandatory kernel extension for Hackintosh to boot, this PR checks if FakeSMC is loaded.

More about Hackintosh: [Wikipedia: OSx86](https://en.wikipedia.org/wiki/OSx86)

## Features
- Detect if the current macOS is a Hackintosh

## TODO
Maybe text rearrangement? "Model" line is a little bit too long (though still less than 80 chars)

## ScreenShot
![image](https://cloud.githubusercontent.com/assets/10568668/26518367/f4cd82ee-42e1-11e7-9766-dc58f6c03d98.png)


