### PR TITLE
add a lolcat option

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -657,6 +657,15 @@ image_source="auto"
 
 # Ascii Options
 
+# Lolcat
+#
+# Apply lolcat filter to the ascii image_backend
+# Default: 'off'
+# Values: 'off', 'on'
+#
+# NOTE: lolcat should be installed
+#       see https://github.com/busyloop/lolcat or https://github.com/jaseg/lolcat or https://github.com/tehmaze/lolcat/
+lolcat='off'
 
 # Ascii distro
 # Which distro's ascii art to display.
@@ -3412,6 +3421,11 @@ image_backend() {
 get_ascii() {
     if [[ -f "$image_source" && ! "$image_source" =~ (png|jpg|jpeg|jpe|svg|gif) ]]; then
         ascii_data="$(< "$image_source")"
+        if [[ "$lolcat" == "on" ]]; then
+	        ascii_data_print="$(cat "$image_source" | lolcat)"
+    	else
+    		ascii_data_print="${ascii_data}"
+		fi        
     else
         err "Ascii: Ascii file not found, using distro ascii."
     fi
@@ -3433,7 +3447,7 @@ get_ascii() {
     ascii_data="${ascii_data//\$\{c6\}/$c6}"
 
     ((text_padding=ascii_length+gap))
-    printf '%b\n' "$ascii_data${reset}"
+    printf '%b\n' "$ascii_data_print${reset}"
     LC_ALL=C
 }
 


### PR DESCRIPTION
Apply the lolcat filter to the ascii art used as input

## Description

I wanted to use neofetch with ascii art as image source. But I also wanted to add some colors to this source using lolcat tool ([here](https://github.com/jaseg/lolcat), [here](https://github.com/busyloop/lolcat) or [here](https://github.com/tehmaze/lolcat/))

But it doesn't work directly since the `get_ascii` doesn't count the length of the image correctly (the ANSI escape codes should be removed).
So I have added a `lolcat` option (`on` or `off`): when `on`, the image source is colored using `lolcat` filter (and the initial image is used to count the length of the image)

## Features
Add a `lolcat` option

## Issues
- lolcat must be installed 

## TODO
- some options for lolcat (the rainbow spread, seed and frequency)
- lolcat must be installed  when used (we may check this)
- a `--lolcat` option may be added
- 