### PR TITLE
cpu_temp: Add support for Zen processors

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1022,7 +1022,7 @@ get_cpu() {
 
             # Select the right temperature file.
             for temp_dir in /sys/class/hwmon/*; do
-                [[ "$(< "${temp_dir}/name")" =~ (coretemp|fam15h_power) ]] && \
+                [[ "$(< "${temp_dir}/name")" =~ (coretemp|fam15h_power|k10temp) ]] && \
                     { temp_dir="${temp_dir}/temp1_input"; break; }
             done
 


### PR DESCRIPTION
Hi there,

Just a little PR to add support for temperature monitoring on AMD Zen processors using the k10temp module.

Please let me know if this is the correct way to go about implementing it. This was tested on a Ryzen 5 1600 on Arch Linux.

## Description
This adds support for Zen based processors(AMD family 17h) like the Ryzen series using the k10temp module.
This requires either having a patched kernel with the hwmon updates see - lkml.org/lkml/2017/9/6/684
Or kernel 4.15+ where the patch was merged.

## Features
Adds temperature monitoring support for AMD Zen based processors


