### PR TITLE
Terminal: Disable terminal detection if device is connected over SSH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 
 - Added font support for mate-terminal. **[@mstraube](https://github.com/mstraube)**
 - [Termite] Fix font mismatch. **[@MatthewCox](https://github.com/MatthewCox)**
+- Use `$SSH_TTY` for terminal detection if machine is connected via SSH.
 
 **GPU**
 

--- a/neofetch
+++ b/neofetch
@@ -1648,15 +1648,19 @@ get_term() {
 
     # Check $PPID for terminal emulator.
     while [[ -z "$term" ]]; do
-        parent="$(get_ppid "$parent")"
-        name="$(get_process_name "$parent")"
-        case "${name// }" in
-            "${SHELL/*\/}" | *"sh" | "tmux"* | "screen" | "su"*) ;;
-            "login"* | *"Login"* | "init" | "(init)") term="$(tty)" ;;
-            "ruby" | "1" | "systemd" | "sshd"* | "python"* | "USER"*"PID"*) break ;;
-            "gnome-terminal-") term="gnome-terminal" ;;
-            *) term="${name##*/}" ;;
-        esac
+        if [[ "$SSH_CONNECTION" ]]; then
+            term="$SSH_TTY"
+        else
+            parent="$(get_ppid "$parent")"
+            name="$(get_process_name "$parent")"
+            case "${name// }" in
+                "${SHELL/*\/}" | *"sh" | "tmux"* | "screen" | "su"*) ;;
+                "login"* | *"Login"* | "init" | "(init)") term="$(tty)" ;;
+                "ruby" | "1" | "systemd" | "sshd"* | "python"* | "USER"*"PID"*) break ;;
+                "gnome-terminal-") term="gnome-terminal" ;;
+                *) term="${name##*/}" ;;
+            esac
+        fi
     done
 
     # Log that the function was run.


### PR DESCRIPTION
## Description

Self-explanatory. Closes #731.

### Features

Self-explanatory.

### TODO

Further testing. I've only done two tests in my own environment using a free shell service and a VM.
