### PR TITLE
Install on OpenBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,21 @@
-PREFIX = /usr
+PREFIX = /usr/local
+
 
 all:
 	@echo Run \'make install\' to install Neofetch
 
 install:
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
-	mkdir -p $(DESTDIR)$(PREFIX)/share/man/man1
+	mkdir -p $(DESTDIR)$(PREFIX)/man/man1
 	mkdir -p $(DESTDIR)/etc/neofetch
 	mkdir -p $(DESTDIR)$(PREFIX)/share/neofetch/ascii/distro
 	cp -p neofetch $(DESTDIR)$(PREFIX)/bin/neofetch
-	cp -p neofetch.1 $(DESTDIR)$(PREFIX)/share/man/man1/neofetch.1
+	cp -p neofetch.1 $(DESTDIR)$(PREFIX)/man/man1/neofetch.1
 	cp -p config/config $(DESTDIR)/etc/neofetch/config
 	cp -p ascii/distro/* $(DESTDIR)$(PREFIX)/share/neofetch/ascii/distro
 
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/neofetch
-	rm -f $(DESTDIR)$(PREFIX)/share/man/man1/neofetch.1
+	rm -f $(DESTDIR)$(PREFIX)/man/man1/neofetch.1
 	rm -f -r $(DESTDIR)$(PREFIX)/share/neofetch
 	rm -f -r $(DESTDIR)/etc/neofetch

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
+UNAME != uname -s
+PREFIX=/usr
+SHARE=/share
+.if "${UNAME}" == "OpenBSD"
 PREFIX = /usr/local
-
+SHARE =  
+.endif
 
 all:
 	@echo Run \'make install\' to install Neofetch
@@ -8,14 +13,14 @@ install:
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
 	mkdir -p $(DESTDIR)$(PREFIX)/man/man1
 	mkdir -p $(DESTDIR)/etc/neofetch
-	mkdir -p $(DESTDIR)$(PREFIX)/share/neofetch/ascii/distro
+	mkdir -p $(DESTDIR)$(PREFIX)$(SHARE)/neofetch/ascii/distro
 	cp -p neofetch $(DESTDIR)$(PREFIX)/bin/neofetch
 	cp -p neofetch.1 $(DESTDIR)$(PREFIX)/man/man1/neofetch.1
 	cp -p config/config $(DESTDIR)/etc/neofetch/config
-	cp -p ascii/distro/* $(DESTDIR)$(PREFIX)/share/neofetch/ascii/distro
+	cp -p ascii/distro/* $(DESTDIR)$(PREFIX)$(SHARE)/neofetch/ascii/distro
 
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/neofetch
 	rm -f $(DESTDIR)$(PREFIX)/man/man1/neofetch.1
-	rm -f -r $(DESTDIR)$(PREFIX)/share/neofetch
+	rm -f -r $(DESTDIR)$(PREFIX)$(SHARE)/neofetch
 	rm -f -r $(DESTDIR)/etc/neofetch

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 UNAME != uname -s
 PREFIX=/usr
 SHARE=/share
-.if "${UNAME}" == "OpenBSD"
+ifeq "${UNAME}" "OpenBSD"
 PREFIX = /usr/local
 SHARE =  
-.endif
+endif
 
 all:
 	@echo Run \'make install\' to install Neofetch


### PR DESCRIPTION
## Description
The default file locations in the Makefile aren't proper for OpenBSD's file structure, and it adds unnecessary directories and "cruft" to the system, and makes the user add another directory to their PATH. This checks if the OS is OpenBSD, and if it is, puts the files in the proper location. It also (For OpenBSD) adds another dependency, GNU Make. I figured it would be easier to add that dependency than it would be to force it the other way and have all the GNU Make users load BSD Make (for the syntax to check the OS name).

## Features
Base install in OpenBSD.

## Issues
Requires GNU Make

## TODO
