### PR TITLE
adding cursor theme support

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2599,13 +2599,12 @@ get_style() {
                     if [[ "$kde" == "cursorTheme" ]]; then
                         if [[ -f "${kde_config_dir}/kcminputrc" ]]; then
                             kde_config_file="${kde_config_dir}/kcminputrc"
-                            kde_theme="$(grep "cursorTheme" "$kde_config_file")"
-                            kde_theme="${kde_theme/*=}"
                         elif [[ -f "${kde_config_dir}/startupconfig" ]]; then
+                            kde="cursortheme"
                             kde_config_file="${kde_config_dir}/startupconfig"
-                            kde_theme="$(grep "cursortheme" "$kde_config_file")"
-                            kde_theme="${kde_theme/*=}"
                         fi
+                        kde_theme="$(grep "${kde}" "$kde_config_file")"
+                        kde_theme="${kde_theme/*=}"
                     fi
                     kde_theme="$kde_theme [KDE], "
                 else

--- a/neofetch
+++ b/neofetch
@@ -64,6 +64,7 @@ print_info() {
     info "WM Theme" wm_theme
     info "Theme" theme
     info "Icons" icons
+    info "Cursor" cursor
     info "Terminal" term
     info "Terminal Font" term_font
     info "CPU" cpu
@@ -2594,6 +2595,18 @@ get_style() {
                         kde_font_size="${kde_font_size/,*}"
                         kde_theme="${kde_theme/,*} ${kde_theme/*,} ${kde_font_size}"
                     fi
+
+                    if [[ "$kde" == "cursorTheme" ]]; then
+                        if [[ -f "${kde_config_dir}/kcminputrc" ]]; then
+                            kde_config_file="${kde_config_dir}/kcminputrc"
+                            kde_theme="$(grep "cursorTheme" "$kde_config_file")"
+                            kde_theme="${kde_theme/*=}"
+                        elif [[ -f "${kde_config_dir}/startupconfig" ]]; then
+                            kde_config_file="${kde_config_dir}/startupconfig"
+                            kde_theme="$(grep "cursortheme" "$kde_config_file")"
+                            kde_theme="${kde_theme/*=}"
+                        fi
+                    fi
                     kde_theme="$kde_theme [KDE], "
                 else
                     err "Theme: KDE config files not found, skipping."
@@ -2731,6 +2744,17 @@ get_font() {
 
     get_style
     font="$theme"
+}
+
+get_cursor() {
+    name="gtk-cursor-theme-name"
+    gsettings="cursor-theme"
+    gconf="cursor_theme"
+    xfconf="/Gtk/CursorThemeName"
+    kde="cursorTheme"
+
+    get_style
+    cursor="$theme"
 }
 
 get_term() {


### PR DESCRIPTION
## Description

This adds support for querying what cursor theme is being used. I figured some people might want to know?

## Issues
Asking KDE which cursor theme is being used is a bit tricky as the default setting is stored in one config file, and if it's changed KDE creates a new config file to store the setting in. This PR looks in both places. Not sure if there's a better way to do this?

## Example
![2019-01-04-193657_1920x1080_scrot](https://user-images.githubusercontent.com/5217745/50717851-83728e00-1058-11e9-8547-b5a5f3816acf.png)

