### PR TITLE
Store thumbnails based on image hash to avoid name collisions

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3696,7 +3696,8 @@ get_image_size() {
 make_thumbnail() {
     # Name the thumbnail using variables so we can
     # use it later.
-    image_name="${crop_mode}-${crop_offset}-${width}-${height}-${image##*/}"
+    image_hash="$(md5sum "$image" | cut -c -32)"
+    image_name="${crop_mode}-${crop_offset}-${width}-${height}-${image_hash}"
 
     # Handle file extensions.
     case "${image##*.}" in


### PR DESCRIPTION
I use album covers as image source and since they all named `cover` or `folder`, current naming scheme results in image never being changed.