### PR TITLE
Shells: add support for tcsh

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -640,6 +640,10 @@ get_shell() {
                 shell="${shell/version}"
             ;;
 
+            "tcsh")
+                shell+="$("$SHELL" -c 'printf "%s" "$tcsh"')"
+            ;;
+
             *)
                 shell+="$("$SHELL" --version 2>&1)"
                 shell="${shell/ "${shell_name}"}"


### PR DESCRIPTION
## Description

Specific support for detecting tcsh is needed as versions < 6.11.04 do not implement the --version flag. The only way to reliably get tcsh version regardless of release is to check the $tcsh variable

## Features

Also works when tcsh is emulating csh(getting the version of the original BSD csh is trickier though afaik)
