### PR TITLE
de: fix Unity in 18.04

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -697,6 +697,7 @@ get_de() {
             if [[ "$XDG_CURRENT_DESKTOP" ]]; then
                 de="${XDG_CURRENT_DESKTOP/'X-'}"
                 de="${de/Budgie:GNOME/Budgie}"
+                de="${de/:Unity7:ubuntu}"
 
             elif [[ "$DESKTOP_SESSION" ]]; then
                 de="${DESKTOP_SESSION##*/}"


### PR DESCRIPTION
XDG_CURRENT_DESKTOP in Ubuntu 18.04 with Unity is containing some extra info.

Before patch:
![zrzut ekranu z 2018-04-27 11-56-56](https://user-images.githubusercontent.com/9713907/39357224-7c560596-4a12-11e8-86c5-8158822e96ff.png)

After:
![zrzut ekranu z 2018-04-27 11-57-42](https://user-images.githubusercontent.com/9713907/39357223-7c132762-4a12-11e8-9c03-e1f338f547ae.png)
