### PR TITLE
Term: Fix mate-terminal font when maximized or fullscreen

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1814,13 +1814,12 @@ get_term_font() {
                 mate-terminal --save-config="$mateterm_config"
 
                 role="$(xprop -id "${WINDOWID}" WM_WINDOW_ROLE)"
-                role="${role##*= }"
+                role="${role##* }"
+                role="${role//\"}"
 
-                term_id="$(grep -A1 "${role//\"}" "$mateterm_config")"
-                term_id="${term_id##*=}"
-
-                profile="$(grep -A1 "\[$term_id\]" "$mateterm_config")"
-                profile="${profile##*=}"
+                profile="$(awk -F '=' -v r="$role" \
+                           '$0~r {getline; if(/Maximized/) getline; if(/Fullscreen/) getline; id=$2"]"}
+                            $0~id {if(id) {getline; print $2; exit}}' "$mateterm_config")"
 
                 rm -f "$mateterm_config"
 


### PR DESCRIPTION
## Description
In maximzed windows and fullscreen mode font detection for MATE Terminal did not work.
The grep commands failed because the config file contains extra lines if the window is maximized and/or fullscreen.

## Features
- Fixes font detection when maximized or fullscreen
- Faster (nearly 2 times)
