### PR TITLE
Packages: Add support for Flatpak and Snap

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1261,6 +1261,7 @@ get_packages() {
             has "sorcery"    && tot gaze installed
             has "alps"       && tot alps showinstalled
             has "butch"      && tot butch list
+            has "flatpak"    && tot flatpak list
 
             # Counting files/dirs.
             has "emerge"     && dir /var/db/pkg/*/*/

--- a/neofetch
+++ b/neofetch
@@ -1262,6 +1262,7 @@ get_packages() {
             has "alps"       && tot alps showinstalled
             has "butch"      && tot butch list
             has "flatpak"    && tot flatpak list
+            has "snap"       && tot snap list && ((packages-=1))
 
             # Counting files/dirs.
             has "emerge"     && dir /var/db/pkg/*/*/


### PR DESCRIPTION
## Description

### Features

Self-explanatory.

### Issues

In case of Snap, it needs to be tested and I can't test it on any of my systems since Snap for some reason depends on systemd and none of my machine have systemd installed currently.

I'm not sure that the offset by 1 is needed for Snap since in case of Flatpak, even if they have offset 1, they're still accurate (bash didn't include the first offset line).

![2018-06-03-205342_804x604_scrot](https://user-images.githubusercontent.com/15692230/40887264-a788b3fe-6735-11e8-93c6-c9f12bb9124b.png)

### TODO

Testing for Snap