### PR TITLE
Updated to fix new kitty bug prior to kitty fixes

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3578,7 +3578,7 @@ get_window_size() {
     fi
 
     [[ "$image_backend" == "kitty" ]] && \
-        IFS=x read -r term_width term_height < <(kitty icat --print-window-size)
+        IFS=x read -r term_width term_height < <(kitty +kitten icat --print-window-size)
 
     # Get terminal width/height if \e[14t is unsupported.
     if (( "${term_width:-0}" < 50 )) && [[ "$DISPLAY" && "$os" != "Mac OS X" ]]; then
@@ -3757,7 +3757,7 @@ display_image() {
         ;;
 
         "kitty")
-            kitty icat \
+            kitty +kitten icat \
                 --align left \
                 --place "$((width/font_width))x$((height/font_height))@${xoffset}x${yoffset}" \
             "$image"


### PR DESCRIPTION
Kitty recently updated and broke just using "kitty icat <image>" however, "kitty +kitten icat <image>" still works as intended.

This commit makes the neofetch script use +kitten.

