### PR TITLE
Fix Terminal Font displaying incorrect information in urxvt, if one of the fonts has 'font' in its name

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1961,7 +1961,7 @@ get_term_font() {
 
         "urxvt" | "urxvtd" | "rxvt-unicode" | "xterm")
             term_font="$(grep -i -F "${term/d}*font" < <(xrdb -query))"
-            term_font="${term_font/*font:}"
+            term_font="${term_font/*"*font:"}"
             term_font="$(trim "$term_font")"
 
             # Xresources has two different font formats, this checks which


### PR DESCRIPTION
## Description
Very specific case, but for example having Unifont (xft:Unifont:style=Medium:antialias=false") as your terminal font, makes Neofetch print it as "Terminal Font: style=Medium:antialias=false" instead of "Terminal Font: Unifont".
This is due to the fact, that it looks for "font:" string. Fixed it by making it look for "*font:" instead, but I'm not sure if that's the right approach.
Pictures say more than words :smiley: 
![Before and after](http://i.imgur.com/2MB9Lx8.png)