### PR TITLE
Fix Install Date for macOS

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2256,7 +2256,7 @@ get_install_date() {
 
         *)
             if [[ "$os" == "Mac OS X" ]]; then
-                install_date="$(ls -dlctuT "$install_file" | awk '{printf $9 " " $6 " " $7 " " $8}')"
+                install_date="$(ls -dlctUT "$install_file" | awk '{printf $9 " " $6 " " $7 " " $8}')"
             else
                 install_date="$(ls -dlctT "$install_file" | awk '{printf $9 " " $6 " " $7 " " $8}')"
             fi

--- a/neofetch
+++ b/neofetch
@@ -2254,7 +2254,13 @@ get_install_date() {
             return
         ;;
 
-        *) install_date="$(ls -dlctT "$install_file" | awk '{printf $9 " " $6 " "$7 " " $8}')" ;;
+        *)
+            if [[ "$os" == "Mac OS X" ]]; then
+                install_date="$(ls -dlctuT "$install_file" | awk '{printf $9 " " $6 " " $7 " " $8}')"
+            else
+                install_date="$(ls -dlctT "$install_file" | awk '{printf $9 " " $6 " " $7 " " $8}')"
+            fi
+        ;;
     esac
 
     install_date="${install_date//-/ }"

--- a/neofetch
+++ b/neofetch
@@ -2256,7 +2256,7 @@ get_install_date() {
 
         *)
             if [[ "$os" == "Mac OS X" ]]; then
-                install_date="$(ls -dlctUT "$install_file" | awk '{printf $9 " " $6 " " $7 " " $8}')"
+                install_date="$(ls -dlctUT "$install_file" | awk '{printf $9 " " $6 " "$7 " " $8}')"
             else
                 install_date="$(ls -dlctT "$install_file" | awk '{printf $9 " " $6 " " $7 " " $8}')"
             fi


### PR DESCRIPTION
## Description

The Install Date function used to print a seemingly random date, I think it might have been the time last booted? Or at least it was when `/var/log/install.log` was last modified. I've fixed it so now it's based off of the creation date of that file. I'm not sure if other OSes that error on `ls --version` support the method I used (just adding `-u` to the ls command for macOS only), and its probably file system specific, so I made the change only work on macOS.