### PR TITLE
Font detection for suckless terminal (st)

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2178,6 +2178,32 @@ END
                          "${XDG_CONFIG_HOME}/sakura/sakura.conf")"
         ;;
 
+        "st")
+            if term_font="$(ps -o command= -p $parent | grep -E '\-f\s?.*?:?')"; then
+                term_font="${term_font/*-f/}"
+                term_font="${term_font/ -*/}"
+            else
+                binary=""
+
+                # On Linux we can get the exact path to the running binary through the procfs
+                # on other systems we just have to guess and assume `st` is invoked from somewhere
+                # in the users $PATH
+                [[ -L /proc/$parent/exe ]] && binary="/proc/$parent/exe"
+                [[ -z "$binary" ]] && binary="$(command -v st)"
+
+                # Grep the output of strings on the `st` binary for anything that looks vaguely
+                # like a font definition. NOTE: There is a slight limitation in this approach.
+                # Technically "Font Name" is a valid font. As it doesn't specify any font options
+                # though it is hard to match it correctly amongst the rest of the noise.
+                [[ -n "$binary" ]] && \
+                    term_font="$(strings "$binary" | \
+                    grep -E '(pixelsize=|size=|antialias=|autohint=)' | head -1)"
+            fi
+
+            term_font="${term_font/xft:}"
+            term_font="${term_font/:*}"
+        ;;
+
         "terminology")
             term_font="$(strings "${XDG_CONFIG_HOME}/terminology/config/standard/base.cfg" |\
                          awk '/^font\.name$/{print a}{a=$0}')"

--- a/neofetch
+++ b/neofetch
@@ -2179,6 +2179,8 @@ END
         ;;
 
         "st")
+            [[ -z "$parent" ]] && parent="$(get_ppid "$PPID")"
+
             term_font="$(ps -o command= -p "$parent" | grep -F -- "-f")"
             if [[ "$term_font" ]]; then
                 term_font="${term_font/*-f/}"

--- a/neofetch
+++ b/neofetch
@@ -2179,7 +2179,7 @@ END
         ;;
 
         "st")
-            if term_font="$(ps -o command= -p $parent | grep -E '\-f\s?.*?:?')"; then
+            if term_font="$(ps -o command= -p "$parent" | grep -E '\-f\s?.*?:?')"; then
                 term_font="${term_font/*-f/}"
                 term_font="${term_font/ -*/}"
             else

--- a/neofetch
+++ b/neofetch
@@ -2179,17 +2179,15 @@ END
         ;;
 
         "st")
-            if term_font="$(ps -o command= -p "$parent" | grep -E '\-f\s?.*?:?')"; then
+            term_font="$(ps -o command= -p "$parent" | grep -F -- "-f")"
+            if [[ "$term_font" ]]; then
                 term_font="${term_font/*-f/}"
                 term_font="${term_font/ -*/}"
             else
-                binary=""
-
                 # On Linux we can get the exact path to the running binary through the procfs
-                # on other systems we just have to guess and assume `st` is invoked from somewhere
-                # in the users $PATH
-                [[ -L /proc/$parent/exe ]] && binary="/proc/$parent/exe"
-                [[ -z "$binary" ]] && binary="$(command -v st)"
+                # (in case `st` is launched from outside of $PATH) on other systems we just
+                # have to guess and assume `st` is invoked from somewhere in the users $PATH
+                [[ -L /proc/$parent/exe ]] && binary="/proc/$parent/exe" || binary="$(type -p st)"
 
                 # Grep the output of strings on the `st` binary for anything that looks vaguely
                 # like a font definition. NOTE: There is a slight limitation in this approach.
@@ -2197,7 +2195,7 @@ END
                 # though it is hard to match it correctly amongst the rest of the noise.
                 [[ -n "$binary" ]] && \
                     term_font="$(strings "$binary" | \
-                    grep -E '(pixelsize=|size=|antialias=|autohint=)' | head -1)"
+                    grep -F -m 1 -e "pixelsize=" -e "size=" -e "antialias=" -e "autohint=")"
             fi
 
             term_font="${term_font/xft:}"


### PR DESCRIPTION
## Description

This adds font detection for the suckless terminal (st).

Command line arguments are checked first, if a font is not specified via command line arguments we run `strings` on the `st` binary and `grep` for something that looks like a font. In my testing this has worked well except in the following edge case:

**config.h**:
```h
static char font[] = "Liberation Mono";
```

The above is technically a valid font. As it doesn't contain anything that indicates it's a font declaration e.g "pixelsize=", "size=", etc it will not be matched.

Other than this one edge-case, in my testing the font has matched correctly 100% of the time. However, it's possible that some patches a user might have applied to `st` (or any modifications that a user has made) might cause `neofetch` to match the wrong thing. For that reason alone I understand if you want to close this pull-request.

For fonts specified as command-line arguments though e.g `st -f "Liberation Mono:pixelsize=12:antialias=true:autohint=true"` **should** be matched correctly.