### PR TITLE
add color-reset to ascii logo drawing

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3416,7 +3416,7 @@ get_ascii() {
     ascii_data="${ascii_data//\$\{c6\}/$c6}"
 
     ((text_padding=ascii_length+gap))
-    printf '%b\n' "$ascii_data"
+    printf '%b\n' "$ascii_data${reset}"
     LC_ALL=C
 }
 


### PR DESCRIPTION
reset the color after drawing the ascii logo.

should fix #1065 and similar issues. This was probably not noticed before because ascii-drawing is the first called function and many other after it do reset the color.
Note: line_break() also does not reset the color, but I think that's fine, since it does not use color.