### PR TITLE
info: Add support for GPU Driver [Linux]

### DIFF
--- a/config/config.conf
+++ b/config/config.conf
@@ -26,6 +26,7 @@ print_info() {
     info "GPU" gpu
     info "Memory" memory
 
+    # info "GPU Driver" gpu_driver  # Linux only
     # info "CPU Usage" cpu_usage
     # info "Disk" disk
     # info "Battery" battery
@@ -35,7 +36,7 @@ print_info() {
     # info "Public IP" public_ip
     # info "Users" users
     # info "Install Date" install_date
-    # info "Locale" locale # This only works on glibc systems.
+    # info "Locale" locale  # This only works on glibc systems.
 
     info line_break
     info cols

--- a/config/travis.conf
+++ b/config/travis.conf
@@ -21,6 +21,7 @@ print_info() {
     info "Terminal Font" term_font
     info "CPU" cpu
     info "GPU" gpu
+    info "GPU Driver" gpu_driver
     info "Memory" memory
 
     info "CPU Usage" cpu_usage

--- a/neofetch
+++ b/neofetch
@@ -2258,6 +2258,14 @@ get_locale() {
     locale="$sys_locale"
 }
 
+get_gpu_driver() {
+    case "$os" in
+        "Linux")
+            gpu_driver="$(lspci -nnk | awk -F ': ' '/VGA/{nr[NR+2]}; NR in nr {print $2}')"
+        ;;
+    esac
+}
+
 get_cols() {
     if [[ "$color_blocks" == "on" ]]; then
         # Convert the width to space chars.

--- a/neofetch
+++ b/neofetch
@@ -2261,7 +2261,8 @@ get_locale() {
 get_gpu_driver() {
     case "$os" in
         "Linux")
-            gpu_driver="$(lspci -nnk | awk -F ': ' '/Display|3D|VGA/{nr[NR+2]}; NR in nr {printf $2 ", "}')"
+            gpu_driver="$(lspci -nnk | awk -F ': ' \
+                          '/Display|3D|VGA/{nr[NR+2]}; NR in nr {printf $2 ", "}')"
             gpu_driver="${gpu_driver%, }"
         ;;
     esac

--- a/neofetch
+++ b/neofetch
@@ -2261,7 +2261,8 @@ get_locale() {
 get_gpu_driver() {
     case "$os" in
         "Linux")
-            gpu_driver="$(lspci -nnk | awk -F ': ' '/VGA/{nr[NR+2]}; NR in nr {print $2}')"
+            gpu_driver="$(lspci -nnk | awk -F ': ' '/Display|3D|VGA/{nr[NR+2]}; NR in nr {printf $2 ", "}')"
+            gpu_driver="${gpu_driver%, }"
         ;;
     esac
 }


### PR DESCRIPTION
## Description

Adds a new (*`off` by default*) info function to display the GPU driver. **This currently only works on Linux.** This works by checking which kernel driver the GPU is using.

I'm not sure if adding support for other OS is nessecary as most OS only have one driver per GPU vendor or the OS is used only on mainframes/servers which have no GPU.

(*This will be merged for Linux users regardless though.*)


Closes #766 