### PR TITLE
OS: Add support for Hyperbola GNU/Linux-libre

### DIFF
--- a/ascii/distro/hyperbola
+++ b/ascii/distro/hyperbola
@@ -1,0 +1,16 @@
+${c1}                     WW
+                     KX              W
+                    WO0W          NX0O
+                    NOO0NW  WNXK0OOKW
+                    W0OOOOOOOOOOOOKN
+                     N0OOOOOOO0KXW
+                       WNXXXNW
+                 NXK00000KN
+             WNK0OOOOOOOOOO0W
+           NK0OOOOOOOOOOOOOO0W
+         X0OOOOOOO00KK00OOOOOK
+       X0OOOO0KNWW      WX0OO0W
+     X0OO0XNW              KOOW
+   N00KNW                   KOW
+ NKXN                       W0W
+WW                           W

--- a/neofetch
+++ b/neofetch
@@ -3592,6 +3592,11 @@ get_distro_colors() {
             ascii_file="haiku"
         ;;
 
+        "Hyperbola"*)
+            set_colors 8
+            ascii_file="hyperbola"
+        ;;
+
         "Kali"*)
             set_colors 4 8
             ascii_file="kali"


### PR DESCRIPTION
https://www.hyperbola.info/

![hyperbola](https://user-images.githubusercontent.com/20053197/36433040-e6b6c1c2-165b-11e8-91e5-0803aaf11f01.png)
