### PR TITLE
CPU [Linux]: Fix inaccurate ARM CPU on SoC systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
 ## Contributors
 
 
+## Info
+
+**CPU**
+
+- [Linux] Fixed inaccurate output on ARM SoC devices.

--- a/neofetch
+++ b/neofetch
@@ -828,26 +828,22 @@ get_cpu() {
     case "$os" in
         "Linux" | "MINIX" | "Windows")
             # Get CPU name.
-            case "$distro" in
-                "Android"*) cpu="$(getprop ro.product.board)" ;;
-                *)
-                    case "$machine_arch" in
-                        "frv" | "hppa" | "m68k" | "openrisc" | "or"* | "powerpc" | "ppc"* | "sparc"*)
-                            cpu="$(awk -F':' '/^cpu\t|^CPU/ {printf $2; exit}' /proc/cpuinfo)"
-                        ;;
-                        "s390"*)
-                            cpu="$(awk -F'=' '/machine/ {print $4; exit}' /proc/cpuinfo)"
-                        ;;
-                        "ia64" | "m32r")
-                            cpu="$(awk -F':' '/model/ {print $2; exit}' /proc/cpuinfo)"
-                            [[ -z "$cpu" ]] && cpu="$(awk -F':' '/family/ {printf $2; exit}' /proc/cpuinfo)"
-                        ;;
-                        *)
-                            cpu="$(awk -F ': | @' '/model name|Processor|^cpu model|chip type|^cpu type/ {printf $2; exit}' /proc/cpuinfo)"
-                        ;;
-                    esac
-                ;;
-            esac
+                case "$machine_arch" in
+                    "frv" | "hppa" | "m68k" | "openrisc" | "or"* | "powerpc" | "ppc"* | "sparc"*)
+                        cpu="$(awk -F':' '/^cpu\t|^CPU/ {printf $2; exit}' /proc/cpuinfo)"
+                    ;;
+                    "s390"*)
+                        cpu="$(awk -F'=' '/machine/ {print $4; exit}' /proc/cpuinfo)"
+                    ;;
+                    "ia64" | "m32r")
+                        cpu="$(awk -F':' '/model/ {print $2; exit}' /proc/cpuinfo)"
+                        [[ -z "$cpu" ]] && cpu="$(awk -F':' '/family/ {printf $2; exit}' /proc/cpuinfo)"
+                    ;;
+                    *)
+                        cpu="$(awk -F ': | @' '/model name|Processor|^cpu model|chip type|^cpu type/ {printf $2; exit}' /proc/cpuinfo)"
+                       [[ "$cpu" == *"processor rev"* ]] && cpu="$(awk -F':' '/Hardware/ {print $2; exit}' /proc/cpuinfo)"
+                    ;;
+                esac
 
             speed_dir="/sys/devices/system/cpu/cpu0/cpufreq"
             temp_dir="/sys/class/hwmon/hwmon0/temp1_input"
@@ -1047,6 +1043,7 @@ get_cpu() {
     cpu="${cpu//, altivec supported}"
     cpu="${cpu//FPU*}"
     cpu="${cpu//Chip Revision*}"
+    cpu="${cpu//Technologies, Inc}"
 
     # Trim spaces from core output
     cores="${cores//[[:space:]]}"
@@ -1068,6 +1065,7 @@ get_cpu() {
             cpu="${cpu/AMD }"
             cpu="${cpu/Intel }"
             cpu="${cpu/Core? Duo }"
+            cpu="${cpu/Qualcomm }"
 
             [[ "$cpu_shorthand" == "tiny" ]] && cpu="${cpu/@*}"
         ;;


### PR DESCRIPTION
## Description

### Rationale

On systems with system-on-a-chip like Raspberry Pi or Android phones, their CPU output in `model name`/`Processor` is `ARMv6-compatible processor rev 7` instead of whatever supposed to be there. They are placed in `Hardware` instead.

```
processor	: 0
model name	: ARMv6-compatible processor rev 7 (v6l)
BogoMIPS	: 2.28
Features	: half thumb fastmult vfp edsp java tls 
CPU implementer	: 0x41
CPU architecture: 7
CPU variant	: 0x0
CPU part	: 0xb76
CPU revision	: 7

Hardware	: BCM2708
Revision	: 0004
Serial		: 00000000163b89e4
```

However there are systems like this, which put proper name of Processors in `Processor` and put the hardware model in `Hardware`.

```
Processor       : StrongARM-1110 rev 9 (v4l)
BogoMIPS        : 137.21
Features        : swp half 26bit fastmult
CPU implementor : 0x69
CPU architecture: 4
CPU variant     : 0x0
CPU part        : 0xb11
CPU revision    : 9

Hardware        : HP iPAQ H3800
Revision        : 0000
Serial          : 0000000000000000
```

This is a compromise measure. So if a SoC is detected, it will detect the `Hardware` part.

It also eliminates the need for `getprop` in Android.

### Issues

N/A, for now.

### TODO

More testing.
