### PR TITLE
Added measurement of the primary screen's diagonal in inches (Linux only)

### DIFF
--- a/config/config
+++ b/config/config
@@ -17,6 +17,7 @@ print_info() {
     info "Packages" packages
     info "Shell" shell
     info "Resolution" resolution
+    info "Screen Diagonal" diagonal
     info "DE" de
     info "WM" wm
     info "WM Theme" wm_theme

--- a/config/travis
+++ b/config/travis
@@ -14,6 +14,7 @@ print_info() {
     info "Packages" packages
     info "Shell" shell
     info "Resolution" resolution
+    info "Screen Diagonal" diagonal
     info "DE" de
     info "WM" wm
     info "WM Theme" wm_theme

--- a/neofetch
+++ b/neofetch
@@ -1511,7 +1511,7 @@ get_resolution() {
 
 get_diagonal() {
     case "$os" in
-        *)
+        Linux)
             mm=($(xrandr | awk '/mm/' | grep -oP '[0-9]+(?=mm)'))
             diagonal="$(echo "scale=1; sqrt(${mm[0]}^2 + ${mm[1]}^2) / 25.4" | bc)\""
             unset mm

--- a/neofetch
+++ b/neofetch
@@ -1509,6 +1509,16 @@ get_resolution() {
     resolution="${resolution%,*}"
 }
 
+get_diagonal() {
+    case "$os" in
+        *)
+            mm=($(xrandr | awk '/mm/' | grep -oP '[0-9]+(?=mm)'))
+            diagonal="$(echo "scale=1; sqrt(${mm[0]}^2 + ${mm[1]}^2) / 25.4" | bc)\""
+            unset mm
+        ;;
+    esac
+}
+
 get_style() {
     # Fix weird output when the function is run multiple times.
     unset gtk2_theme gtk3_theme theme path
@@ -3873,7 +3883,6 @@ convert_time() {
         5) week_day="Fri" ;;
         6) week_day="Sat" ;;
     esac
-
     # Convert 24 hour time to 12 hour time + AM/PM.
     case "$install_time_format" in
         "12h")
@@ -3884,10 +3893,8 @@ convert_time() {
         ;;
         *) time="$4" ;;
     esac
-
     # Toggle showing the time.
     [[ "$install_time" == "off" ]] && unset time
-
     # Print the install date.
     printf "%s" "$week_day $day $month $year $time"
 }

--- a/neofetch
+++ b/neofetch
@@ -1512,8 +1512,13 @@ get_resolution() {
 get_diagonal() {
     case "$os" in
         Linux)
-            mm=($(xrandr | awk '/mm/' | grep -oP '[0-9]+(?=mm)'))
-            diagonal="$(echo "scale=1; sqrt(${mm[0]}^2 + ${mm[1]}^2) / 25.4" | bc)\""
+            # Using --nograb and --current make xrandr print REALLY fast.
+            # Replaced the grep and awk with a single grep command. The less pipes the better.
+            mm=($(xrandr | grep -oP '[0-9]+(?=mm)'))
+
+            # Using <<< you can remove the call to echo.
+            diagonal="$(bc <<< "scale=1; sqrt(${mm[0]}^2 + ${mm[1]}^2) / 25.4")\""
+
             unset mm
         ;;
     esac


### PR DESCRIPTION
## Description

Displays the measurement of the primary screen in inches.

## Issues
- Only works on Linux
- Only works with one screen

## TODO
- Implement on other OSes
- Test with more than one screens