### PR TITLE
gpu: Hide duplicate identical gpus

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1113,7 +1113,7 @@ get_gpu() {
         "Linux")
             # Read GPUs into array.
             IFS=$'\n'
-            gpus=($(lspci -mm | awk -F '\\"|\\" \\"' '/"Display|"3D|"VGA/ {print $3 " " $4}'))
+            gpus=($(lspci -mm | awk -F '\\"|\\" \\"|\\(' '/"Display|"3D|"VGA/ {print $3 " " $4}' | uniq))
             IFS="$old_ifs"
 
             # Number the GPUs if more than one exists.

--- a/neofetch
+++ b/neofetch
@@ -1113,7 +1113,9 @@ get_gpu() {
         "Linux")
             # Read GPUs into array.
             IFS=$'\n'
-            gpus=($(lspci -mm | awk -F '\\"|\\" \\"|\\(' '/"Display|"3D|"VGA/ {print $3 " " $4}' | uniq))
+            gpus=($(lspci -mm | awk -F '\\"|\\" \\"|\\(' \
+                                       '/"Display|"3D|"VGA/ {a[$0] = $3 " " $4} END{for(i in a)
+                                        {if(!seen[a[i]]++) print a[i]}}'))
             IFS="$old_ifs"
 
             # Number the GPUs if more than one exists.


### PR DESCRIPTION
## Description

Fixes #702 

Ideally we don't want to pipe a second time but it doesn't seem like there's another way of doing this. (Unless `awk` has a way of removing duplicates?) Also it'd be nice to append a count to the end but I don't think it's possible with the way the function is written. We'd have to rewrite it so we'll save that for another day.

I've tested this on an AMD and Intel machine but it should work on all others as well.