### PR TITLE
theme: Show KDE and GTK output if both are available.

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -833,6 +833,8 @@ get_wm_theme() {
             elif [[ -f "$kdebugrc" ]]; then
                 wm_theme="$(awk '/(decoration)/ {gsub(/\[/,"",$1); print $1; exit}' "$kdebugrc")"
             fi
+
+            wm_theme="${wm_theme/'theme='}"
         ;;
 
         "Quartz Compositor")

--- a/neofetch
+++ b/neofetch
@@ -1613,15 +1613,12 @@ get_style() {
                 if [[ -f "${kde_config_dir}/kdeglobals" ]]; then
                     kde_config_file="${kde_config_dir}/kdeglobals"
 
-                    theme="$(grep "^${kde}" "$kde_config_file")"
-                    theme="${theme/${kde}*=}"
-                    theme="$(uppercase "$theme")"
-
-                    gtk_shorthand="on"
+                    kde_theme="$(grep "^${kde}" "$kde_config_file")"
+                    kde_theme="${theme/${kde}*=}"
+                    kde_theme="$(uppercase "$theme")"
                 else
                     err "Theme: KDE config files not found, skipping."
                 fi
-                return
             ;;
 
             *"Cinnamon"*)
@@ -1700,6 +1697,7 @@ get_style() {
         # Toggle visibility of GTK themes.
         [[ "$gtk2" == "off" ]] && unset gtk2_theme
         [[ "$gtk3" == "off" ]] && unset gtk3_theme
+        [[ "$kde" == "off" ]] && unset kde_theme
 
         # Format the string based on which themes exist.
         if  [[ "$gtk2_theme" && "$gtk2_theme" == "$gtk3_theme" ]]; then
@@ -1716,12 +1714,13 @@ get_style() {
         fi
 
         # Final string.
-        theme="${gtk2_theme}${gtk3_theme}"
+        theme="${kde_theme}${gtk2_theme}${gtk3_theme}"
 
         # Make the output shorter by removing "[GTKX]" from the string.
         if [[ "$gtk_shorthand" == "on" ]]; then
             theme="${theme// '[GTK'[0-9]']'}"
             theme="${theme/ '[GTK2/3]'}"
+            theme="${theme/ '[KDE]'}"
         fi
     fi
 }

--- a/neofetch
+++ b/neofetch
@@ -1614,8 +1614,8 @@ get_style() {
                     kde_config_file="${kde_config_dir}/kdeglobals"
 
                     kde_theme="$(grep "^${kde}" "$kde_config_file")"
-                    kde_theme="${theme/${kde}*=}"
-                    kde_theme="$(uppercase "$theme")"
+                    kde_theme="${kde_theme/${kde}*=}"
+                    kde_theme="$(uppercase "$kde_theme") [KDE], "
                 else
                     err "Theme: KDE config files not found, skipping."
                 fi
@@ -1697,10 +1697,9 @@ get_style() {
         # Toggle visibility of GTK themes.
         [[ "$gtk2" == "off" ]] && unset gtk2_theme
         [[ "$gtk3" == "off" ]] && unset gtk3_theme
-        [[ "$kde" == "off" ]] && unset kde_theme
 
         # Format the string based on which themes exist.
-        if  [[ "$gtk2_theme" && "$gtk2_theme" == "$gtk3_theme" ]]; then
+        if [[ "$gtk2_theme" && "$gtk2_theme" == "$gtk3_theme" ]]; then
             gtk3_theme+=" [GTK2/3]"
             unset gtk2_theme
 
@@ -1715,6 +1714,7 @@ get_style() {
 
         # Final string.
         theme="${kde_theme}${gtk2_theme}${gtk3_theme}"
+        theme="${theme%, }"
 
         # Make the output shorter by removing "[GTKX]" from the string.
         if [[ "$gtk_shorthand" == "on" ]]; then


### PR DESCRIPTION
## Features

- Show GTK info when running KDE.
- Fixed bug in `get_wm_theme` for KDE systems.

Closes #808 
