### PR TITLE
Add default config path for Kitty

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2862,7 +2862,7 @@ END
 
         "kitty"*)
             shopt -s nullglob
-            confs=({$KITTY_CONFIG_DIRECTORY,$XDG_CONFIG_HOME,~/Library/Preferences}/kitty/kitty.con?)
+            confs=({$KITTY_CONFIG_DIRECTORY,$XDG_CONFIG_HOME,~/Library/Preferences,~/.config}/kitty/kitty.con?)
             shopt -u nullglob
 
             [[ -f "${confs[0]}" ]] || return


### PR DESCRIPTION
This adds `~/.config` to the locations to search for `/kitty/kitty.conf`. This is the default path as the [documentation](https://sw.kovidgoyal.net/kitty/conf.html) states.