### PR TITLE
tiny fix for WM always being detected as Kwm on macOS

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -706,7 +706,7 @@ get_wm() {
     else
         case "$os" in
             "Mac OS X")
-                ps_line="$(ps -e | grep -o '[S]pectacle\|[A]methyst\|[k]wm\|[c]hunkwm')"
+                ps_line="$(ps -e | grep -o '[S]pectacle\|[A]methyst\|[k]wm\|[c]hun[k]wm')"
 
                 case "$ps_line" in
                     *"kwm"*) wm="Kwm" ;;


### PR DESCRIPTION
the grep command which included `[c]hunkwm` in it's search parameters was triggering the `*"kwm"*)` glob in the switch statement, since the **kwm** substring of [c]hun**kwm** fits the glob pattern, if that makes any sense....

This was the most obvious and simplest fix I could come up with