### PR TITLE
wm_version: add support for xfwm4

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1605,6 +1605,8 @@ get_wm() {
             wmv="${wmv/©*}"
             wmv="${wmv/(c)*}"
             wmv="${wmv/ : }"
+            wmv="${wmv/This is ${wm,,}/$wm}"
+            wmv="${wmv/(revision*}"
             wm="$wmv"
         fi
 


### PR DESCRIPTION
## Description

Add wm_version support for xfwm4.

This is the output of `xfwm4 --version` on my system.
```
        This is xfwm4 version 4.12.4 (revision 7844952) for Xfce 4.12
        Released under the terms of the GNU General Public License.
        Compiled against GTK+-2.24.31, using GTK+-2.24.32.

        Build configuration and supported features:
        - Startup notification support:                 Yes
        - XSync support:                                Yes
        - Render support:                               Yes
        - Xrandr support:                               Yes
        - Embedded compositor:                          Yes
        - KDE systray proxy (deprecated):               No
```