### PR TITLE
Add get_editor() for printing user's installed ${VISUAL:-$EDITOR}

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1490,33 +1490,39 @@ get_editor() {
     esac
 
     if [[ "$editor_version" == "on" ]]; then
-        # resolve symlink (for vi case)
-        case "$(realpath "$editor_full_path")" in
-            *"/amp")
-                # no flag provided
-                editor="$editor_full_path"
-            ;;
-            *"/pico")
-                editor="$("$editor_full_path" -version 2>&1)"
-            ;;
-            *"/micro")
-                editor="$editor$("$editor_full_path" -version 2>&1)"
-                editor="${editor/$'\n'*}"
-            ;;
-            *"/busybox")
-                editor="$editor$("$editor_full_path" --help 2>&1)"
-                editor="${editor/$'\n'*}"
-                editor="${editor/ \(*}"
-            ;;
-            *"/ex" | *"/vi")
-                editor="$(printf ':version\n:q\n' | "$editor_full_path" -s)"
-                editor="${editor/*$'\n'}"
-            ;;
-            *)
-                editor="$("$editor_full_path" --version 2>&1)"
-                editor="${editor/$'\n'*}"
-            ;;
-        esac
+        while
+            case "$editor_full_path" in
+                *"/amp")
+                    # no flag provided
+                    editor="$editor_full_path"
+                ;;
+                *"/pico")
+                    editor="$("$editor_full_path" -version 2>&1)"
+                ;;
+                *"/micro")
+                    editor="$editor$("$editor_full_path" -version 2>&1)"
+                    editor="${editor/$'\n'*}"
+                ;;
+                *"/busybox")
+                    editor="$editor$("$editor_full_path" --help 2>&1)"
+                    editor="${editor/$'\n'*}"
+                    editor="${editor/ \(*}"
+                ;;
+                *"/ex" | *"/vi")
+                    if [[ -h "$editor_full_path" ]]; then
+                        editor_full_path="$(realpath "$editor_full_path")"
+                        continue
+                    fi
+                    editor="$(printf ':version\n:q\n' | "$editor_full_path" -s)"
+                    editor="${editor/*$'\n'}"
+                ;;
+                *)
+                    editor="$("$editor_full_path" --version 2>&1)"
+                    editor="${editor/$'\n'*}"
+                ;;
+            esac
+            false
+        do :; done
     fi
 
     # Remove unwanted info.

--- a/neofetch
+++ b/neofetch
@@ -1489,6 +1489,9 @@ get_editor() {
 
     if [[ "$editor_version" == "on" ]]; then
         case "${editor_name:=${editor##*/}}" in
+            "pico"*)
+                editor="$("$editor_full_path" -version 2>&1 | head -n1)"
+            ;;
             *)
                 editor="$("$editor_full_path" --version 2>&1 | head -n1)"
             ;;

--- a/neofetch
+++ b/neofetch
@@ -1476,6 +1476,8 @@ get_shell() {
 }
 
 get_editor() {
+    [[ "$editor" ]] && return
+
     local editor_full_path
     # disable SC2153: EDITOR vs editor
     # shellcheck disable=2153

--- a/neofetch
+++ b/neofetch
@@ -70,6 +70,7 @@ print_info() {
     info "GPU" gpu
     info "Memory" memory
 
+    # info "Editor" editor
     # info "GPU Driver" gpu_driver  # Linux/macOS only
     # info "CPU Usage" cpu_usage
     # info "Disk" disk
@@ -197,6 +198,32 @@ shell_path="off"
 # on:  'bash 4.4.5'
 # off: 'bash'
 shell_version="on"
+
+
+# Editor
+
+
+# Show the path to $VISUAL or $EDITOR
+#
+# Default: 'off'
+# Values:  'on', 'off'
+# Flag:    --editor_path
+#
+# Example:
+# on:  '/usr/bin/vim'
+# off: 'vim'
+editor_path="off"
+
+# Show version
+#
+# Default: 'on'
+# Values:  'on', 'off'
+# Flag:    --editor_version
+#
+# Example:
+# on:  'VIM - Vi IMproved 8.1'
+# off: 'vim'
+editor_version="on"
 
 
 # CPU
@@ -1446,6 +1473,31 @@ get_shell() {
         shell="${shell/options*}"
         shell="${shell/\(*\)}"
     fi
+}
+
+get_editor() {
+    local editor_full_path
+    # disable SC2153: EDITOR vs editor
+    # shellcheck disable=2153
+    editor_full_path="${VISUAL:-$EDITOR}"
+    case "$editor_path" in
+        "on")  editor="$editor_full_path " ;;
+        "off") editor="${editor_full_path##*/} " ;;
+    esac
+
+    if [[ "$editor_version" == "on" ]]; then
+        case "${editor_name:=${editor##*/}}" in
+            *)
+                editor+="$("$editor_full_path" --version 2>&1 | head -n1)"
+                editor="${editor/ "${editor_name}"}"
+            ;;
+        esac
+    fi
+
+    # Remove unwanted info.
+    editor="${editor/, version}"
+    editor="${editor/options*}"
+    editor="${editor/\(*\)}"
 }
 
 get_de() {
@@ -4541,6 +4593,8 @@ get_args() {
             "--gtk3") gtk3="$2" ;;
             "--shell_path") shell_path="$2" ;;
             "--shell_version") shell_version="$2" ;;
+            "--editor_path") editor_path="$2" ;;
+            "--editor_version") editor_version="$2" ;;
             "--ip_host") public_ip_host="$2" ;;
             "--ip_timeout") public_ip_timeout="$2" ;;
             "--song_format") song_format="$2" ;;

--- a/neofetch
+++ b/neofetch
@@ -1482,15 +1482,25 @@ get_editor() {
     # disable SC2153: EDITOR vs editor
     # shellcheck disable=2153
     editor_full_path="${VISUAL:-$EDITOR}"
+    # remove arguments
+    editor_full_path="${editor_full_path%% *}"
     case "$editor_path" in
         "on")  editor="$editor_full_path " ;;
         "off") editor="${editor_full_path##*/} " ;;
     esac
 
     if [[ "$editor_version" == "on" ]]; then
-        case "${editor_name:=${editor##*/}}" in
-            "pico"*)
+        # resolve symlink (for busybox vi case)
+        case "$(realpath "$(command -v "$editor")")" in
+            *"/pico"*)
                 editor="$("$editor_full_path" -version 2>&1 | head -n1)"
+            ;;
+            *"/busybox"*)
+                editor="$editor$("$editor_full_path" --help 2>&1 | head -n1)"
+                editor="${editor/ \(*}"
+            ;;
+            *"/vi"*|*"/ex"*)
+                editor="$editor$(printf ':version\n:q\n' | "$editor_full_path" -s | tail -n1)"
             ;;
             *)
                 editor="$("$editor_full_path" --version 2>&1 | head -n1)"

--- a/neofetch
+++ b/neofetch
@@ -1490,20 +1490,24 @@ get_editor() {
     esac
 
     if [[ "$editor_version" == "on" ]]; then
-        # resolve symlink (for busybox vi case)
+        # resolve symlink (for vi case)
         case "$(realpath "$editor_full_path")" in
             *"/pico")
-                editor="$("$editor_full_path" -version 2>&1 | head -n1)"
+                editor="$("$editor_full_path" -version 2>&1)"
+                editor="${editor/$'\n'*}"
             ;;
             *"/busybox")
-                editor="$editor$("$editor_full_path" --help 2>&1 | head -n1)"
+                editor="$editor$("$editor_full_path" --help 2>&1)"
+                editor="${editor/$'\n'*}"
                 editor="${editor/ \(*}"
             ;;
             *"/ex" | *"/vi")
-                editor="$editor$(printf ':version\n:q\n' | "$editor_full_path" -s | tail -n1)"
+                editor="$editor$(printf ':version\n:q\n' | "$editor_full_path" -s)"
+                editor="${editor/*$'\n'}"
             ;;
             *)
-                editor="$("$editor_full_path" --version 2>&1 | head -n1)"
+                editor="$("$editor_full_path" --version 2>&1)"
+                editor="${editor/$'\n'*}"
             ;;
         esac
     fi

--- a/neofetch
+++ b/neofetch
@@ -1488,8 +1488,7 @@ get_editor() {
     if [[ "$editor_version" == "on" ]]; then
         case "${editor_name:=${editor##*/}}" in
             *)
-                editor+="$("$editor_full_path" --version 2>&1 | head -n1)"
-                editor="${editor/ "${editor_name}"}"
+                editor="$("$editor_full_path" --version 2>&1 | head -n1)"
             ;;
         esac
     fi

--- a/neofetch
+++ b/neofetch
@@ -1492,14 +1492,14 @@ get_editor() {
     if [[ "$editor_version" == "on" ]]; then
         # resolve symlink (for busybox vi case)
         case "$(realpath "$editor_full_path")" in
-            *"/pico"*)
+            *"/pico")
                 editor="$("$editor_full_path" -version 2>&1 | head -n1)"
             ;;
-            *"/busybox"*)
+            *"/busybox")
                 editor="$editor$("$editor_full_path" --help 2>&1 | head -n1)"
                 editor="${editor/ \(*}"
             ;;
-            *"/vi"*|*"/ex"*)
+            *"/ex" | *"/vi")
                 editor="$editor$(printf ':version\n:q\n' | "$editor_full_path" -s | tail -n1)"
             ;;
             *)

--- a/neofetch
+++ b/neofetch
@@ -1502,7 +1502,7 @@ get_editor() {
                 editor="${editor/ \(*}"
             ;;
             *"/ex" | *"/vi")
-                editor="$editor$(printf ':version\n:q\n' | "$editor_full_path" -s)"
+                editor="$(printf ':version\n:q\n' | "$editor_full_path" -s)"
                 editor="${editor/*$'\n'}"
             ;;
             *)

--- a/neofetch
+++ b/neofetch
@@ -1483,7 +1483,7 @@ get_editor() {
     # shellcheck disable=2153
     editor_full_path="${VISUAL:-$EDITOR}"
     # remove arguments
-    editor_full_path="${editor_full_path%% *}"
+    editor_full_path="$(type -p "${editor_full_path%% *}")"
     case "$editor_path" in
         "on")  editor="$editor_full_path " ;;
         "off") editor="${editor_full_path##*/} " ;;
@@ -1491,7 +1491,7 @@ get_editor() {
 
     if [[ "$editor_version" == "on" ]]; then
         # resolve symlink (for busybox vi case)
-        case "$(realpath "$(command -v "$editor")")" in
+        case "$(realpath "$editor_full_path")" in
             *"/pico"*)
                 editor="$("$editor_full_path" -version 2>&1 | head -n1)"
             ;;

--- a/neofetch
+++ b/neofetch
@@ -1492,8 +1492,15 @@ get_editor() {
     if [[ "$editor_version" == "on" ]]; then
         # resolve symlink (for vi case)
         case "$(realpath "$editor_full_path")" in
+            *"/amp")
+                # no flag provided
+                editor="$editor_full_path"
+            ;;
             *"/pico")
                 editor="$("$editor_full_path" -version 2>&1)"
+            ;;
+            *"/micro")
+                editor="$editor$("$editor_full_path" -version 2>&1)"
                 editor="${editor/$'\n'*}"
             ;;
             *"/busybox")

--- a/neofetch.1
+++ b/neofetch.1
@@ -119,6 +119,12 @@ Enable/Disable showing $SHELL path
 \fB\-\-shell_version\fR on/off
 Enable/Disable showing $SHELL version
 .TP
+\fB\-\-editor_path\fR on/off
+Enable/Disable showing editor path
+.TP
+\fB\-\-editor_version\fR on/off
+Enable/Disable showing editor version
+.TP
 \fB\-\-disk_show\fR value
 Which disks to display.
 Possible values: '/', '/dev/sdXX', '/path/to/mount point'


### PR DESCRIPTION
Based off of current get_shell

## Features

- `--editor_path` a la `--shell_path`
- `--editor_version` a la `--shell_version` *(needs testing)*

## TODO

- [x] Update man page
- [ ] Test more editors
- - [x] busybox vi, ed, emacs, ex, dav, mcedit, micro, moe, nano, nvim, pico, red, vi (4.0), vim
- - [x] amp (no version)
- - [ ] (?) (please test your own editor if not listed above)