### PR TITLE
Fixed scrot_cmd not accepting options.

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2858,8 +2858,8 @@ scrot_program() {
     # falling back to OS specific screenshot tools.
     if [[ -n "$DISPLAY" ]]; then
         if [[ "$scrot_cmd" != "auto" ]] && type -p $(awk '{print $1;}' <<< $scrot_cmd) >/dev/null; then
-          scrot_program=$(awk '{print $1;}' <<< $scrot_cmd)
-          scrot_args=$(echo ${scrot_cmd//$scrot_program} | xargs)
+            scrot_program=$(awk '{print $1;}' <<< $scrot_cmd)
+            scrot_args=$(echo ${scrot_cmd//$scrot_program} | xargs)
 
         elif type -p maim >/dev/null; then
             scrot_program=(maim)

--- a/neofetch
+++ b/neofetch
@@ -2857,8 +2857,9 @@ scrot_program() {
     # We first check to see if an X server is running before
     # falling back to OS specific screenshot tools.
     if [[ -n "$DISPLAY" ]]; then
-        if [[ "$scrot_cmd" != "auto" ]] && type -p "$scrot_cmd" >/dev/null; then
-            scrot_program=("$scrot_cmd")
+        if [[ "$scrot_cmd" != "auto" ]] && type -p $(awk '{print $1;}' <<< $scrot_cmd) >/dev/null; then
+          scrot_program=$(awk '{print $1;}' <<< $scrot_cmd)
+          scrot_args=$(echo ${scrot_cmd//$scrot_program} | xargs)
 
         elif type -p maim >/dev/null; then
             scrot_program=(maim)
@@ -2897,7 +2898,7 @@ scrot_program() {
     printf "%s\r" "Taking scrot..."
 
     # Take the scrot.
-    "${scrot_program[@]}" "$1"
+    $scrot_program $scrot_args "$1"
 
     err "Scrot: Screen captured using ${scrot_program[0]}"
 }


### PR DESCRIPTION
## Description

Currently if you want to supply additional options to the `scrot_cmd` option in the config file or on the command line, neofetch does not use the command. For example, change `scrot_cmd` in the config or on the command line to `scrot -u`. This should make scrot only take a screenshot of the currently focused window. However, it does not do that. This is because neofetch is testing the whole command, including the option, against currently installed programs.

Now, with this patch, additional options now are accepted because neofetch is only testing the command call itself, not including the options.

### Current neofetch behavior

`test -p 'scrot -u'` -> `false`

### Fixed neofetch behavior

`test -p 'scrot'` -> `true`