### PR TITLE
Misc: Disable 2>/dev/null if verbose mode is on

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2746,8 +2746,10 @@ info() {
     unset -v prin
 
     # Call the function.
-    "get_${2:-$1}" 2>/dev/null
-
+    case "$verbose" in
+        "on") "get_${2:-$1}" ;;
+        *) "get_${2:-$1}" ;;
+    esac
     # If the get_func function called 'prin' directly, stop here.
     [[ "$prin" ]] && return
 
@@ -4362,9 +4364,15 @@ get_args() {
 main() {
     cache_uname
     get_os
-    get_default_config 2>/dev/null
+    case "$verbose" in
+        "on") get_default_config ;;
+        *) get_default_config 2>/dev/null ;;
+    esac
     get_args "$@"
-    get_distro 2>/dev/null
+    case "$verbose" in
+        "on") get_distro ;;
+        *) get_distro 2>/dev/null ;;
+    esac
     get_bold
     get_distro_colors
 
@@ -4380,7 +4388,10 @@ main() {
     image_backend
     old_functions
     get_cache_dir
-    print_info 2>/dev/null
+    case "$verbose" in
+        "on") print_info ;;
+        *) print_info 2>/dev/null ;;
+    esac
     dynamic_prompt
 
     # w3m-img: Draw the image a second time to fix


### PR DESCRIPTION
## Description

Self-explanatory.

### Rationale

Before this commit, the verbose output will be just like this.

```
+ export LC_ALL=C
+ LC_ALL=C
+ [[ ascii != \o\f\f ]]
+ printf %b '\033[19A\033[9999999D'
+ old_functions
+ type printinfo
+ get_cache_dir
+ case "$os" in
+ cache_dir=/tmp
+ print_info
+ dynamic_prompt
+ case "$image_backend" in
+ printf '\n'
+ (( lines < info_height ))
+ [[ -n '' ]]
+ return
+ [[ ascii == *w3m* ]]
```

`print_info`, that's it. We have no idea what's happening *inside* `print_info`, so if errors are detected because of one malfunction inside `print_info`, we won't know what happened.

After this commit, the verbose output will be like this:

```
+ export LC_ALL=C
+ LC_ALL=C
+ [[ ascii != \o\f\f ]]
+ printf %b '\033[19A\033[9999999D'
+ old_functions
+ type printinfo
+ get_cache_dir
+ case "$os" in
+ cache_dir=/tmp
+ case "$verbose" in
+ print_info
+ info title
+ [[ -n '' ]]
+ unset -v prin
+ case "$verbose" in
+ get_title
+ user=koni
(...)
+ get_cpu
+ [[ Arch Linux  x86_64 == \N\e\t\B\S\D* ]]
+ case "$os" in
+ case "$machine_arch" in
++ awk -F ': | @' '/model name|Processor|^cpu model|chip type|^cpu type/ {printf $2; exit}' /proc/cpuinfo
+ cpu='Intel(R) Core(TM) i5-4460  CPU'
+ [[ Intel(R) Core(TM) i5-4460  CPU == *\p\r\o\c\e\s\s\o\r\ \r\e\v* ]]
+ speed_dir=/sys/devices/system/cpu/cpu0/cpufreq
+ temp_dir=/sys/class/hwmon/hwmon0/temp1_input
+ [[ -d /sys/devices/system/cpu/cpu0/cpufreq ]]
./neofetch: line 859: /sys/devices/system/cpu/cpu0/cpufreq/bios_limit: No such file or directory
+ speed=
./neofetch: line 860: /sys/devices/system/cpu/cpu0/cpufreq/bios_limit: No such file or directory
+ speed=
+ speed=3400000
+ speed=3400
(...)
+ (( ++info_height ))
+ prin=1
+ [[ -n 1 ]]
+ return
+ dynamic_prompt
+ case "$image_backend" in
+ printf '\n'
+ (( lines < info_height ))
+ [[ -n '' ]]
+ return
+ [[ ascii == *w3m* ]]
```

Yes, it will expose errors like `bad substitution` or `/sys/devices/system/cpu/cpu0/cpufreq/bios_limit: No such file or directory`, but hey, that's kinda the point of verbose mode, isn't it?

## TODO

N/A