### PR TITLE
add term-font support for yakuake

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2872,7 +2872,7 @@ END
                               END { print font " " size}' "${confs[0]}")"
         ;;
 
-        "konsole"*)
+        "konsole" | "yakuake")
             # Get Process ID of current konsole window / tab
             child="$(get_ppid "$$")"
 


### PR DESCRIPTION
Yakuake terminal uses the same config files as Konsole.