### PR TITLE
Use printf to trim instead of echo

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3263,7 +3263,7 @@ get_bold() {
 }
 
 trim() {
-    printf "%s" "${1//[[:space:]]/ }"
+    printf '%s\n' "$1" | tr -s "[:space:]"
 }
 
 trim_quotes() {

--- a/neofetch
+++ b/neofetch
@@ -3263,20 +3263,7 @@ get_bold() {
 }
 
 trim() {
-    # When a string is passed to "echo" all trailing and leading
-    # whitespace is removed and inside the string multiple spaces are
-    # condensed into single spaces.
-    #
-    # The "set -f/+f" is here so that "echo" doesn't cause any expansion
-    # of special characters.
-    #
-    # The whitespace trim doesn't work with multiline strings so we use
-    # "${1//[[:space:]]/ }" to remove newlines before we trim the whitespace.
-
-    set -f
-    # shellcheck disable=2086
-    builtin echo -E ${1//[[:space:]]/ }
-    set +f
+    printf "%s" "${1//[[:space:]]/ }"
 }
 
 trim_quotes() {


### PR DESCRIPTION
## Description

This PR replaces the last `echo` in `neofetch` with an equivalent `printf`!

## Issues

@dylanaraps it looks like it's mostly equivalent, but there are a few extra spaces lying around (see screenshots below). I wasn't able to fix this issue at a cursory glance (neofetch is huge), do you have any insights?

Current `master`:

![image](https://user-images.githubusercontent.com/14209781/38169291-4c9c9bf0-3534-11e8-8e98-de707148b3ed.png)

`better-trim`:

![image](https://user-images.githubusercontent.com/14209781/38169293-5df7ac64-3534-11e8-810e-6ca4a9106600.png)

