### PR TITLE
get_song: stop iTunesHelper from being detected

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2358,7 +2358,7 @@ get_song() {
 
     printf -v players "|%s" "${players[@]}"
     player="$(ps aux | awk -v pattern="(${players:1})" \
-                '!/ awk / && match($0,pattern){print substr($0,RSTART,RLENGTH); exit}')"
+                '!/ awk / && !/iTunesHelper/ && match($0,pattern){print substr($0,RSTART,RLENGTH); exit}')"
 
     [[ "$music_player" && "$music_player" != "auto" ]] && \
         player="$music_player"


### PR DESCRIPTION
Resolves the annoying edge case in the awk statement. Also, I've found this isn't necessary on Mojave anymore, iTunesHelper hasn't been run since upgrading for me

Closes #1059 