### PR TITLE
Robuster kitty font parsing

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2912,10 +2912,7 @@ END
             kitty_config="$(kitty --debug-config)"
             [[ "$kitty_config" != *font_family* ]] && return
 
-            term_font_size="${kitty_config/*font_size}"
-            term_font_size="${term_font_size/$'\n'*}"
-            term_font="${kitty_config/*font_family}"
-            term_font="${term_font/$'\n'*} $term_font_size"
+            term_font="$(awk '/^font_family|^font_size/ {printf $2 " "}' <<< "$kitty_config")"
         ;;
 
         "konsole" | "yakuake")


### PR DESCRIPTION
I've got a shortcut defined in kitty to change the font size. The relevant part of 'kitty --debug-config':
```
Changed shortcuts:
         shift+control+minus KeyAction(func='decrease_font_size', args=())
```
My neofetch output:
```
Terminal Font: Hack ', args=())
```
This commit changes the parsing to an awk pattern that only matches the start of lines in the debug output.
New output:
```
Terminal Font: Hack 8.9 
```