### PR TITLE
gpu_driver: Add macOS (Nvidia) support

### DIFF
--- a/config/config.conf
+++ b/config/config.conf
@@ -26,7 +26,7 @@ print_info() {
     info "GPU" gpu
     info "Memory" memory
 
-    # info "GPU Driver" gpu_driver  # Linux only
+    # info "GPU Driver" gpu_driver  # Linux/macOS only
     # info "CPU Usage" cpu_usage
     # info "Disk" disk
     # info "Battery" battery

--- a/neofetch
+++ b/neofetch
@@ -2280,6 +2280,13 @@ get_gpu_driver() {
                           '/Display|3D|VGA/{nr[NR+2]}; NR in nr {printf $2 ", "}')"
             gpu_driver="${gpu_driver%, }"
         ;;
+        "Mac OS X")
+            if [[ "$(kextstat | grep "GeForceWeb")" != "" ]]; then
+                gpu_driver="Nvidia Web Driver"
+            else
+                gpu_driver="macOS Default Graphics Driver"
+            fi
+        ;;
     esac
 }
 


### PR DESCRIPTION
## Description

Adds `gpu_driver` support for macOS, really only affects Mac Pro and Hackintosh systems (although I think some older iMacs and MacBook Pros may have this work too). Only works for Nvidia cards with the Nvidia web drivers installed, otherwise it just falls back to "macOS Default Graphics Driver" (which is what the Nvidia web drivers refer to the included driver as, so I'm referring to the default driver for all GPUs as that)