### PR TITLE
gpu: Fix ATI/AMD branding issue.

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1313,8 +1313,10 @@ get_gpu() {
 
                 case "$gpu" in
                     *"advanced"*)
-                        brand="${gpu/*AMD*/AMD}"
+                        brand="${gpu/*AMD*ATI*/AMD ATI}"
+                        brand="${brand:-${gpu/*AMD*/AMD}}"
                         brand="${brand:-${gpu/*ATI*/ATi}}"
+
                         gpu="${gpu/'[AMD/ATI]' }"
                         gpu="${gpu/'[AMD]' }"
                         gpu="${gpu/OEM }"

--- a/neofetch
+++ b/neofetch
@@ -1313,6 +1313,8 @@ get_gpu() {
 
                 case "$gpu" in
                     *"advanced"*)
+                        brand="${gpu/*AMD*/AMD}"
+                        brand="${brand:-${gpu/*ATI*/ATi}}"
                         gpu="${gpu/'[AMD/ATI]' }"
                         gpu="${gpu/'[AMD]' }"
                         gpu="${gpu/OEM }"
@@ -1320,7 +1322,7 @@ get_gpu() {
                         gpu="${gpu/ \/ *}"
                         gpu="${gpu/*\[}"
                         gpu="${gpu/\]*}"
-                        gpu="AMD $gpu"
+                        gpu="$brand $gpu"
                     ;;
 
                     *"nvidia"*)


### PR DESCRIPTION
Figure out the GPU brand and append it to the start of the GPU string.

This needs testing as it my duplicate the branding.

Closes #959