### PR TITLE
Display total resolution when using xrandr

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2526,21 +2526,26 @@ get_resolution() {
 
         *)
             if type -p xrandr >/dev/null; then
+                resolution="$(xrandr --nograb --current |\
+                                awk -F'current' -F',' 'NR==1 {gsub(" |current","");print $2}')"
                 case "$refresh_rate" in
                     "on")
-                        resolution="$(xrandr --nograb --current |\
+                        monitors="$(xrandr --nograb --current |\
                                       awk 'match($0,/[0-9]*\.[0-9]*\*/) {
                                            printf $1 " @ " substr($0,RSTART,RLENGTH) "Hz, "}')"
                     ;;
 
                     "off")
-                        resolution="$(xrandr --nograb --current |\
+                        monitors="$(xrandr --nograb --current |\
                                       awk -F 'connected |\\+|\\(' \
                                              '/ connected/ && $2 {printf $2 ", "}')"
-                        resolution="${resolution/primary }"
+                        monitors="${monitors/primary }"
                     ;;
                 esac
-                resolution="${resolution//\*}"
+                if [ -n "$monitors" ]; then
+                    monitors="${monitors%,*}"
+                    resolution="$resolution (${monitors//\*}), "
+                fi
 
             elif type -p xwininfo >/dev/null; then
                 read -r w h \

--- a/neofetch
+++ b/neofetch
@@ -2542,7 +2542,7 @@ get_resolution() {
                         monitors="${monitors/primary }"
                     ;;
                 esac
-                if [ -n "$monitors" ]; then
+                if [[ -n "$monitors" ]]; then
                     monitors="${monitors%,*}"
                     resolution="$resolution (${monitors//\*}), "
                 fi


### PR DESCRIPTION
## Features
Displays total display resolution when using xrandr, similar to xwininfo, xdpyinfo. Individual displays are included in par

## Issues
* Runs xrandr command an extra time

## To Do
* Only display if there are multiple monitors (count number of connected monitors?)
* Toggle to allow hiding of individual monitor details