### PR TITLE
macOS fixes & improvements

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3255,7 +3255,11 @@ strip_sequences() {
 }
 
 uppercase() {
-    ((bash_version >= 4)) && printf "%s" "${1^}"
+    if ((bash_version >= 4)); then
+        printf "%s" "${1^}"
+    else
+        echo $1
+    fi
 }
 
 # COLORS

--- a/neofetch
+++ b/neofetch
@@ -1522,7 +1522,7 @@ get_memory() {
 }
 
 get_song() {
-    player="$(ps -e | grep -m 1 -o -F \
+    player="$(ps -e | grep -m 1 -o \
                            -e "Google Play" \
                            -e "Spotify" \
                            -e "amarok" \
@@ -1537,7 +1537,7 @@ get_song() {
                            -e "exaile" \
                            -e "gnome-music" \
                            -e "guayadeque" \
-                           -e "iTunes.app" \
+                           -e "iTunes$" \
                            -e "juk" \
                            -e "lollypop" \
                            -e "mocp" \
@@ -1604,9 +1604,11 @@ get_song() {
 
                 "Mac OS X")
                     song="$(osascript <<END
-tell application "Spotify"
-    artist of current track as string & " - " & name of current track as string
-end tell
+if application "Spotify" is running then
+    tell application "Spotify"
+        artist of current track as string & " - " & name of current track as string
+    end tell
+end if
 END
 )"
                 ;;
@@ -1615,9 +1617,11 @@ END
 
         "itunes"*)
             song="$(osascript <<END
-tell application "iTunes"
-    artist of current track as string & " - " & name of current track as string
-end tell
+if application "iTunes" is running then
+    tell application "iTunes"
+        artist of current track as string & " - " & name of current track as string
+    end tell
+end if
 END
 )"
         ;;

--- a/neofetch
+++ b/neofetch
@@ -930,9 +930,7 @@ get_wm_theme() {
             wm_theme="$(PlistBuddy -c "Print AppleInterfaceStyle" "$global_preferences")"
             wm_theme_color="$(PlistBuddy -c "Print AppleAquaColorVariant" "$global_preferences")"
 
-            if [[ -z "$wm_theme" ]]; then
-                wm_theme="Light"
-            fi
+            [[ -z "$wm_theme" ]] && wm_theme="Light"
 
             if [[ -z "$wm_theme_color" ]] || ((wm_theme_color == 1)); then
                 wm_theme_color="Blue"

--- a/neofetch
+++ b/neofetch
@@ -1603,13 +1603,23 @@ get_song() {
                 "Linux") get_song_dbus "spotify" ;;
 
                 "Mac OS X")
-                    song="$(osascript -e 'tell application "Spotify" to artist of current track as string & " - " & name of current track as string')"
+                    song="$(osascript <<END
+tell application "Spotify"
+    artist of current track as string & " - " & name of current track as string
+end tell
+END
+)"
                 ;;
             esac
         ;;
 
         "itunes"*)
-            song="$(osascript -e 'tell application "iTunes" to artist of current track as string & " - " & name of current track as string')"
+            song="$(osascript <<END
+tell application "iTunes"
+    artist of current track as string & " - " & name of current track as string
+end tell
+END
+)"
         ;;
 
         "banshee"*)
@@ -1965,7 +1975,10 @@ get_term_font() {
         ;;
 
         "Apple_Terminal")
-            term_font="$(osascript -e 'tell application "Terminal" to font name of window frontmost')"
+            term_font="$(osascript <<END
+tell application "Terminal" to font name of window frontmost
+END
+)"
         ;;
 
         "iTerm2")
@@ -1976,7 +1989,10 @@ get_term_font() {
             # See: https://groups.google.com/forum/#!topic/iterm2-discuss/0tO3xZ4Zlwg
             local current_profile_name profiles_count profile_name diff_font none_ascii
 
-            current_profile_name="$(osascript -e 'tell application "iTerm2" to profile name of current session of current window')"
+            current_profile_name="$(osascript <<END
+tell application "iTerm2" to profile name of current session of current window
+END
+)"
 
             # Warning: Dynamic profiles are not taken into account here!
             # https://www.iterm2.com/documentation-dynamic-profiles.html
@@ -2620,7 +2636,10 @@ get_image_source() {
 get_wallpaper() {
     case "$os" in
         "Mac OS X")
-            image="$(osascript -e 'tell application "System Events" to picture of current desktop')"
+            image="$(osascript <<END
+tell application "System Events" to picture of current desktop
+END
+)"
         ;;
 
         "Windows")

--- a/neofetch
+++ b/neofetch
@@ -3265,7 +3265,7 @@ uppercase() {
     if ((bash_version >= 4)); then
         printf "%s" "${1^}"
     else
-        echo $1
+        echo "$1"
     fi
 }
 

--- a/neofetch
+++ b/neofetch
@@ -1611,11 +1611,12 @@ get_song() {
 
                 "Mac OS X")
                     song="$(osascript <<END
-if application "Spotify" is running then
-    tell application "Spotify"
-        artist of current track as string & " - " & name of current track as string
-    end tell
-end if
+                            if application "Spotify" is running then
+                                tell application "Spotify"
+                                    artist of current track as string & \
+                                    " - " & name of current track as string
+                                end tell
+                            end if
 END
 )"
                 ;;
@@ -1624,11 +1625,12 @@ END
 
         "itunes"*)
             song="$(osascript <<END
-if application "iTunes" is running then
-    tell application "iTunes"
-        artist of current track as string & " - " & name of current track as string
-    end tell
-end if
+                    if application "iTunes" is running then
+                        tell application "iTunes"
+                            artist of current track as string & \
+                            " - " & name of current track as string
+                        end tell
+                    end if
 END
 )"
         ;;
@@ -1987,7 +1989,7 @@ get_term_font() {
 
         "Apple_Terminal")
             term_font="$(osascript <<END
-tell application "Terminal" to font name of window frontmost
+                         tell application "Terminal" to font name of window frontmost
 END
 )"
         ;;
@@ -2001,7 +2003,8 @@ END
             local current_profile_name profiles_count profile_name diff_font none_ascii
 
             current_profile_name="$(osascript <<END
-tell application "iTerm2" to profile name of current session of current window
+                                    tell application "iTerm2" to profile name \
+                                    of current session of current window
 END
 )"
 
@@ -2648,7 +2651,7 @@ get_wallpaper() {
     case "$os" in
         "Mac OS X")
             image="$(osascript <<END
-tell application "System Events" to picture of current desktop
+                     tell application "System Events" to picture of current desktop
 END
 )"
         ;;

--- a/neofetch
+++ b/neofetch
@@ -926,14 +926,21 @@ get_wm_theme() {
         ;;
 
         "Quartz Compositor")
-            wm_theme="$(PlistBuddy -c "Print AppleAquaColorVariant" \
-                        "${HOME}/Library/Preferences/.GlobalPreferences.plist")"
+            global_preferences="${HOME}/Library/Preferences/.GlobalPreferences.plist"
+            wm_theme="$(PlistBuddy -c "Print AppleInterfaceStyle" "$global_preferences")"
+            wm_theme_color="$(PlistBuddy -c "Print AppleAquaColorVariant" "$global_preferences")"
 
-            if [[ -z "$wm_theme" ]] || ((wm_theme == 1)); then
-                wm_theme="Blue"
-            else
-                wm_theme="Graphite"
+            if [[ -z "$wm_theme" ]]; then
+                wm_theme="Light"
             fi
+
+            if [[ -z "$wm_theme_color" ]] || ((wm_theme_color == 1)); then
+                wm_theme_color="Blue"
+            else
+                wm_theme_color="Graphite"
+            fi
+
+            wm_theme="$wm_theme_color ($wm_theme)"
         ;;
 
         *"Explorer")

--- a/neofetch
+++ b/neofetch
@@ -3265,7 +3265,7 @@ uppercase() {
     if ((bash_version >= 4)); then
         printf "%s" "${1^}"
     else
-        echo "$1"
+        printf "%s" "$1"
     fi
 }
 


### PR DESCRIPTION
## Description

Fixes #902 as well as makes a few fixes/tweaks for macOS; tested on 10.12.6

## Features

* Feature detection on macOS that relies on AppleScript snippets works again (#902)
* Music player detection on macOS is now more reliable at detecting iTunes vs. Spotify — no guarantees made if both are running (looks like it prefers iTunes on my machine)
* Now detects Light vs. Dark theme in addition to Blue vs. Graphite, outputting `WM Theme: Blue (Light)` (for example)
* neofetch's `uppercase()` function no longer prevents feature detection under `bash` < v4

## Issues

* Music player detection is still not perfect — ideally it would use fancier regex to ignore the iTunes Helper and Spotify daemons, but then the `grep` would match itself, so that would have to be handled as a failure to match any player.  This shouldn't be too much of a problem, because even if a user doesn't have Spotify installed or iTunes running, iTunes Helper will be running, so `grep` will match something.  The app-is-running checks in the AppleScript segments then keep neofetch from opening iTunes/Spotify simply to check if they're playing music.

## TODO

- [ ] Test if this works on non-macOS systems