### PR TITLE
get_ascii: Do not parse file if it's an image file

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3393,7 +3393,7 @@ image_backend() {
 }
 
 get_ascii() {
-    if [[ -f "$image_source" ]]; then
+    if [[ -f "$image_source" && ! "$image_source" =~ (png|jpg|jpeg|jpe|svg|gif) ]]; then
         ascii_data="$(< "$image_source")"
     else
         err "Ascii: Ascii file not found, using distro ascii."


### PR DESCRIPTION
## Description

Neofetch error, doesnt show ASCII image in tty(text mode) while used an image.


## Features
Displaying alternative Distros ASCII Logo in GNU/Linux text mode.

## Issues
ASCII Logo doesnt display automaticly in text mode.


## TODO
