### PR TITLE
RFC: kitty: This got to be the last fix...

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2910,10 +2910,11 @@ END
 
             fi
 
-            term_font="$(awk '/^[\S\n_#]+?font_family\s+?/
-                              { $1 = ""; gsub(/^[[:space:]]/, ""); font = $0 }
-                              /^[\S\n_#]+?font_size\s+?\d+?/
-                              { size = $2 } END { print font " " size}' \
+            term_font="$(awk '/^([[:space:]]*|[^#_])font_family[[:space:]]+/ \
+                              { $1 = ""; gsub(/^[[:space:]]/, ""); font = $0 } \
+                              /^([[:space:]]*|[^#_])font_size[[:space:]]+/ \
+                              { size = $2 } \
+                              END { print font " " size}' \
                               "${kitty_file}")"
         ;;
 


### PR DESCRIPTION
**_(I am off to bed, but if desired, and I can explain the regex as good as I can in the morning?)_**

## Description

Damn I mess up sometimes..  So this should be the last...  At least this time I learned hopefully from my previous mistakes.

Been at this for the past two hours.  Ended up reading the [GNU Awk manual on regex](https://www.gnu.org/software/gawk/manual/html_node/Regexp.html#Regexp) several times (and other man pages).  Seems that this is the most portable way.  Tested with both `awk` & `gawk` on macOS.

Hopefully this will fix #977 & #981 once and for all.

To make sure this did not happen again, I wrote my own test script:
```shell
#!/bin/sh
# vim: tw=0
# My basic script to make sure things works..... :)

file="$HOME/.config/kitty/kitty.conf"

read -r awk <<"_EOF_"
/^([[:space:]]*|[^#_])font_family[[:space:]]+/ { $1 = ""; gsub(/^[[:space:]]/, ""); font = $0 } /^([[:space:]]*|[^#_])font_size[[:space:]]+/ { size = $2 } END { print font " " size}
_EOF_


printf '\n# regex #\n%s\n\n' "$awk"

# awk test
printf '# %s #\n' 'awk'
awk "$awk" "$file"
sleep 1

printf '\n'

# gawk test
printf '# %s #\n' 'gawk'
gawk "$awk" "$file"
```

Also this is the test file with various variants that have caused havok in the past:
```conf
map ctrl+shift+backspace restore_font_size
# font_family          Nerd Font Mono
font_familyHack Nerd Bont Mono
 font_family Hack Nerd Bont Mono
# font_family Sonn Nerd Bont Mono
    #font_family          Hack Nerd Font Mono
          #font_family          Hack Nerd Font Mono
  #font_size            14.2212
font_size            14
 font_size14
```

## Issues
Fixes my previous faults :'(