### PR TITLE
Made variables local in get_cols function

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3359,6 +3359,7 @@ get_gpu_driver() {
 }
 
 get_cols() {
+    local blocks blocks2 cols
     if [[ "$color_blocks" == "on" ]]; then
         # Convert the width to space chars.
         printf -v block_width "%${block_width}s"


### PR DESCRIPTION
## Description
The variables blocks, blocks2, and cols were not set as local in the get_cols function, which made neofetch print whatever value they had before showing the colorblocks. This commit makes these variables local so the output doesn't get affected if they are set (e.g. export blocks="string") beforehand.

