### PR TITLE
distro: fix OpenWrt/LEDE detection

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -122,7 +122,9 @@ get_distro() {
             elif [[ -d "/system/app/" && -d "/system/priv-app" ]]; then
                 distro="Android $(getprop ro.build.version.release)"
 
-            elif [[ -f "/etc/os-release" || -f "/usr/lib/os-release" || -f "/etc/openwrt_release" ]]; then
+            elif [[ -f "/etc/os-release" || \
+                    -f "/usr/lib/os-release" || \
+                    -f "/etc/openwrt_release" ]]; then
                 files=("/etc/os-release" "/usr/lib/os-release" "/etc/openwrt_release")
 
                 # Source the os-release file
@@ -231,7 +233,7 @@ get_distro() {
         "IRIX")
             distro="IRIX ${kernel_version}"
         ;;
-        
+
         "FreeMiNT")
             distro="FreeMiNT"
         ;;
@@ -682,7 +684,7 @@ get_de() {
                     *neod*) de="NeoDesk" ;;
                     *zdesk*) de="zDesk" ;;
                     *mdesk*) de="mDesk" ;;
-                esac  
+                esac
             done
         ;;
 
@@ -805,7 +807,7 @@ get_wm() {
                         *myaes*) wm="MyAES" ;;
                         *naes*) wm="N.AES" ;;
                         geneva) wm="Geneva" ;;
-                    esac  
+                    esac
                 done
             ;;
         esac
@@ -1239,7 +1241,7 @@ get_cpu_usage() {
                     "iPhone OS") cores="${cpu/*\(}"; cores="${cores/\)*}" ;;
                     "AIX") cores="$(lparstat -i | awk -F':' '/Online Virtual CPUs/ {printf $2}')" ;;
                     "IRIX") cores="$(sysconf NPROC_ONLN)" ;;
-                    "FreeMiNT") cores="$(sysctl -n hw.ncpu)" 
+                    "FreeMiNT") cores="$(sysctl -n hw.ncpu)"
                 esac
             fi
 

--- a/neofetch
+++ b/neofetch
@@ -122,8 +122,8 @@ get_distro() {
             elif [[ -d "/system/app/" && -d "/system/priv-app" ]]; then
                 distro="Android $(getprop ro.build.version.release)"
 
-            elif [[ -f "/etc/os-release" || -f "/usr/lib/os-release" ]]; then
-                files=("/etc/os-release" "/usr/lib/os-release")
+            elif [[ -f "/etc/os-release" || -f "/usr/lib/os-release" || -f "/etc/openwrt_release" ]]; then
+                files=("/etc/os-release" "/usr/lib/os-release" "/etc/openwrt_release")
 
                 # Source the os-release file
                 for file in "${files[@]}"; do


### PR DESCRIPTION
I was surprised that OpenWrt and LEDE are detected as generic Linux. Didn't noticed it or something. After this commit it's fine.