### PR TITLE
Added font support for kitty terminal

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2071,6 +2071,22 @@ END
             term_font="$(trim_quotes "$term_font")"
         ;;
 
+        "kitty"*)
+            if [[ -f "${KITTY_CONFIG_DIRECTORY}/kitty/kitty.conf" ]]; then
+                kitty_file="${KITTY_CONFIG_DIRECTORY}/kitty/kitty.conf"
+            elif [[ -f "${XDG_CONFIG_HOME}/kitty/kitty.conf" ]]; then
+                kitty_file="${XDG_CONFIG_HOME}/kitty/kitty.conf"
+            elif [[ -f "${HOME}/.config/kitty/kitty.conf" ]]; then
+                kitty_file="${HOME}/.config/kitty/kitty.conf"
+            elif [[ -f "${HOME}/Library/Preferences/kitty/kitty.conf" ]]; then
+                kitty_file="${HOME}/Library/Preferences/kitty/kitty.conf"
+            fi
+
+            term_font="$(awk '/font_family/ { $1 = ""; gsub(/^[[:space:]]/, ""); font = $0 } \
+                         /font_size/ { size = $2 } END { print font " " size}' \
+                         "${kitty_file}")"
+        ;;
+
         "konsole"*)
             # Get Process ID of current konsole window / tab
             child="$(get_ppid "$$")"


### PR DESCRIPTION
## Description

Added support for pulling font details when using kitty terminal on macOS, and perhaps *nix.  (Have not testet the latter.)

Please review.  Were a bit unsure how to format the line breaks.

<img width="682" alt="screen shot 2018-02-26 at 14 58 51" src="https://user-images.githubusercontent.com/33870508/36674179-9fd10156-1b05-11e8-9ed2-dd9a559d8650.png">


## Features
* Show font details when using the kitty terminal.