### PR TITLE
song: fix deepin-music

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2423,7 +2423,7 @@ get_song() {
         "bluemindo"*)    get_song_dbus "Bluemindo" ;;
         "guayadeque"*)   get_song_dbus "guayadeque" ;;
         "yarock"*)       get_song_dbus "yarock" ;;
-        "deepin-music"*) get_song_dbus "deepinmusic" ;;
+        "deepin-music"*) get_song_dbus "DeepinMusic" ;;
         "tomahawk"*)     get_song_dbus "tomahawk" ;;
         "elisa"*)        get_song_dbus "elisa" ;;
         "sayonara"*)     get_song_dbus "sayonara" ;;


### PR DESCRIPTION
## Description

The mpris player name has changed.

```
$ qdbus | grep mpris
 org.mpris.MediaPlayer2.DeepinMusic
```

```
$ deepin-music --version
deepin-music 3.1
```
