### PR TITLE
disk: change Haiku's df detection

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2032,7 +2032,7 @@ get_disk() {
     # Get "df" version.
     df_version="$(df --version 2>&1)"
     case "$df_version" in
-        *"blocks"*) # Haiku
+        *"Tracker"*) # Haiku
             err "Your version of df cannot be used due to the non-standard flags"
             return
         ;;


### PR DESCRIPTION
'blocks' keyword is also present in busybox' df.
Busybox' df also has -P and -h flags, so it can be detected as normal df.
'Tracker' keyword seems to be exclusive to Haiku's df.

Tested on Alpine with busybox and on Haiku.