### PR TITLE
WM: Fix/add Window Maker detection

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -663,10 +663,13 @@ get_wm() {
 
     if [[ -n "$DISPLAY" && "$os" != "Mac OS X" ]]; then
         id="$(xprop -root -notype | awk '$1=="_NET_SUPPORTING_WM_CHECK:"{print $5}')"
-        wm="$(xprop -id "$id" -notype -f _NET_WM_NAME 8t)"
+        wm="$(xprop -id "$id" -notype -len 100 -f _NET_WM_NAME 8t)"
         wm="${wm/*_NET_WM_NAME = }"
         wm="${wm/\"}"
         wm="${wm/\"*}"
+
+        # Window Maker does not set _NET_WM_NAME
+        [[ "$wm" =~ "WINDOWMAKER" ]] && wm="wmaker"
 
         # Fallback for Wayland wms.
         [[ "$wm" == "xwlc" ]] && \


### PR DESCRIPTION
## Description
Currently it looks like this:

![wmaker](https://user-images.githubusercontent.com/20053197/28208148-a98684f4-688c-11e7-836a-ef89f798b208.png)

## Notes
Added `-len 100` because otherwise that call to `xprop` is very slow.
(the property _WINDOWMAKER_ICON_TILE is very long)
