### PR TITLE
song: simplify get_song_dbus

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2403,8 +2403,8 @@ get_song() {
             dbus-send --print-reply --dest=org.mpris.MediaPlayer2."${1}" /org/mpris/MediaPlayer2 \
             org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' \
             string:'Metadata' |\
-            awk -F 'string "' '/string|array/ {printf "%s",$2; next}{print ""}' |\
-            awk -F '"' '/artist/ {a=$2} /album"/ {b=$2} /title/ {t=$2} END{print a " ‡ " b " ‡ " t}'
+            awk -F '"' 'BEGIN {RS=" entry"}; /xesam:artist/ {a = $4} /xesam:album/ {b = $4}
+                        /xesam:title/ {t = $4} END {print a " ‡ " b " ‡ " t}'
         )"
     }
 


### PR DESCRIPTION
## Description

Get rid of a `awk` call in `get_song_dbus()`.

## TODO

Test with all players that use `get_song_dbus`.
- [x] gnome-music
- [x] lollypop
- [x] clementine
- [x] juk
- [x] bluemindo
- [x] guayadeque
- [x] yarock
- [x] deepin-music
- [x] tomahawk
- [x] elisa
- [x] sayonara
- [x] audacious
- [x] spotify
