### PR TITLE
OS: Add support for the Siduction OS

### DIFF
--- a/ascii/distro/siduction
+++ b/ascii/distro/siduction
@@ -1,0 +1,21 @@
+${c1}                 _aass,                  
+                jQh: =$w                 
+                QWmwawQW                 
+                )$QQQQ@(   ..            
+          _a_a.   ~??^  syDY?Sa,         
+        _mW>-<$c       jWmi  imm.        
+        ]QQwayQE       4QQmgwmQQ`        
+         ?WWQWP'       -9QQQQQ@'._aas,   
+  _a%is.        .adYYs,. -"?!` aQB*~^3$c 
+ _Qh;.nm       .QWc. {QL      ]QQp;..vmQ/
+ "QQmmQ@       -QQQggmQP      ]QQWmggmQQ(
+  -???"         "$WQQQY`  __,  ?QQQQQQW! 
+         _yZ!?q,   -   .yWY!!Sw, "???^   
+        .QQa_=qQ       mQm>..vmm         
+         $QQWQQP       $QQQgmQQ@         
+          "???"   _aa, -9WWQQWY`         
+                _mB>~)$a  -~~            
+                mQms_vmQ.                
+                ]WQQQQQP                 
+                 -?T??"                  
+

--- a/neofetch
+++ b/neofetch
@@ -78,6 +78,12 @@ get_distro() {
                     *) distro="Red Star OS $(awk -F'[^0-9*]' '$0=$2' /etc/redstar-release)"
                 esac
 
+            elif [[ -f "/etc/siduction-version" ]]; then
+                case "$distro_shorthand" in
+                    "on" | "tiny") distro="Siduction" ;;
+                    *) distro="Siduction ($(lsb_release -sic))"
+                esac
+
             elif type -p lsb_release >/dev/null; then
                 case "$distro_shorthand" in
                     "on")   lsb_flags="-sir" ;;
@@ -3558,6 +3564,11 @@ get_distro_colors() {
         "Scientific"*)
             set_colors 4 7 1
             ascii_file="scientific"
+        ;;
+
+	"Siduction"*)
+            set_colors 4 4
+            ascii_file="siduction"
         ;;
 
         "Slackware"*)


### PR DESCRIPTION
This pull-request adds support for the [Siduction](https://siduction.org) GNU/Linux Distribution.
It's not the prettiest ascii logo, but it does the job :smile:.

![neofetch_siduction-final](https://user-images.githubusercontent.com/649340/29224357-4504d0c2-7eca-11e7-8d08-494a9240654a.png)
