### PR TITLE
fix in mac can not make_thumbnail

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2686,7 +2686,8 @@ get_image_size() {
 make_thumbnail() {
     # Name the thumbnail using variables so we can
     # use it later.
-    image_name="$crop_mode-$crop_offset-$width-$height-${image//'/'/_}"
+    # fix in mac cannot replace '/' with '_', optionally can use ${image//\//_}
+    image_name="$crop_mode-$crop_offset-$width-$height-${image##*/}"
 
     # Handle file extensions.
     case "${image##*.}" in


### PR DESCRIPTION
# fix in mac high Sierra cannot replace '/' with '_', optionally can use ${image//\//_}

## Description

Only fill in the fields below if relevant.


## Features

## Issues
in mac, iterm2 cannot process ${image//'/'//_}, therefore make_thumbnail() will fail and there will be no image displayed.
## TODO