### PR TITLE
tweak kitty font regex

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2906,7 +2906,7 @@ END
             fi
 
             term_font="$(awk '/font_family/ { $1 = ""; gsub(/^[[:space:]]/, ""); font = $0 } \
-                         /\s?font_size\s/ { size = $2 } END { print font " " size}' \
+                         /\^[\S\n_#]+?font_size\s+?\d+?/ { size = $2 } END { print font " " size}' \
                          "${kitty_file}")"
         ;;
 


### PR DESCRIPTION
## Description
Initial take on a fix for the regex bug.  The old regex included the new line above, making it hard to extract the right portions I believe.  This worked on macOS.  Not sure with `gawk`.

Old regex resulting in adding the line above.  To me giving a blank output:
<img width="525" alt="screen shot 2018-05-06 at 14 04 15" src="https://user-images.githubusercontent.com/33870508/39673102-62c8ddb2-5136-11e8-857a-6528d5e3e5fa.png">

Please take a look.  I hope I am on the right right, spent almost 5-7 hours trying to learn regex 👍 

## Issues
Trying to fix regex that broke kitty's font size reporting. PR https://github.com/dylanaraps/neofetch/pull/935

## kitty.conf
```ini
# ~/.config/kitty/kitty.conf - Kitty Terminal Config
# vim: set expandtab filetype=conf softtabstop=2 shiftwidth=2 :


# You can get a list of full family names available on your computer by running
# kitty list-fonts
font_family          Hack Nerd Font Mono
font_size            13

# Number of lines of history to keep in memory for scrolling back
scrollback_lines     20000

# The window padding (in pts) (blank area between the text and the window border)
window_padding_width 5


# colorscheme {{{
# srcsry colorscheme
# https://github.com/roosta/vim-srcery/

foreground           #fce8c3
background           #1c1b19
cursor               #fce8c3

# black
color0               #1C1B19
color8               #2D2C29

# red
color1               #EF2F27
color9               #F75341

# green
color2               #519F50
color10              #98BC37

# yellow
color3               #FBB829
color11              #FED06E

# blue
color4               #2C78BF
color12              #68A8E4

# magenta
color5               #E02C6D
color13              #FF5C8F

# cyan
color6               #0AAEB3
color14              #53FDE9

# white
color7               #918175
color15              #FCE8C3

# }}} colorscheme end


# macoS specific settings {{{

# Hide the kitty window's title bar on macOS.
macos_hide_titlebar  yes

# Can use the macOS unicode input technique.
macos_option_as_alt  yes

# }}} macOS specific settings end
```