### PR TITLE
CPU [Linux/ARM]: Use Hardware field directly

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1805,13 +1805,9 @@ get_cpu() {
                 ;;
 
                 *)
-                    cpu="$(awk -F ': | @' '/model name|Processor|^cpu model|chip type|^cpu type/ {
-                                               printf $2;
-                                               exit
-                                           }' "$cpu_file")"
-
-                    [[ "$cpu" == *"processor rev"* ]] && \
-                        cpu="$(awk -F':' '/Hardware/ {print $2; exit}' "$cpu_file")"
+                    cpu="$(awk -F ': | @' \
+                            '/model name|Hardware|Processor|^cpu model|chip type|^cpu type/ {
+                            printf $2; exit}' "$cpu_file")"
                 ;;
             esac
 


### PR DESCRIPTION
## Description

Self-explanatory.

## Rationale

In the newer ARM devices (say, Android devices, Raspberry Pi, etc.) it seems the `Processor/model name:` field [isn't used at all](https://github.com/pytorch/cpuinfo/commit/3365a916ae9cbd5d4e00af3c70c97a8033f4a2c5).

In old ARM devices (aka. [Intel StrongARM](https://github.com/randombit/cpuinfo/commit/d66ca6699880723efff6e22afe36a7364545376e/arm/arm.004)), this was filled properly, but with the future of ARM (especially in the age of SoC), I doubt ARM manufacturers will fill the field properly again (apart of generic ARMv7 processor rev 8 or something like that).

## TODO

- [x] Testing