### PR TITLE
song: fix audacious album

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2417,7 +2417,7 @@ get_song() {
 
         "audacious"*)
             song="$(audtool current-song)"
-            [[ -z "$song" ]] && get_song_dbus "audacious"
+            [[ -z "$song" || "$song_shorthand" == "on" ]] && get_song_dbus "audacious"
         ;;
 
         "cmus"*)


### PR DESCRIPTION
fallback to get_song_dbus() when song_shorthand is on
audtool won't work due to the `-` separator in it's output
