### PR TITLE
Misc: Use comma syntax in awk to print spaces

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -989,8 +989,8 @@ get_distro() {
 
         "Solaris")
             case "$distro_shorthand" in
-                "on" | "tiny") distro="$(awk 'NR==1{print $1 " " $3;}' /etc/release)" ;;
-                *)             distro="$(awk 'NR==1{print $1 " " $2 " " $3;}' /etc/release)" ;;
+                "on" | "tiny") distro="$(awk 'NR==1 {print $1,$3}' /etc/release)" ;;
+                *)             distro="$(awk 'NR==1 {print $1,$2,$3}' /etc/release)" ;;
             esac
             distro="${distro/\(*}"
         ;;
@@ -2862,13 +2862,13 @@ END
         ;;
 
         "deepin-terminal"*)
-            term_font="$(awk -F '=' '/font=/ {a=$2} /font_size/ {b=$2} END {print a " " b}' \
+            term_font="$(awk -F '=' '/font=/ {a=$2} /font_size/ {b=$2} END {print a,b}' \
                          "${XDG_CONFIG_HOME}/deepin/deepin-terminal/config.conf")"
         ;;
 
         "GNUstep_Terminal")
              term_font="$(awk -F '>|<' '/>TerminalFont</ {getline; f=$3}
-                          />TerminalFontSize</ {getline; s=$3} END {print f " " s}' \
+                          />TerminalFontSize</ {getline; s=$3} END {print f,s}' \
                           "${HOME}/GNUstep/Defaults/Terminal.plist")"
         ;;
 
@@ -2892,7 +2892,7 @@ END
                               /^([[:space:]]*|[^#_])font_size[[:space:]]+/ {
                                   size = $2
                               }
-                              END { print font " " size}' "${confs[0]}")"
+                              END {print font,size}' "${confs[0]}")"
         ;;
 
         "konsole" | "yakuake")
@@ -2919,7 +2919,7 @@ END
             profile_filename="${profile_filename/$'\n'*}"
 
             [[ "$profile_filename" ]] && \
-                term_font="$(awk -F '=|,' '/Font=/ {print $2 " " $3}' "$profile_filename")"
+                term_font="$(awk -F '=|,' '/Font=/ {print $2,$3}' "$profile_filename")"
         ;;
 
         "lxterminal"*)
@@ -2978,7 +2978,7 @@ END
         ;;
 
         "qterminal")
-            term_font="$(awk -F '=' '/fontFamily=/ {a=$2} /fontSize=/ {b=$2} END {print a " " b}' \
+            term_font="$(awk -F '=' '/fontFamily=/ {a=$2} /fontSize=/ {b=$2} END {print a,b}' \
                          "${XDG_CONFIG_HOME}/qterminal.org/qterminal.ini")"
         ;;
 


### PR DESCRIPTION
## Description
Awk has built-in functionality to separate output fields. So why not use it? :wink:
