### PR TITLE
Font: Fix KDE font, #821

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1617,7 +1617,12 @@ get_style() {
                     kde_config_file="${kde_config_dir}/kdeglobals"
 
                     kde_theme="$(grep "^${kde}" "$kde_config_file")"
-                    kde_theme="${kde_theme/${kde}*=}"
+                    kde_theme="${kde_theme/*=}"
+                    if [[ "$kde" == "font" ]]; then
+                        kde_font_size="${kde_theme#*,}"
+                        kde_font_size="${kde_font_size/,*}"
+                        kde_theme="${kde_theme/,*} ${kde_theme/*,} ${kde_font_size}"
+                    fi
                     kde_theme="$(uppercase "$kde_theme") [KDE], "
                 else
                     err "Theme: KDE config files not found, skipping."


### PR DESCRIPTION
Fix displayed font when using KDE. See #821

before
`Font: Noto Sans,10,-1,5,50,0,0,0,0,0,Regular [KDE], Noto Sans Regular 10 [GTK2/3]`

after
`Font: Noto Sans Regular 10 [KDE], Noto Sans Regular 10 [GTK2/3]`
