### PR TITLE
Fixed neofetch not finding urxvt fonts with the `.` declaration.

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1976,6 +1976,12 @@ get_term_font() {
             term_font="${term_font/*"*font:"}"
             term_font="$(trim "$term_font")"
 
+            if [[ -z "$term_font" ]]; then
+                term_font="$(grep -i -F "${term/d}.font" < <(xrdb -query))"
+                term_font="${term_font/*".font:"}"
+                term_font="$(trim "$term_font")"
+            fi
+
             # Xresources has two different font formats, this checks which
             # one is in use and formats it accordingly.
             case "$term_font" in


### PR DESCRIPTION
## Description

Currently if you declare your urxvt fonts with `.` instead of `*` in your `.Xresources`, neofetch will not find your terminal font. This patch fixes that.

I'd imagine there's a much simpler way of doing this (without calling the same 3 lines twice with minor differences), but I'm not an expert at bash. Sorry about that.