### PR TITLE
Terminal: add support for Neovim terminal emulator

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1669,6 +1669,8 @@ get_term() {
                 "login"* | *"Login"* | "init" | "(init)") term="$(tty)" ;;
                 "ruby" | "1" | "systemd" | "sshd"* | "python"* | "USER"*"PID"*) break ;;
                 "gnome-terminal-") term="gnome-terminal" ;;
+                *"nvim") term="Neovim Terminal" ;;
+                *"NeoVimServer"*) term="VimR Terminal" ;;
                 *) term="${name##*/}" ;;
             esac
         fi


### PR DESCRIPTION
## Description
Add support for Neovim `:terminal` mode, the embedded terminal emulator in neovim.

## Feature
- Showing **Neovim Terminal** if neofetch is running under neovim terminal emulator and
- Showing **VimR Terminal** if neofetch is running under neovim with VimR.

## Screenshot
##### VimR under macOS
![image](https://user-images.githubusercontent.com/10568668/27178133-9fee0ca2-51fb-11e7-8ced-4ca8cc5f45f5.png)
##### Neovim-Qt under Linux
![screenshot_20170615_184906 png-shadow](https://user-images.githubusercontent.com/10568668/27178320-5ee833a8-51fc-11e7-97f5-3c556486f8bf.png)


