### PR TITLE
Make Makefile more portable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
-PREFIX = /usr
-SYSCONFDIR = /etc
+PREFIX ?= /usr
+SYSCONFDIR ?= /etc
+MANDIR ?= $(PREFIX)/share/man
 
 all:
 	@echo Run \'make install\' to install Neofetch.
@@ -8,7 +9,7 @@ install:
 	@echo 'Making directories...'
 	@mkdir -p $(DESTDIR)$(PREFIX)/bin
 	@mkdir -p $(DESTDIR)$(PREFIX)/share/neofetch/ascii/distro
-	@mkdir -p $(DESTDIR)$(PREFIX)/share/man/man1
+	@mkdir -p $(DESTDIR)$(MANDIR)/man1
 	@mkdir -p $(DESTDIR)$(SYSCONFDIR)/neofetch
 
 	@echo 'Installing binaries...'
@@ -17,12 +18,12 @@ install:
 
 	@echo 'Installing ASCII files, man page and config file...'
 	@cp -p ascii/distro/* $(DESTDIR)$(PREFIX)/share/neofetch/ascii/distro
-	@cp -p neofetch.1 $(DESTDIR)$(PREFIX)/share/man/man1
+	@cp -p neofetch.1 $(DESTDIR)$(MANDIR)/man1
 	@cp -p config/config.conf $(DESTDIR)$(SYSCONFDIR)/neofetch/config.conf
 
 uninstall:
 	@echo 'Removing files...'
 	@rm -rf $(DESTDIR)$(PREFIX)/bin/neofetch
-	@rm -rf $(DESTDIR)$(PREFIX)/share/man/man1/neofetch.1*
+	@rm -rf $(DESTDIR)$(MANDIR)/man1/neofetch.1*
 	@rm -rf $(DESTDIR)$(PREFIX)/share/neofetch
 	@rm -rf $(DESTDIR)$(SYSCONFDIR)/neofetch


### PR DESCRIPTION
## Description

- Make PREFIX, SYSCONFDIR overridable
- Make MANDIR customizable (for instance, FreeBSD uses $(PREFIX)/man instead of $(PREFIX)/share/man)
