### PR TITLE
Term: Fix mate-terminal font

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1926,8 +1926,7 @@ get_term_font() {
                 rm -f "$mateterm_config"
 
                 mate_get() {
-                   gsettings get org.mate.terminal.profile:\
-                   /org/mate/terminal/profiles/"$1"/ "$2"
+                   gsettings get org.mate.terminal.profile:/org/mate/terminal/profiles/"$1"/ "$2"
                 }
 
                 if [[ "$(mate_get "$profile" "use-system-font")" == "true" ]]; then


### PR DESCRIPTION
It does not work with the linebreak and still fits in line length 100 without it.
