### PR TITLE
Fixes for OpenBSD CPU temperature and memory used values

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1086,8 +1086,9 @@ get_cpu() {
                     deg="${deg/C}"
                 ;;
                 "OpenBSD"* | "Bitrig"*)
-                    deg="$(sysctl -n hw.sensors.lm0.temp0)"
-                    deg="${deg/ degC}"
+                    deg_var="$(sysctl hw.sensors | grep -m1 temp0 | cut -d'=' -f1)"
+                    deg="$(sysctl -n $deg_var)"
+                    deg="${deg/0 degC}"
                 ;;
             esac
         ;;

--- a/neofetch
+++ b/neofetch
@@ -1086,7 +1086,8 @@ get_cpu() {
                     deg="${deg/C}"
                 ;;
                 "OpenBSD"* | "Bitrig"*)
-                    deg="$(sysctl hw.sensors | awk -F '=| degC' '/lm0.temp|cpu0.temp/ {print $2; exit}')"
+                    deg="$(sysctl hw.sensors | \
+                           awk -F '=| degC' '/lm0.temp|cpu0.temp/ {print $2; exit}')"
                     deg="${deg/00/0}"
                 ;;
             esac

--- a/neofetch
+++ b/neofetch
@@ -1086,9 +1086,8 @@ get_cpu() {
                     deg="${deg/C}"
                 ;;
                 "OpenBSD"* | "Bitrig"*)
-                    deg_var="$(sysctl hw.sensors | grep -m1 -E 'lm0.temp0|cpu0.temp0' | cut -d'=' -f1)"
-                    deg="$(sysctl -n $deg_var)"
-                    deg="${deg/0 degC}"
+                    deg="$(sysctl hw.sensors | awk -F '=| degC' '/lm0.temp|cpu0.temp/ {print $2; exit}')"
+                    deg="${deg/00/0}"
                 ;;
             esac
         ;;

--- a/neofetch
+++ b/neofetch
@@ -1466,9 +1466,10 @@ get_memory() {
             # Mem used.
             case "$kernel_name" in
                 "OpenBSD"*)
-                    mem_used="$(vmstat | awk 'END{printf $4}')"
-                    mem_used="$((${mem_used/M} / 1024))"
+                    mem_used="$(vmstat | awk 'END{printf $3}')"
+                    mem_used="${mem_used/M}"
                 ;;
+
                 *) mem_used="$((mem_total - mem_free))" ;;
             esac
         ;;

--- a/neofetch
+++ b/neofetch
@@ -3788,7 +3788,7 @@ get_distro_colors() {
             ascii_file="scientific"
         ;;
 
-	"Siduction"*)
+        "Siduction"*)
             set_colors 4 4
             ascii_file="siduction"
         ;;

--- a/neofetch
+++ b/neofetch
@@ -1086,7 +1086,7 @@ get_cpu() {
                     deg="${deg/C}"
                 ;;
                 "OpenBSD"* | "Bitrig"*)
-                    deg_var="$(sysctl hw.sensors | grep -m1 temp0 | cut -d'=' -f1)"
+                    deg_var="$(sysctl hw.sensors | grep -m1 -E 'lm0.temp0|cpu0.temp0' | cut -d'=' -f1)"
                     deg="$(sysctl -n $deg_var)"
                     deg="${deg/0 degC}"
                 ;;


### PR DESCRIPTION
## Description

This fixes the CPU temperature and memory used values in OpenBSD.

For the memory usage, the script was previously looking at the wrong vmstat field, and was dividing by 1024, even though the value was already in MiB.

For the CPU temperature, the sysctl call was only looking for lm0.temp0, which doesn't exist on some machines.  I changed it to look for cpu0.temp0 as well.  I also changed it to remove the second 0 after the decimal, which was previously making the temperature formatting logic produce an incorrect value, as it was only expecting one 0 after the decimal.

I also changed the only line that was using a tab as indentation to the appropriate 4 spaces per indent level format.

Before:

```
./neofetch --cpu_temp C
                                     _    rage311@x240-openbsd
                                    (_)   ----------------------------------- 
              |    .                      OS: OpenBSD 6.2 amd64 
          .   |L  /|   .          _       Host: LENOVO 20AMS0HH00 
      _ . |\ _| \--+._/| .       (_)      Uptime: 1 day, 3 hours, 4 mins 
     / ||\| Y J  )   / |/| ./             Packages: 187 
    J  |)'( |        ` F`.'/        _     Shell: zsh 5.4.2 
  -<|  F         __     .-<        (_)    Resolution: 1920x1080 
    | /       .-'. `.  /-. L___           WM: i3 
    J \      <    \  | | O\|.-'  _        Theme: Adwaita [GTK3] 
  _J \  .-    \/ O | | \  |F    (_)       Icons: Adwaita [GTK3] 
 '-F  -<_.     \   .-'  `-' L__           Terminal: urxvtd 
__J  _   _.     >-'  )._.   |-'           Terminal Font: hack 
 `-|.'   /_.          \_|   F             CPU: Intel i5-4300U (4) @ 2.501GHz 
  /.-   .                _.<              GPU: Mesa DRI Intel(R) Haswell Mobile 
 /'    /.'             .'  `\             Memory: 5MiB / 8056MiB 
  /L  /'   |/      _.-'-\ 
 /'J       ___.---'\|                                             
   |\  .--' V  | `. ` 
   |/`. `-.     `._) 
      / .-.\ 
      \ (  `\ 
       `.\ 

```


After:

```
./neofetch --cpu_temp C
                                     _    rage311@x240-openbsd
                                    (_)   ----------------------------------- 
              |    .                      OS: OpenBSD 6.2 amd64 
          .   |L  /|   .          _       Host: LENOVO 20AMS0HH00 
      _ . |\ _| \--+._/| .       (_)      Uptime: 1 day, 3 hours 
     / ||\| Y J  )   / |/| ./             Packages: 187 
    J  |)'( |        ` F`.'/        _     Shell: zsh 5.4.2 
  -<|  F         __     .-<        (_)    Resolution: 1920x1080 
    | /       .-'. `.  /-. L___           WM: i3 
    J \      <    \  | | O\|.-'  _        Theme: Adwaita [GTK3] 
  _J \  .-    \/ O | | \  |F    (_)       Icons: Adwaita [GTK3] 
 '-F  -<_.     \   .-'  `-' L__           Terminal: urxvtd 
__J  _   _.     >-'  )._.   |-'           Terminal Font: hack 
 `-|.'   /_.          \_|   F             CPU: Intel i5-4300U (4) @ 2.501GHz [43.0°C] 
  /.-   .                _.<              GPU: Mesa DRI Intel(R) Haswell Mobile 
 /'    /.'             .'  `\             Memory: 954MiB / 8056MiB 
  /L  /'   |/      _.-'-\ 
 /'J       ___.---'\|                                             
   |\  .--' V  | `. ` 
   |/`. `-.     `._) 
      / .-.\ 
      \ (  `\ 
       `.\ 
```
