### PR TITLE
Update config comment with kitty backend.

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -637,7 +637,7 @@ disk_display="off"
 # Image backend.
 #
 # Default:  'ascii'
-# Values:   'ascii', 'caca', 'jp2a', 'iterm2', 'off', 'termpix', 'pixterm', 'tycat', 'w3m'
+# Values:   'ascii', 'caca', 'jp2a', 'iterm2', 'off', 'termpix', 'pixterm', 'tycat', 'w3m', 'kitty'
 # Flag:     --backend
 image_backend="ascii"
 


### PR DESCRIPTION
## Description

The kitty image backend was merged in #953 and v4.0.0, but the comment hasn't been updated to reflect the new backend being a valid option. This is important so that people can stumble upon this while editing their config, and so that people know it's a valid option. :slightly_smiling_face: 