### PR TITLE
OS: Add Bedrock Linux

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -827,7 +827,12 @@ get_distro() {
 
     case "$os" in
         "Linux" | "BSD" | "MINIX")
-            if [[ -f "/etc/redstar-release" ]]; then
+            if [[ -f "/bedrock/etc/bedrock-release" ]] && [[ $PATH == */bedrock/cross/* ]]; then
+                case "$distro_shorthand" in
+                    "on" | "tiny") distro="Bedrock Linux" ;;
+                    *) distro="$(< /bedrock/etc/bedrock-release)"
+                esac
+            elif [[ -f "/etc/redstar-release" ]]; then
                 case "$distro_shorthand" in
                     "on" | "tiny") distro="Red Star OS" ;;
                     *) distro="Red Star OS $(awk -F'[^0-9*]' '$0=$2' /etc/redstar-release)"
@@ -1268,7 +1273,21 @@ get_packages() {
     has() { type -p "$1" >/dev/null && manager="$_"; }
     dir() { ((packages+=$#)); pac "$#"; }
     pac() { (($1 > 0)) && { managers+=("$1 (${manager})"); manager_string+="${manager}, "; }; }
-    tot() { IFS=$'\n' read -d "" -ra pkgs < <("$@");((packages+="${#pkgs[@]}"));pac "${#pkgs[@]}"; }
+    if [[ -f "/bedrock/etc/bedrock-release" ]] && [[ "$PATH" == */bedrock/cross/* ]]; then
+        tot() {
+            IFS=$'\n' read -d "" -ra pkgs < <(for s in $(brl list); do strat -r "${s}" "$@"; done)
+            ((packages+="${#pkgs[@]}"))
+            pac "${#pkgs[@]}"
+        }
+        prefix="/bedrock/strata/*"
+    else
+        tot() {
+            IFS=$'\n' read -d "" -ra pkgs < <("$@")
+            ((packages+="${#pkgs[@]}"))
+            pac "${#pkgs[@]}";
+        }
+        prefix=""
+    fi
 
     case "$os" in
         "Linux" | "BSD" | "iPhone OS" | "Solaris")
@@ -1290,15 +1309,15 @@ get_packages() {
             has "pkginfo"    && tot pkginfo -i
 
             # Counting files/dirs.
-            has "emerge"     && dir /var/db/pkg/*/*/
-            has "nix-env"    && dir /nix/store/*/
-            has "guix"       && dir /gnu/store/*/
-            has "Compile"    && dir /Programs/*/
-            has "eopkg"      && dir /var/lib/eopkg/package/*
-            has "crew"       && dir /usr/local/etc/crew/meta/*.filelist
-            has "pkgtool"    && dir /var/log/packages/*
-            has "cave"       && dir /var/db/paludis/repositories/cross-installed/*/data/*/ \
-                                    /var/db/paludis/repositories/installed/data/*/
+            has "emerge"     && dir ${prefix}/var/db/pkg/*/*/
+            has "nix-env"    && dir ${prefix}/nix/store/*/
+            has "guix"       && dir ${prefix}/gnu/store/*/
+            has "Compile"    && dir ${prefix}/Programs/*/
+            has "eopkg"      && dir ${prefix}/var/lib/eopkg/package/*
+            has "crew"       && dir ${prefix}/usr/local/etc/crew/meta/*.filelist
+            has "pkgtool"    && dir ${prefix}/var/log/packages/*
+            has "cave"       && dir ${prefix}/var/db/paludis/repositories/cross-installed/*/data/*/ \
+                                    ${prefix}/var/db/paludis/repositories/installed/data/*/
 
             # Other (Needs complex command)
             has "kpm-pkg" && ((packages+="$(kpm  --get-selections | grep -cv deinstall$)"))
@@ -3426,6 +3445,7 @@ get_ascii() {
 
     # Calculate size of ascii file in line length / line count.
     while IFS=$'\n' read -r line; do
+        line="${line//\\\\/\\}"
         ((++lines,${#line}>ascii_length)) && ascii_length="${#line}"
     done <<< "${ascii_data//\$\{??\}}"
 
@@ -5180,6 +5200,29 @@ ${c1}   .oyyyyyyo. :yyyyyy/${c2}-yyyyyy+ ---------
 ${c1}  .syyyyyy+`  :yyyyyy/${c2}-yyyyy+-+syyyyyyyy
 ${c1} -syyyyyy/    :yyyyyy/${c2}-yyys:.syyyyyyyyyy
 ${c1}:syyyyyy/     :yyyyyy/${c2}-yyo.:syyyyyyyyyyy
+EOF
+        ;;
+
+        "Bedrock"*)
+            set_colors 0 7
+            read -rd '' ascii_data <<'EOF'
+${c1}--------------------------------------
+${c1}--------------------------------------
+${c1}--------------------------------------
+${c1}---${c2}\\\\\\\\\\\\\\\\\\\\\\\\${c1}-----------------------
+${c1}----${c2}\\\\\\      \\\\\\${c1}----------------------
+${c1}-----${c2}\\\\\\      \\\\\\${c1}---------------------
+${c1}------${c2}\\\\\\      \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\${c1}------
+${c1}-------${c2}\\\\\\                    \\\\\\${c1}-----
+${c1}--------${c2}\\\\\\                    \\\\\\${c1}----
+${c1}---------${c2}\\\\\\        ______      \\\\\\${c1}---
+${c1}----------${c2}\\\\\\                   ///${c1}---
+${c1}-----------${c2}\\\\\\                 ///${c1}----
+${c1}------------${c2}\\\\\\               ///${c1}-----
+${c1}-------------${c2}\\\\\\////////////////${c1}------
+${c1}--------------------------------------
+${c1}--------------------------------------
+${c1}--------------------------------------
 EOF
         ;;
 


### PR DESCRIPTION
I'd like to add Bedrock Linux support.  I believe there were discussions about doing this in the past, but at the time Bedrock was not in a suitable position to cleanly inter-operate with neofetch.  We are now beta testing Bedrock Linux 0.7 Poki which includes changes I explicitly made with the aim of getting it to play more nicely with neofetch.  I hope to have Poki out of beta and properly released in around a month, and it'd be great if I could show it off with neofetch then.

Looks like a lot of preliminary work was done in the intervening time period:

- https://gist.github.com/dylanaraps/ec1eb7e8dc13fef54740
- https://github.com/dylanaraps/neofetch/pull/229

which makes me hopeful this will go well.

Some background, in case readers are unfamiliar with Bedrock Linux:  A Bedrock system is composed of features from other distros.  For example, I'm typing this on a system where my init comes from Void Linux, my Xorg server from Debian Stretch, my window manager from Gentoo Linux, and my web browser comes form Arch.

A couple Bedrock specific concepts that I think neofetch should handle:

- Sometimes users want Bedrock to integrate different distros together, and sometimes they want the given piece of software to be restricted to its native stratum.  Bedrock offers a `strat -r` feature which can be used to disable cross-distro integration.  When `strat -r` is not used, neofetch should report the system as Bedrock and list all of the packages from all of the strata.  When `strat -r` is used, neofetch should report the system as the given stratum's distribution and only count its packages.  For example, while `neofetch` should report the system as Bedrock, `strat -r arch neofetch` should report the system as Arch Linux.  We can detect this `strat -r` feature is set by looking for the absence of `/bedrock/cross/` directories in the `$PATH`.
- A Bedrock system can have multiple instances of the same package manager.  For example, a Bedrock system could have components from both Debian and Ubuntu, and thus have two `dpkg`'s.  Package counts should reflect this.
	- For package counts that are generated by running a command, we can loop over all of the strata and run each package manager with `strat -r`.  For example, we can run `strat -r debian dpkg-query -f '.\n' -W` and `strat -r ubuntu dpkg-query -f '.\n' -W`.
	- For package counts that are generated by counting files, we can list all instances of files on all strata by prefixing `/bedrock/strata/*/`.  For example, we can count both `/bedrock/strata/gentoo/var/db/pkg/*/*/` and `/bedrock/strata/funtoo/var/db/pkg/*/*/`

I don't want Bedrock's unusual attributes to make a mess of the very clean neofetch code base.  If there is any disagreement with how I implemented these features I'm happy to change things accordingly.