### PR TITLE
kitty: fix regression in regex

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2906,8 +2906,8 @@ END
 
             fi
 
-            term_font="$(awk '/font_family/ { $1 = ""; gsub(/^[[:space:]]/, ""); font = $0 } \
-                         /\^[\S\n_#]+?font_size\s+?\d+?/ { size = $2 } END { print font " " size}' \
+            term_font="$(awk '/^[\S\n_#]+?font_family\s+?/ { $1 = ""; gsub(/^[[:space:]]/, ""); font = $0 } \
+                         /^[\S\n_#]+?font_size\s+?\d+?/ { size = $2 } END { print font " " size}' \
                          "${kitty_file}")"
         ;;
 


### PR DESCRIPTION
## Issues
Fixing my own regression in https://github.com/dylanaraps/neofetch/pull/973.

I seem to have escaped the carrot for the begging-of-the-line, and I also added the same check to `font_family`.  I had lines commented out and they were picked up by the regex.

Sorry for the regression.