### PR TITLE
AIX: Reduce dependency on prtconf

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -991,7 +991,7 @@ get_cpu() {
 
         "AIX")
             # Get CPU name.
-            cpu="$(prtconf | awk -F':' '/Processor Type/ {printf $2}')"
+            cpu="$(lsattr -El proc0 -a type | awk '{printf $2}')"
 
             # Get CPU speed.
             speed="$(prtconf -s | awk -F':' '{printf $2}')"

--- a/neofetch
+++ b/neofetch
@@ -994,7 +994,7 @@ get_cpu() {
             cpu="$(prtconf | awk -F':' '/Processor Type/ {printf $2}')"
 
             # Get CPU speed.
-            speed="$(prtconf | awk -F':' '/Processor Clock Speed/ {printf $2}')"
+            speed="$(prtconf -s | awk -F':' '{printf $2}')"
             speed="${speed/MHz}"
 
             # Get CPU cores.

--- a/neofetch
+++ b/neofetch
@@ -316,7 +316,7 @@ get_model() {
         ;;
 
         "AIX")
-            model="$(prtconf | awk -F':' '/System Model/ {printf $2}')"
+            model="$(/usr/bin/uname -M)"
         ;;
     esac
 


### PR DESCRIPTION
## Description

`prtconf` can be *really* slow in AIX (the total output is 8 seconds for neofetch for a full output), so to ease the burden, some commands are changed so the output will be faster.

## Issues

<s>The `-M` option exists in default AIX uname, but when there's GNU uname, the option `-M` doesn't exist. We can put add standard PATH for neofetch and add the `PATH` before it so it will be like this:

`export PATH="/usr/xpg4/bin:/usr/sbin:/sbin:/usr/etc:/usr/bin:/bin:${PATH}"`</s>

---------

P.S.: I set up a crontab in an AIX server that should generate output [here](http://polarhome.com:773/~koni/output) and logs [here](http://polarhome.com:773/~koni/log) from neofetch's latest master. So if something is up with AIX we can fix them.