### PR TITLE
Improve nix support with termite

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3031,13 +3031,24 @@ END
             [[ -f "${XDG_CONFIG_HOME}/termite/config" ]] && \
                 termite_config="${XDG_CONFIG_HOME}/termite/config"
 
+            XDG_DIR="/etc/xdg"
+            OLD_IFS=$IFS
+            IFS=":"
+            for directory in $XDG_CONFIG_DIRS; do
+                if [[ -f "$directory/termite/config" ]]; then
+                    XDG_DIR="$directory"
+                    break
+                fi
+            done
+            IFS=$OLD_IFS
+
             term_font="$(awk -F '= ' '/\[options\]/ {
                                           opt=1
                                       }
                                       /^\s*font/ {
                                           if(opt==1) a=$2;
                                           opt=0
-                                      } END {print a}' "/etc/xdg/termite/config" \
+                                      } END {print a}' "$XDG_DIR/termite/config" \
                          "$termite_config")"
         ;;
 

--- a/neofetch
+++ b/neofetch
@@ -2778,6 +2778,10 @@ get_term() {
                 break
             ;;
 
+            "."*"-wrap"*)
+                [[ $name =~ \.(.*)-wrap.* ]] && term=${BASH_REMATCH[1]}
+            ;;
+
             "gnome-terminal-") term="gnome-terminal" ;;
             "urxvtd")          term="urxvt" ;;
             *"nvim")           term="Neovim Terminal" ;;


### PR DESCRIPTION
Hi,

Using Nix some apps get wrapped, hence a name like ".APP-wrapped", causing later failure when matching a terminal name for font detection.

Moreover, for termite, directory /etc/xdg does not exist with NixOS, while $XDG_CONFIG_DIRS is set, which needed additional lookup.
(I didn't explore with other terminal yet, but the problem might occur for others)

Before fix
![neofetch-nix-before](https://user-images.githubusercontent.com/3458542/49671434-250dbc00-fa68-11e8-8083-5683a0f9b9d8.png)

After fix
![neofetch-nix-after](https://user-images.githubusercontent.com/3458542/49671433-250dbc00-fa68-11e8-91f6-d2d0dd91fc1f.png)

Thanks for your work and review :)