### PR TITLE
song: use get_song_dbus for amarok

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2370,6 +2370,7 @@ get_song() {
         "vlc"*)           get_song_dbus "vlc" ;;
         "gmusicbrowser"*) get_song_dbus "gmusicbrowser" ;;
         "pragha"*)        get_song_dbus "pragha" ;;
+        "amarok"*)        get_song_dbus "amarok" ;;
 
         "cmus"*)
             song="$(cmus-remote -Q | awk 'BEGIN { ORS=" "};
@@ -2407,12 +2408,6 @@ get_song() {
             song="$(banshee --query-artist --query-album --query-title |\
                     awk -F':' '/^artist/ {a=$2} /^album/ {b=$2} /^title/ {t=$2}
                                END {print a " \n " b " \n "t}')"
-        ;;
-
-        "amarok"*)
-            song="$(qdbus org.kde.amarok /Player GetMetadata |\
-                    awk -F':' '/^artist:/ {a=$2} /^album:/ {b=$2} /^title:/ {t=$2}
-                               END {print a " \n " b " \n " t}')"
         ;;
 
         "exaile"*)

--- a/neofetch
+++ b/neofetch
@@ -2411,6 +2411,7 @@ get_song() {
         ;;
 
         "exaile"*)
+            # NOTE: Exaile >= 4.0.0 will support mpris2.
             song="$(dbus-send --print-reply --dest=org.exaile.Exaile  /org/exaile/Exaile \
                     org.exaile.Exaile.Query |
                     awk -F':|,' '{if ($6 && $8 && $4) printf $6 " \n" $8 " \n" $4}')"


### PR DESCRIPTION
## Description

Amarok supports mpris2 so we can use `get_song_dbus`.
Exaile 4.0.0 will also support mpris2, added a reminder for now.
