### PR TITLE
Fix borked version display for mksh

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1366,7 +1366,7 @@ get_shell() {
             "sh" | "ash" | "dash") ;;
 
             "mksh" | "ksh")
-                shell+="$("$SHELL" -c "printf %s \$KSH_VERSION")"
+                shell+="$("$SHELL" -c "printf %s \"\$KSH_VERSION\"")"
                 shell="${shell/ * KSH}"
                 shell="${shell/version}"
             ;;


### PR DESCRIPTION
`"$SHELL" -c "printf %s \$KSH_VERSION"` as part of the shell version
detection for ksh and mksh was expanding to `printf %s $KSH_VERSION`
inside of shell. This resulted in `$KSH_VERSION` being substituted as
multiple arguments to printf. While (afaik) unspecified, mksh, bash
and zsh resort to repeating the format strings. This resulted in all
spaces missing from `$shell`, which in turn caused the string cleanup
to fail: `Shell: mksh @MIRBSDKSHR562017/08/29`

Quoting `$KSH_VERSION` causes it to be given to printf as a single
argument, which preserves its spaces. The output after this change
looks like follows: `Shell: mksh R56 2017/08/29`