### PR TITLE
OS: detect 32-bit IRIX

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -43,7 +43,7 @@ get_os() {
         "Haiku") os="Haiku" ;;
         "MINIX") os="MINIX" ;;
         "AIX") os="AIX" ;;
-        "IRIX64" | "IRIX") os="IRIX" ;;
+        "IRIX64") os="IRIX" ;;
         "FreeMiNT") os="FreeMiNT" ;;
         *)
             printf "%s\n" "Unknown OS detected: '$kernel_name', aborting..." >&2

--- a/neofetch
+++ b/neofetch
@@ -43,7 +43,7 @@ get_os() {
         "Haiku") os="Haiku" ;;
         "MINIX") os="MINIX" ;;
         "AIX") os="AIX" ;;
-        "IRIX64") os="IRIX" ;;
+        "IRIX"*) os="IRIX" ;;
         "FreeMiNT") os="FreeMiNT" ;;
         *)
             printf "%s\n" "Unknown OS detected: '$kernel_name', aborting..." >&2

--- a/neofetch
+++ b/neofetch
@@ -43,7 +43,7 @@ get_os() {
         "Haiku") os="Haiku" ;;
         "MINIX") os="MINIX" ;;
         "AIX") os="AIX" ;;
-        "IRIX64") os="IRIX" ;;
+        "IRIX64" | "IRIX") os="IRIX" ;;
         "FreeMiNT") os="FreeMiNT" ;;
         *)
             printf "%s\n" "Unknown OS detected: '$kernel_name', aborting..." >&2


### PR DESCRIPTION
## Description

neofetch currently only works on 64-bit installations of IRIX, change so that it matches on the uname output from 32-bit too. Works on my O2.

![neofetch-o2](https://user-images.githubusercontent.com/35123112/34596057-07f2a4b2-f1dd-11e7-922e-3c7336520491.png)

## Features

## Issues

## TODO
