### PR TITLE
Model: Add support for Hackintosh

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -242,7 +242,14 @@ get_model() {
             fi
         ;;
 
-        "Mac OS X") model="$(sysctl -n hw.model)" ;;
+        "Mac OS X") 
+            if [[ "$(kextstat | grep "FakeSMC")" != "" ]]; then
+                model="Hackintosh (SMBIOS: $(sysctl -n hw.model))"
+            else
+                model="$(sysctl -n hw.model)"
+            fi
+        ;;
+
         "iPhone OS")
             case "$machine_arch" in
                 "iPad1,1") model="iPad" ;;


### PR DESCRIPTION
## Description
This PR adds support for detecting if the macOS is running on a PC (Hackintosh)

Since FakeSMC.kext is a mandatory kernel extension for Hackintosh to boot, this PR checks if FakeSMC is loaded.

More about Hackintosh: [Wikipedia: OSx86](https://en.wikipedia.org/wiki/OSx86)

## Features
- Detect if the current macOS is a Hackintosh

## Screenshot
![image](https://cloud.githubusercontent.com/assets/10568668/26576198/8e2b395c-455a-11e7-90dd-4ee29ac18a8b.png)
