### PR TITLE
Distro: Refactor $machine_arch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@
 
 ## Info
 
+**Distro**
+
+- [Solaris, AIX, Haiku] The machine architecture will now be shown properly instead of machine ID.
+
 **Terminal Emulator**
 
 - Added font support for mate-terminal. **[@mstraube](https://github.com/mstraube)**

--- a/neofetch
+++ b/neofetch
@@ -216,8 +216,14 @@ get_distro() {
     [[ -z "$distro" ]] && distro="$os (Unknown)"
 
     # Get OS architecture.
-    [[ "$os_arch" == "on" ]] && \
+    if [[ "$os_arch" == "on" ]]; then
+        case "$os" in
+            "Solaris" | "AIX" | "BSD" | "macOS") machine_arch="$(uname -p)" ;;
+            *) machine_arch="$(uname -m)" ;;
+
+        esac
         distro+=" ${machine_arch}"
+    fi
 
     [[ "${ascii_distro:-auto}" == "auto" ]] && \
         ascii_distro="$(trim "$distro")"
@@ -3772,11 +3778,10 @@ old_options() {
 cache_uname() {
     # Cache the output of uname so we don't
     # have to spawn it multiple times.
-    uname=($(uname -srm))
+    uname=($(uname -sr))
 
     kernel_name="${uname[0]}"
     kernel_version="${uname[1]}"
-    machine_arch="${uname[2]}"
 }
 
 convert_time() {

--- a/neofetch
+++ b/neofetch
@@ -218,7 +218,7 @@ get_distro() {
     # Get OS architecture.
     if [[ "$os_arch" == "on" ]]; then
         case "$os" in
-            "Solaris" | "AIX" | "BSD" | "macOS") machine_arch="$(uname -p)" ;;
+            "Solaris" | "AIX" | "BSD" | "Haiku") machine_arch="$(uname -p)" ;;
             *) machine_arch="$(uname -m)" ;;
 
         esac


### PR DESCRIPTION
## Description

Self-explanatory.

### Rationale

In systems like Solaris and AIX, often times the `$machine_arch` output is *not* the actual machine architecture, but the machine ID/machine name. This is especially true in [the manpage for uname(1) for AIX](https://www.ibm.com/support/knowledgecenter/en/ssw_aix_72/com.ibm.aix.cmds5/uname.htm):

```
-m     Displays the machine ID number of the hardware running the system.
```

and if we want to detect proper machine architecture,

```
-p 	Displays the architecture of the system processor.
```

in Linux, however, if we use `-p`, the output will be `unknown`, more testing is needed. I'll merge this when it's ready.

### Testing

- [x] Linux (`-m`/<s>`-p`</s>)
- [x] BSD (<s>`-m`</s>/`-p`)
  - [x] FreeBSD / DragonFly (<s>`-m`</s>/`-p`)
  - [x] OpenBSD / Bitrig (<s>`-m`</s>/`-p`)
  - [x] NetBSD (<s>`-m`</s>/`-p`)
- [x] GNU Hurd (`-m`/<s>`-p`</s>)
- [x] Solaris (<s>`-m`</s>/`-p`)
- [x] AIX (<s>`-m`</s>/`-p`)
- [x] MINIX (`-m`/<s>`-p`</s>)
- [x] macOS (`-m`/<s>`-p`</s>)
- [x] Haiku (<s>`-m`</s>/`-p`)
- [x] Windows (`-m`/<s>`-p`</s>)
  - [x] Cygwin (`-m`/<s>`-p`</s>)
  - [x] Windows 10 Linux subsystem (`-m`/<s>`-p`</s>)
  - [x] MinGW/MSYS2 (`-m`/<s>`-p`</s>)