### PR TITLE
general: Remove unsafe splitting.

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1510,7 +1510,8 @@ get_memory() {
         ;;
 
         "AIX")
-            mem_stat=($(svmon -G -O unit=MB))
+            IFS=" " read -ra mem_stat <<< "$(svmon -G -O unit=MB)"
+
             mem_total="${mem_stat[11]/.*}"
             mem_free="${mem_stat[16]/.*}"
             mem_used="$((mem_total - mem_free))"
@@ -1518,7 +1519,9 @@ get_memory() {
         ;;
 
         "IRIX")
-            mem_stat=($(pmem | head -1))
+            IFS=$'\n' read -d "" -ra mem_cmd <<< "$(pmem)"
+            IFS=" " read -ra mem_stat <<< "${mem_cmd[0]}"
+
             mem_total="$((mem_stat[3] / 1024))"
             mem_free="$((mem_stat[5] / 1024))"
             mem_used="$((mem_total - mem_free))"

--- a/neofetch
+++ b/neofetch
@@ -1434,18 +1434,10 @@ get_memory() {
         "Linux" | "Windows")
             # MemUsed = Memtotal + Shmem - MemFree - Buffers - Cached - SReclaimable
             # Source: https://github.com/KittyKatt/screenFetch/issues/386#issuecomment-249312716
-            while IFS=":" read -r a b; do
-                case "$a" in
-                    "MemTotal") mem_used="$((mem_used+=${b/kB}))"; mem_total="${b/kB}" ;;
-                    "Shmem") mem_used="$((mem_used+=${b/kB}))"  ;;
-                    "MemFree" | "Buffers" | "Cached" | "SReclaimable")
-                        mem_used="$((mem_used-=${b/kB}))"
-                    ;;
-                esac
-            done < /proc/meminfo
+            IFS=$'\n'"|:|kB" read -d "" -ra mem < /proc/meminfo
 
-            mem_used="$((mem_used / 1024))"
-            mem_total="$((mem_total / 1024))"
+            mem_used="$(((mem[1] + mem[64] - mem[4] - mem[11] - mem[14]- mem[70]) / 1024))"
+            mem_total="$((mem[1] / 1024))"
         ;;
 
         "Mac OS X" | "iPhone OS")

--- a/neofetch
+++ b/neofetch
@@ -1432,12 +1432,20 @@ get_gpu() {
 get_memory() {
     case "$os" in
         "Linux" | "Windows")
-            IFS=$'\n'":kB" read -d "" -ra mem < /proc/meminfo
-
             # MemUsed = Memtotal + Shmem - MemFree - Buffers - Cached - SReclaimable
             # Source: https://github.com/KittyKatt/screenFetch/issues/386#issuecomment-249312716
-            mem_used="$(((mem[1] + mem[64] - mem[4] - mem[11] - mem[14]- mem[70]) / 1024))"
-            mem_total="$((mem[1] / 1024))"
+            while IFS=":" read -r a b; do
+                case "$a" in
+                    "MemTotal") mem_used="$((mem_used+=${b/kB}))"; mem_total="${b/kB}" ;;
+                    "Shmem") mem_used="$((mem_used+=${b/kB}))"  ;;
+                    "MemFree" | "Buffers" | "Cached" | "SReclaimable")
+                        mem_used="$((mem_used-=${b/kB}))"
+                    ;;
+                esac
+            done < /proc/meminfo
+
+            mem_used="$((mem_used / 1024))"
+            mem_total="$((mem_total / 1024))"
         ;;
 
         "Mac OS X" | "iPhone OS")

--- a/neofetch
+++ b/neofetch
@@ -1510,7 +1510,7 @@ get_memory() {
         ;;
 
         "AIX")
-            IFS=" " read -ra mem_stat <<< "$(svmon -G -O unit=MB)"
+            IFS=$'\n'"| " read -d "" -ra mem_stat <<< "$(svmon -G -O unit=MB)"
 
             mem_total="${mem_stat[11]/.*}"
             mem_free="${mem_stat[16]/.*}"

--- a/neofetch
+++ b/neofetch
@@ -1432,10 +1432,10 @@ get_gpu() {
 get_memory() {
     case "$os" in
         "Linux" | "Windows")
+            IFS=$'\n'":kB" read -d "" -ra mem < /proc/meminfo
+
             # MemUsed = Memtotal + Shmem - MemFree - Buffers - Cached - SReclaimable
             # Source: https://github.com/KittyKatt/screenFetch/issues/386#issuecomment-249312716
-            IFS=$'\n'"|:|kB" read -d "" -ra mem < /proc/meminfo
-
             mem_used="$(((mem[1] + mem[64] - mem[4] - mem[11] - mem[14]- mem[70]) / 1024))"
             mem_total="$((mem[1] / 1024))"
         ;;


### PR DESCRIPTION
This PR removes unsafe word splitting from two commands related to AIX and IRIX.

I can't test these changes so this won't be merged until someone can let me know that they don't break neofetch.