### PR TITLE
song: Fix matching

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2313,7 +2313,7 @@ get_memory() {
 }
 
 get_song() {
-    player="$(ps -e | grep -m 1 -o \
+    player="$(ps -e | grep -m 1 \
                            -e "Google Play" \
                            -e "Spotify" \
                            -e "amarok" \
@@ -2345,6 +2345,8 @@ get_song() {
                            -e "yarock" \
                            -e "sayonara" \
                            -e "vlc")"
+    player="${player/* }"
+    player="${player##*/}"
 
     [[ "$music_player" && "$music_player" != "auto" ]] && \
         player="$music_player"

--- a/neofetch
+++ b/neofetch
@@ -2313,7 +2313,7 @@ get_memory() {
 }
 
 get_song() {
-    player="$(ps -e | grep -m 1 \
+    player="$(ps -e | grep -m 1 -F \
                            -e "Google Play" \
                            -e "Spotify" \
                            -e "amarok" \
@@ -2328,7 +2328,7 @@ get_song() {
                            -e "exaile" \
                            -e "gnome-music" \
                            -e "guayadeque" \
-                           -e "iTunes$" \
+                           -e "iTunes" \
                            -e "juk" \
                            -e "lollypop" \
                            -e "mocp" \


### PR DESCRIPTION
This fixes cases where `ItunesHelper` is running but `Itunes` is not causing an incorrect match. This needs testing as the output of `ps -e` may differ on different machines.