### PR TITLE
Fix kitty font_size regex

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2082,7 +2082,7 @@ END
             fi
 
             term_font="$(awk '/font_family/ { $1 = ""; gsub(/^[[:space:]]/, ""); font = $0 } \
-                         /font_size/ { size = $2 } END { print font " " size}' \
+                         /\s?font_size\s/ { size = $2 } END { print font " " size}' \
                          "${kitty_file}")"
         ;;
 


### PR DESCRIPTION
## Description

This fixes a small bug in the regex used for retrieving the font size used in the kitty terminal.

![](https://i.imgur.com/lfLnBSL.png)

The regex used is too greedy so matches the `map ctrl+shift+backspace restore_font_size` found in my config.

The proposed fix should match any preceding whitespace (before `font_size`) and require at least one whitespace character after `font_size` (so that we don't match too much).