### PR TITLE
fixed get_battery for device names starting with CMB

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2077,7 +2077,7 @@ get_battery() {
         "Linux")
             # We use 'prin' here so that we can do multi battery support
             # with a single battery per line.
-            for bat in "/sys/class/power_supply/"{BAT,axp288_fuel_gauge}*; do
+            for bat in "/sys/class/power_supply/"{BAT,axp288_fuel_gauge,CMB}*; do
                 capacity="$(< "${bat}/capacity")"
                 status="$(< "${bat}/status")"
 


### PR DESCRIPTION
## Description

On some devices I tested (Fujitsu Lifebook E754, ThinkPad T410s, ThinkPad T400), the battery gets assigned the device path /sys/class/power_supply/CMB1 when using Fedora 26 with Kernel 4.12.5-300.fc26.x86_64. I adapted the get_battery function for this case.

## Features
* Fix get_battery for Fedora 26

## Issues

## TODO
