### PR TITLE
postmarketOS: Add small ASCII logo

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -4461,7 +4461,7 @@ ASCII:
                                 'Ubuntu-Studio' or 'Ubuntu-Budgie' to use the flavors.
 
                                 NOTE: Alpine, Arch, CRUX, Debian, Gentoo, FreeBSD, Mac, NixOS,
-                                OpenBSD, and Void have a smaller logo variant.
+                                OpenBSD, postmarketOS, and Void have a smaller logo variant.
 
                                 NOTE: Use '{distro name}_small' to use the small variants.
 
@@ -7581,6 +7581,21 @@ s:  yNm+`   .smNd+.
            .sy`
              .+:
                 `
+EOF
+        ;;
+
+        "postmarketos_small")
+            set_colors 2 7
+            read -rd '' ascii_data <<'EOF'
+${c1}        /\\
+       /  \\
+      /    \\
+      \\__   \\
+    /\\__ \\  _\\
+   /   /  \\/ __
+  /   / ____/  \\
+ /    \\ \\       \\
+/_____/ /________\\
 EOF
         ;;
 


### PR DESCRIPTION
This was generated with the same script as #1178, but this time it is only 9 lines tall.

## Preview

![pmos-neofetch-9lines](https://user-images.githubusercontent.com/26132344/51777493-f81e7280-20c2-11e9-8b0c-4d1074e77d2e.png)
