### PR TITLE
get_memory: fix awk for vm_stat on macOS

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2220,9 +2220,9 @@ get_memory() {
 
         "Mac OS X" | "iPhone OS")
             mem_total="$(($(sysctl -n hw.memsize) / 1024 / 1024))"
-            mem_wired="$(vm_stat | awk '/wired/ { print $4 }')"
-            mem_active="$(vm_stat | awk '/active / { printf $3 }')"
-            mem_compressed="$(vm_stat | awk '/occupied/ { printf $5 }')"
+            mem_wired="$(vm_stat | awk '/ wired/ { print $4 }')"
+            mem_active="$(vm_stat | awk '/ active/ { printf $3 }')"
+            mem_compressed="$(vm_stat | awk '/ occupied/ { printf $5 }')"
             mem_compressed="${mem_compressed:-0}"
             mem_used="$(((${mem_wired//.} + ${mem_active//.} + ${mem_compressed//.}) * 4 / 1024))"
         ;;


### PR DESCRIPTION
Fixes the match for `active`, also changed `wired` and `occupied` to have the leading space to be safe.

Closes #1047 