### PR TITLE
fix GPU driver detection bug with bumblebee-managed dual video cards

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3304,7 +3304,7 @@ get_gpu_driver() {
     case "$os" in
         "Linux")
             gpu_driver="$(lspci -nnk | awk -F ': ' \
-                          '/Display|3D|VGA/{nr[NR+2]}; NR in nr {printf $2 ", "}')"
+                          '/Display|3D|VGA/{nr[NR+2]}; NR in nr && $1 == "	Kernel driver in use" {printf $2 ", "}')"
             gpu_driver="${gpu_driver%, }"
 
             if [[ "$gpu_driver" == *"nvidia"* ]]; then

--- a/neofetch
+++ b/neofetch
@@ -3304,7 +3304,7 @@ get_gpu_driver() {
     case "$os" in
         "Linux")
             gpu_driver="$(lspci -nnk | awk -F ': ' \
-                          '/Display|3D|VGA/{nr[NR+2]}; NR in nr && $1 == "	Kernel driver in use" {printf $2 ", "}')"
+                          '/Display|3D|VGA/{nr[NR+2]}; NR in nr && $1~"nel driv" {printf $2 ", "}')"
             gpu_driver="${gpu_driver%, }"
 
             if [[ "$gpu_driver" == *"nvidia"* ]]; then


### PR DESCRIPTION
## Description

gpu_driver is enabled in my console to reassure the video card I am currently using, as my laptop is equipped with dual graphic cards. 

However, the output seems a bit curious: 

![bug_screenshot](https://user-images.githubusercontent.com/34372453/49573133-3d061280-f978-11e8-8949-13ca20335db0.png)

The cause is explained in the picture below: 

![cause](https://user-images.githubusercontent.com/34372453/49574218-da624600-f97a-11e8-927f-8947397caea1.png)

As I have used bumblebee to manage my graphic cards, normally the nvidia card is disabled. Simply add 2 to the NR where the nvidia card appears causes this incorrect result. 

## Features

Fix the bug described above. 

## Issues

~~I am sorry I did not come up with a simple solution to keep this line less than 100 characters. The line I altered has 117 characters now.~~

~~I do have some ideas to shorten it, like `tmp_str="first half"; str="$tmp_str && the rest"`, but I think that is even worse.~~

To pass the travis check, the field name match is set as containing "nel driv" instead of exactly matching "	Kernel driver in use" (as the line length should be smaller than 102 according to the .travis.yml). 

This could be potentially problematic, but I think the keywords I choose should avoid much. Please Let me know if you you have any thoughts about this. You are also welcome to edit it directly if you like. Thanks! 

## TODO

No further work is required so far. 
