### PR TITLE
image: Add framebuffer support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ request on the repo and our Travis.ci hook will run ShellCheck for you.
 - Don’t use `sed`.
     - Use `bash`'s built-in [parameter expansion](http://wiki.bash-hackers.org/syntax/pe).
 - Don’t use `cat`.
-    - Use `bash`'s built-in syntax (`file="$(< /path/to/file.txt)")`).
+    - Use `bash`'s built-in syntax (`file="$(< /path/to/file.txt)"`).
 - Don’t use `grep "pattern" | awk '{ printf }'`.
     - Use `awk '/pattern/ { printf }'`
 - Don’t use `wc`.

--- a/neofetch
+++ b/neofetch
@@ -3639,35 +3639,46 @@ get_window_size() {
     [[ "$image_backend" == "kitty" ]] && \
         IFS=x read -r term_width term_height < <(kitty +kitten icat --print-window-size)
 
+    [[ -z "$term" ]] && get_term
+
     # Get terminal width/height if \e[14t is unsupported.
-    if (( "${term_width:-0}" < 50 )) && [[ "$DISPLAY" && "$os" != "Mac OS X" ]]; then
-        if type -p xdotool &>/dev/null; then
-            IFS=$'\n' read -d "" -ra win < <(xdotool getactivewindow getwindowgeometry --shell %1)
-            term_width="${win[3]/WIDTH=}"
-            term_height="${win[4]/HEIGHT=}"
+    if (( "${term_width:-0}" < 50 )); then
+        if [[ "$DISPLAY" && "$os" != "Mac OS X" ]]; then
+            if type -p xdotool &>/dev/null; then
+                IFS=$'\n' read -d "" -ra win < \
+                    <(xdotool getactivewindow getwindowgeometry --shell %1)
+                term_width="${win[3]/WIDTH=}"
+                term_height="${win[4]/HEIGHT=}"
 
-        elif type -p xwininfo &>/dev/null; then
-            # Get the focused window's ID.
-            if type -p xdo &>/dev/null; then
-                current_window="$(xdo id)"
+            elif type -p xwininfo &>/dev/null; then
+                # Get the focused window's ID.
+                if type -p xdo &>/dev/null; then
+                    current_window="$(xdo id)"
 
-            elif type -p xdpyinfo &>/dev/null; then
-                current_window="$(xdpyinfo | grep -F "focus:")"
-                current_window="${current_window/*window }"
-                current_window="${current_window/,*}"
+                elif type -p xdpyinfo &>/dev/null; then
+                    current_window="$(xdpyinfo | grep -F "focus:")"
+                    current_window="${current_window/*window }"
+                    current_window="${current_window/,*}"
 
-            elif type -p xprop &>/dev/null; then
-                current_window="$(xprop -root _NET_ACTIVE_WINDOW)"
-                current_window="${current_window##* }"
+                elif type -p xprop &>/dev/null; then
+                    current_window="$(xprop -root _NET_ACTIVE_WINDOW)"
+                    current_window="${current_window##* }"
+                fi
+
+                # If the ID was found get the window size.
+                if [[ "$current_window" ]]; then
+                    term_size="$(xwininfo -id "$current_window")"
+                    term_width="${term_size#*Width: }"
+                    term_width="${term_width/$'\n'*}"
+                    term_height="${term_size/*Height: }"
+                    term_height="${term_height/$'\n'*}"
+                fi
             fi
 
-            # If the ID was found get the window size.
-            if [[ "$current_window" ]]; then
-                term_size="$(xwininfo -id "$current_window")"
-                term_width="${term_size#*Width: }"
-                term_width="${term_width/$'\n'*}"
-                term_height="${term_size/*Height: }"
-                term_height="${term_height/$'\n'*}"
+        elif [[ "$term" == /dev/tty[0-9]* && -w "/dev/fb0" ]]; then
+            if type -p fbset &>/dev/null; then
+                [[ "$(fbset --show)" =~ .*\"([0-9]+x[0-9]+)\".* ]]
+                IFS=x read -r term_width term_height <<< "${BASH_REMATCH[1]}"
             fi
         fi
     fi
@@ -4190,7 +4201,6 @@ kde_config_dir() {
 
 term_padding() {
     # Get terminal padding to properly align cursor.
-    [[ -z "$term" ]] && get_term
 
     case "$term" in
         urxvt*|"rxvt-unicode")


### PR DESCRIPTION
Tested and confirmed to work with the `caca`, `chafa`, `jp2a`,  `pixterm`, and `w3m` backends, although `w3m` is the only one that actually uses the framebuffer as far as I know. The rest failing was not specific to the framebuffer or tty.