### PR TITLE
Adds scoop package manager support

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1341,6 +1341,9 @@ get_packages() {
                 "MSYS"*)   has "pacman"   && tot pacman -Qq --color never ;;
             esac
 
+            # Scoop environment throws errors if `tot scoop list` is used
+            has "scoop" && dir ~/scoop/apps/* && ((packages-=1))
+
             # Count chocolatey packages.
             [[ -d "/cygdrive/c/ProgramData/chocolatey/lib" ]] && \
                 dir /cygdrive/c/ProgramData/chocolatey/lib/*


### PR DESCRIPTION
## Features
- Adds support for the scoop package manager in Windows
## Issues
Resolves #1129 
## Notes
If using `tot scoop list` in the environment that Scoop installs neofetch to, bash throws the error `bash: /dev/fd/62: No such file or directory`.
Since this is the environment most likely to be reporting Scoop packages with neofetch, the `dir` function was used instead.