### PR TITLE
fix pacman name conflict bug

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -484,16 +484,9 @@ get_uptime() {
 }
 
 get_packages() {
-    # Remove /usr/games from $PATH.
-    # This solves issues with neofetch opening the "pacman" game.
-    local PATH=":${PATH}:"
-    local PATH="${PATH/':/usr/games:'/:}"
-    local PATH="${PATH%:}"
-    local PATH="${PATH#:}"
-
     case "$os" in
         "Linux" | "BSD" | "iPhone OS" | "Solaris")
-            type -p pacman >/dev/null && \
+            type -p paclog-pkglist >/dev/null && \
                 packages="$(pacman -Qq --color never | wc -l)"
 
             type -p dpkg >/dev/null && \


### PR DESCRIPTION
Description: Add a os-release check to make sure the distro really is Arch Linux when `pacman` is in the $PATH

------

Reason: Before this same bug was solved by removing /usr/games from the $PATH. However this did not work for 2 reasons:

1. The pacman game could be somewhere else, (OpenBSD for example has /games, /usr/games, and /usr/local/games
2. It could be anything! Such as this color script in my ~/bin/ascii folder:

![Image](https://i.imgur.com/lWjqoso.png)