### PR TITLE
Prioritise maim(1) over scrot(1).

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2702,11 +2702,11 @@ scrot_program() {
         if [[ "$scrot_cmd" != "auto" ]] && type -p "$scrot_cmd" >/dev/null; then
             scrot_program=("$scrot_cmd")
 
-        elif type -p scrot >/dev/null; then
-            scrot_program=(scrot)
-
         elif type -p maim >/dev/null; then
             scrot_program=(maim)
+
+        elif type -p scrot >/dev/null; then
+            scrot_program=(scrot)
 
         elif type -p import >/dev/null && [[ "$os" != "Mac OS X" ]]; then
             scrot_program=(import -window root)


### PR DESCRIPTION
If a user has maim(1) installed as well as scrot(1), they likely wish to use the former instead of the latter, as it is less commonly installed (and is even described as "supposed to be an improved scrot").