### PR TITLE
CPU: Fix inaccurate speed for processors below 1GHz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - [Linux] Fixed inaccurate output on ARM SoC devices.
 - [NetBSD] Added support for CPU temperature. (NOTE: This only supports newer Intel processors)
+- Fixed inaccurate speed output in systems with CPU speed less than 1 GHz.
 
 **Terminal**
 

--- a/config/config.conf
+++ b/config/config.conf
@@ -142,6 +142,7 @@ speed_type="bios_limit"
 # Default: 'off'
 # Values: 'on', 'off'.
 # Flag:    --speed_shorthand.
+# NOTE: This flag is not supported in systems with CPU speed less than 1 GHz
 #
 # Example:
 # on:    'i7-6500U (4) @ 3.1GHz'

--- a/neofetch
+++ b/neofetch
@@ -3951,6 +3951,9 @@ INFO:
                                 NOTE: This only supports Linux with cpufreq.
 
     --speed_shorthand on/off    Whether or not to show decimals in CPU speed.
+
+                                NOTE: This flag is not supported in systems with CPU speed less than 1 GHz.
+
     --cpu_shorthand type        Shorten the output of CPU
                                 Possible values: name, speed, tiny, on, off
     --cpu_cores type            Whether or not to display the number of CPU cores

--- a/neofetch
+++ b/neofetch
@@ -1014,18 +1014,13 @@ get_cpu() {
     esac
 
     if [[ "$speed" ]]; then
-        # Hide decimals if on.
-        [[ "$speed_shorthand" == "on" ]] && \
-            speed="$((speed / 100))"
-
-        # Fix for speeds under 1ghz.
-        if [[ -z "${speed:1}" ]]; then
-            speed="0.${speed}"
+        if (( speed < 1000 )); then
+            cpu="$cpu @ ${speed}MHz $temp"
         else
+            [[ "$speed_shorthand" == "on" ]] && speed="$((speed / 100))"
             speed="${speed:0:1}.${speed:1}"
+            cpu="$cpu @ ${speed}GHz $temp"
         fi
-
-        cpu="$cpu @ ${speed}GHz $temp"
     fi
 
     # Remove un-needed patterns from cpu output.

--- a/neofetch.1
+++ b/neofetch.1
@@ -32,6 +32,8 @@ NOTE: This only supports Linux with cpufreq.
 .TP
 \fB\-\-speed_shorthand\fR on/off
 Whether or not to show decimals in CPU speed.
+.IP
+NOTE: This flag is not supported in systems with CPU speed less than 1 GHz.
 .TP
 \fB\-\-cpu_shorthand\fR type
 Shorten the output of CPU


### PR DESCRIPTION
## Description

Self-explanatory.

`speed_shorthand` will have to be disabled for CPU speed below 1 GHz. Unless we want to nest another `if` there.