### PR TITLE
Fix cannot correctly get window size

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3557,6 +3557,7 @@ get_window_size() {
     # user input so we have to use read to store the out
     # -put as a variable.
     IFS=';t' read -d t -t 0.05 -sra term_size
+    unset IFS
 
     # Split the string into height/width.
     if [[ "$image_backend" == "tycat" ]]; then


### PR DESCRIPTION
Fix a bug caused by not correctly unset IFS to read array.

## Description

Image cannot correctly display due to get_window_size() cannot get window size. Tests passed on MacOS High Sierra.


## Features

## Issues
For the issue: [Images not displaying #1045](https://github.com/dylanaraps/neofetch/issues/1045 "Images not displaying")

## TODO