### PR TITLE
Add boot_method that can display BIOS or UEFI

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1203,9 +1203,6 @@ get_boot_method() {
         "Linux")
             [ -d /sys/firmware/efi ] && boot_method="UEFI" || boot_method="BIOS"
         ;;
-        *)
-            boot_method="UNKNOWN"
-        ;;
     esac
 }
 

--- a/neofetch
+++ b/neofetch
@@ -77,6 +77,7 @@ print_info() {
 
     # info "GPU Driver" gpu_driver  # Linux/macOS only
     # info "CPU Usage" cpu_usage
+    # info "Boot Method" boot_method
     # info "Disk" disk
     # info "Battery" battery
     # info "Font" font
@@ -1195,6 +1196,17 @@ get_kernel() {
             *) unset kernel ;;
         esac
     fi
+}
+
+get_boot_method() {
+    case "$os" in
+        "Linux")
+            [ -d /sys/firmware/efi ] && boot_method="UEFI" || boot_method="BIOS"
+        ;;
+        *)
+            boot_method="UNKNOWN"
+        ;;
+    esac
 }
 
 get_uptime() {

--- a/neofetch
+++ b/neofetch
@@ -1201,7 +1201,7 @@ get_kernel() {
 get_boot_method() {
     case "$os" in
         "Linux")
-            [ -d /sys/firmware/efi ] && boot_method="UEFI" || boot_method="BIOS"
+            [[ -d "/sys/firmware/efi" ]] && boot_method="UEFI" || boot_method="BIOS"
         ;;
     esac
 }


### PR DESCRIPTION
## Description

This PR adds a boot_method option that displays BIOS, UEFI or UNKNOWN

## Features

## Issues

## TODO
I'd like to add support for more OSs though am not sure how to detect boot method on them. Modern Mac OS X is probably UEFI, not sure what Windows does these days. Can do some research.