### PR TITLE
Massive quotes removal from safe string literals.

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -52,35 +52,35 @@ print_info() {
     info title
     info underline
 
-    info "OS" distro
-    info "Host" model
-    info "Kernel" kernel
-    info "Uptime" uptime
-    info "Packages" packages
-    info "Shell" shell
-    info "Resolution" resolution
-    info "DE" de
-    info "WM" wm
+    info OS distro
+    info Host model
+    info Kernel kernel
+    info Uptime uptime
+    info Packages packages
+    info Shell shell
+    info Resolution resolution
+    info DE de
+    info WM wm
     info "WM Theme" wm_theme
-    info "Theme" theme
-    info "Icons" icons
-    info "Terminal" term
+    info Theme theme
+    info Icons icons
+    info Terminal term
     info "Terminal Font" term_font
-    info "CPU" cpu
-    info "GPU" gpu
-    info "Memory" memory
+    info CPU cpu
+    info GPU gpu
+    info Memory memory
 
     # info "GPU Driver" gpu_driver  # Linux/macOS only
     # info "CPU Usage" cpu_usage
-    # info "Disk" disk
-    # info "Battery" battery
-    # info "Font" font
-    # info "Song" song
+    # info Disk disk
+    # info Battery battery
+    # info Font font
+    # info Song song
     # [[ "$player" ]] && prin "Music Player" "$player"
     # info "Local IP" local_ip
     # info "Public IP" public_ip
-    # info "Users" users
-    # info "Locale" locale  # This only works on glibc systems.
+    # info Users users
+    # info Locale locale  # This only works on glibc systems.
 
     info cols
 }
@@ -99,7 +99,7 @@ print_info() {
 # Example:
 # on:  '4.8.9-1-ARCH'
 # off: 'Linux 4.8.9-1-ARCH'
-kernel_shorthand="on"
+kernel_shorthand=on
 
 
 # Distro
@@ -111,7 +111,7 @@ kernel_shorthand="on"
 # Values:   'on', 'tiny', 'off'
 # Flag:     --distro_shorthand
 # Supports: Everything except Windows and Haiku
-distro_shorthand="off"
+distro_shorthand=off
 
 # Show/Hide OS Architecture.
 # Show 'x86_64', 'x86' and etc in 'Distro:' output.
@@ -123,7 +123,7 @@ distro_shorthand="off"
 # Example:
 # on:  'Arch Linux x86_64'
 # off: 'Arch Linux'
-os_arch="on"
+os_arch=on
 
 
 # Uptime
@@ -139,7 +139,7 @@ os_arch="on"
 # on:   '2 days, 10 hours, 3 mins'
 # tiny: '2d 10h 3m'
 # off:  '2 days, 10 hours, 3 minutes'
-uptime_shorthand="on"
+uptime_shorthand=on
 
 
 # Memory
@@ -154,7 +154,7 @@ uptime_shorthand="on"
 # Example:
 # on:   '1801MiB / 7881MiB (22%)'
 # off:  '1801MiB / 7881MiB'
-memory_percent="off"
+memory_percent=off
 
 
 # Packages
@@ -170,7 +170,7 @@ memory_percent="off"
 # on:   '998 (pacman), 8 (flatpak), 4 (snap)'
 # tiny: '908 (pacman, flatpak, snap)'
 # off:  '908'
-package_managers="on"
+package_managers=on
 
 
 # Shell
@@ -185,7 +185,7 @@ package_managers="on"
 # Example:
 # on:  '/bin/bash'
 # off: 'bash'
-shell_path="off"
+shell_path=off
 
 # Show $SHELL version
 #
@@ -196,7 +196,7 @@ shell_path="off"
 # Example:
 # on:  'bash 4.4.5'
 # off: 'bash'
-shell_version="on"
+shell_version=on
 
 
 # CPU
@@ -221,7 +221,7 @@ speed_type="bios_limit"
 # Example:
 # on:    'i7-6500U (4) @ 3.1GHz'
 # off:   'i7-6500U (4) @ 3.100GHz'
-speed_shorthand="off"
+speed_shorthand=off
 
 # Enable/Disable CPU brand in output.
 #
@@ -232,7 +232,7 @@ speed_shorthand="off"
 # Example:
 # on:   'Intel i7-6500U'
 # off:  'i7-6500U (4)'
-cpu_brand="on"
+cpu_brand=on
 
 # CPU Speed
 # Hide/Show CPU speed.
@@ -244,7 +244,7 @@ cpu_brand="on"
 # Example:
 # on:  'Intel i7-6500U (4) @ 3.1GHz'
 # off: 'Intel i7-6500U (4)'
-cpu_speed="on"
+cpu_speed=on
 
 # CPU Cores
 # Display CPU cores in output
@@ -258,7 +258,7 @@ cpu_speed="on"
 # logical:  'Intel i7-6500U (4) @ 3.1GHz' (All virtual cores)
 # physical: 'Intel i7-6500U (2) @ 3.1GHz' (All physical cores)
 # off:      'Intel i7-6500U @ 3.1GHz'
-cpu_cores="logical"
+cpu_cores=logical
 
 # CPU Temperature
 # Hide/Show CPU temperature.
@@ -275,7 +275,7 @@ cpu_cores="logical"
 # C:   'Intel i7-6500U (4) @ 3.1GHz [27.2°C]'
 # F:   'Intel i7-6500U (4) @ 3.1GHz [82.0°F]'
 # off: 'Intel i7-6500U (4) @ 3.1GHz'
-cpu_temp="off"
+cpu_temp=off
 
 
 # GPU
@@ -290,7 +290,7 @@ cpu_temp="off"
 # Example:
 # on:  'AMD HD 7950'
 # off: 'HD 7950'
-gpu_brand="on"
+gpu_brand=on
 
 # Which GPU to display
 #
@@ -309,7 +309,7 @@ gpu_brand="on"
 #
 # integrated:
 #   GPU1: Intel Integrated Graphics
-gpu_type="all"
+gpu_type=all
 
 
 # Resolution
@@ -324,7 +324,7 @@ gpu_type="all"
 # Example:
 # on:  '1920x1080 @ 60Hz'
 # off: '1920x1080'
-refresh_rate="off"
+refresh_rate=off
 
 
 # Gtk Theme / Icons / Font
@@ -339,7 +339,7 @@ refresh_rate="off"
 # Example:
 # on:  'Numix, Adwaita'
 # off: 'Numix [GTK2], Adwaita [GTK3]'
-gtk_shorthand="off"
+gtk_shorthand=off
 
 
 # Enable/Disable gtk2 Theme / Icons / Font
@@ -351,7 +351,7 @@ gtk_shorthand="off"
 # Example:
 # on:  'Numix [GTK2], Adwaita [GTK3]'
 # off: 'Adwaita [GTK3]'
-gtk2="on"
+gtk2=on
 
 # Enable/Disable gtk3 Theme / Icons / Font
 #
@@ -362,7 +362,7 @@ gtk2="on"
 # Example:
 # on:  'Numix [GTK2], Adwaita [GTK3]'
 # off: 'Numix [GTK2]'
-gtk3="on"
+gtk3=on
 
 
 # IP Address
@@ -422,7 +422,7 @@ disk_show=('/')
 # dir:    'Disk (/): 74G / 118G (66%)'
 #         'Disk (Local Disk): 74G / 118G (66%)'
 #         'Disk (Videos): 74G / 118G (66%)'
-disk_subtitle="mount"
+disk_subtitle=mount
 
 
 # Song
@@ -469,7 +469,7 @@ disk_subtitle="mount"
 # vlc
 # xmms2d
 # yarock
-music_player="auto"
+music_player=auto
 
 # Format to display song information.
 #
@@ -493,7 +493,7 @@ song_format="%artist% - %album% - %title%"
 #      'Song: Chelsea Dagger'
 #
 # off: 'Song: The Fratellis - Costello Music - Chelsea Dagger'
-song_shorthand="off"
+song_shorthand=off
 
 # 'mpc' arguments (specify a host, password etc).
 #
@@ -528,21 +528,21 @@ colors=(distro)
 # Default:  'on'
 # Values:   'on', 'off'
 # Flag:     --bold
-bold="on"
+bold=on
 
 # Enable/Disable Underline
 #
 # Default:  'on'
 # Values:   'on', 'off'
 # Flag:     --underline
-underline_enabled="on"
+underline_enabled=on
 
 # Underline character
 #
 # Default:  '-'
 # Values:   'string'
 # Flag:     --underline_char
-underline_char="-"
+underline_char=-
 
 
 # Info Separator
@@ -581,7 +581,7 @@ block_range=(0 7)
 # Default:  'on'
 # Values:   'on', 'off'
 # Flag:     --color_blocks
-color_blocks="on"
+color_blocks=on
 
 # Color block width in spaces
 #
@@ -610,7 +610,7 @@ block_height=1
 # Example:
 # neofetch --bar_char 'elapsed' 'total'
 # neofetch --bar_char '-' '='
-bar_char_elapsed="-"
+bar_char_elapsed=-
 bar_char_total="="
 
 # Toggle Bar border
@@ -618,7 +618,7 @@ bar_char_total="="
 # Default:  'on'
 # Values:   'on', 'off'
 # Flag:     --bar_border
-bar_border="on"
+bar_border=on
 
 # Progress bar length in spaces
 # Number of chars long to make the progress bars.
@@ -638,8 +638,8 @@ bar_length=15
 # Example:
 # neofetch --bar_colors 3 4
 # neofetch --bar_colors distro 5
-bar_color_elapsed="distro"
-bar_color_total="distro"
+bar_color_elapsed=distro
+bar_color_total=distro
 
 
 # Info display
@@ -657,10 +657,10 @@ bar_color_total="distro"
 # infobar: 'info [---=======]'
 # barinfo: '[---=======] info'
 # off:     'info'
-cpu_display="off"
-memory_display="off"
-battery_display="off"
-disk_display="off"
+cpu_display=off
+memory_display=off
+battery_display=off
+disk_display=off
 
 
 # Backend Settings
@@ -672,7 +672,7 @@ disk_display="off"
 # Values:   'ascii', 'caca', 'chafa', 'jp2a', 'iterm2', 'off',
 #           'termpix', 'pixterm', 'tycat', 'w3m', 'kitty'
 # Flag:     --backend
-image_backend="ascii"
+image_backend=ascii
 
 # Image Source
 #
@@ -686,7 +686,7 @@ image_backend="ascii"
 # NOTE: 'auto' will pick the best image source for whatever image backend is used.
 #       In ascii mode, distro ascii art will be used and in an image mode, your
 #       wallpaper will be used.
-image_source="auto"
+image_source=auto
 
 
 # Ascii Options
@@ -705,7 +705,7 @@ image_source="auto"
 #       Change this to 'Lubuntu', 'Xubuntu', 'Ubuntu-GNOME' or 'Ubuntu-Budgie' to use the flavors.
 # NOTE: Arch, Crux and Gentoo have a smaller logo variant.
 #       Change this to 'arch_small', 'crux_small' or 'gentoo_small' to use the small logos.
-ascii_distro="auto"
+ascii_distro=auto
 
 # Ascii Colors
 #
@@ -724,7 +724,7 @@ ascii_colors=(distro)
 # Default: 'on'
 # Values:  'on', 'off'
 # Flag:    --ascii_bold
-ascii_bold="on"
+ascii_bold=on
 
 
 # Image Options
@@ -737,7 +737,7 @@ ascii_bold="on"
 # Default:  'off'
 # Values:   'on', 'off'
 # Flag:     --loop
-image_loop="off"
+image_loop=off
 
 # Thumbnail directory
 #
@@ -753,7 +753,7 @@ thumbnail_dir="${XDG_CACHE_HOME:-${HOME}/.cache}/thumbnails/neofetch"
 #
 # See this wiki page to learn about the fit and fill options.
 # https://github.com/dylanaraps/neofetch/wiki/What-is-Waifu-Crop%3F
-crop_mode="normal"
+crop_mode=normal
 
 # Crop offset
 # Note: Only affects 'normal' crop mode.
@@ -762,7 +762,7 @@ crop_mode="normal"
 # Values:   'northwest', 'north', 'northeast', 'west', 'center'
 #           'east', 'southwest', 'south', 'southeast'
 # Flag:     --crop_offset
-crop_offset="center"
+crop_offset=center
 
 # Image size
 # The image is half the terminal width by default.
@@ -771,7 +771,7 @@ crop_offset="center"
 # Values:  'auto', '00px', '00%', 'none'
 # Flags:   --image_size
 #          --size
-image_size="auto"
+image_size=auto
 
 # Gap between image and text
 #
@@ -806,7 +806,7 @@ background_color=
 # Useful for piping into another command.
 # Default: 'off'
 # Values: 'on', 'off'
-stdout="off"
+stdout=off
 EOF
 
 # DETECT INFORMATION
@@ -848,49 +848,49 @@ get_distro() {
     [[ "$distro" ]] && return
 
     case "$os" in
-        "Linux" | "BSD" | "MINIX")
-            if [[ -f "/bedrock/etc/bedrock-release" && "$PATH" == */bedrock/cross/* ]]; then
+        Linux | BSD | MINIX)
+            if [[ -f /bedrock/etc/bedrock-release && "$PATH" == */bedrock/cross/* ]]; then
                 case "$distro_shorthand" in
-                    "on" | "tiny") distro="Bedrock Linux" ;;
+                    on | tiny) distro="Bedrock Linux" ;;
                     *) distro="$(< /bedrock/etc/bedrock-release)"
                 esac
-            elif [[ -f "/etc/redstar-release" ]]; then
+            elif [[ -f /etc/redstar-release ]]; then
                 case "$distro_shorthand" in
-                    "on" | "tiny") distro="Red Star OS" ;;
+                    on | tiny) distro="Red Star OS" ;;
                     *) distro="Red Star OS $(awk -F'[^0-9*]' '$0=$2' /etc/redstar-release)"
                 esac
 
-            elif [[ -f "/etc/siduction-version" ]]; then
+            elif [[ -f /etc/siduction-version ]]; then
                 case "$distro_shorthand" in
-                    "on" | "tiny") distro="Siduction" ;;
+                    on | tiny) distro=Siduction ;;
                     *) distro="Siduction ($(lsb_release -sic))"
                 esac
 
             elif type -p lsb_release >/dev/null; then
                 case "$distro_shorthand" in
-                    "on")   lsb_flags="-sir" ;;
-                    "tiny") lsb_flags="-si" ;;
-                    *)      lsb_flags="-sd" ;;
+                    on)   lsb_flags=-sir ;;
+                    tiny) lsb_flags=-si ;;
+                    *)      lsb_flags=-sd ;;
                 esac
                 distro="$(lsb_release "$lsb_flags")"
 
-            elif [[ -f "/etc/GoboLinuxVersion" ]]; then
+            elif [[ -f /etc/GoboLinuxVersion ]]; then
                 case "$distro_shorthand" in
-                    "on" | "tiny") distro="GoboLinux" ;;
+                    on | tiny) distro=GoboLinux ;;
                     *) distro="GoboLinux $(< /etc/GoboLinuxVersion)"
                 esac
 
             elif type -p guix >/dev/null; then
                 case "$distro_shorthand" in
-                    "on" | "tiny") distro="GuixSD" ;;
+                    on | tiny) distro=GuixSD ;;
                     *) distro="GuixSD $(guix system -V | awk 'NR==1{printf $5}')"
                 esac
 
             elif type -p crux >/dev/null; then
                 distro="$(crux)"
                 case "$distro_shorthand" in
-                    "on")   distro="${distro//version}" ;;
-                    "tiny") distro="${distro//version*}" ;;
+                    on)   distro="${distro//version}" ;;
+                    tiny) distro="${distro//version*}" ;;
                 esac
 
             elif type -p tazpkg >/dev/null; then
@@ -898,21 +898,21 @@ get_distro() {
 
             elif type -p kpt >/dev/null && \
                  type -p kpm >/dev/null; then
-                distro="KSLinux"
+                distro=KSLinux
 
-            elif [[ -d "/system/app/" && -d "/system/priv-app" ]]; then
+            elif [[ -d /system/app/ && -d /system/priv-app ]]; then
                 distro="Android $(getprop ro.build.version.release)"
 
             # Chrome OS doesn't conform to the /etc/*-release standard.
             # While the file is a series of variables they can't be sourced
             # by the shell since the values aren't quoted.
-            elif [[ -f "/etc/lsb-release" && "$(< /etc/lsb-release)" == *CHROMEOS* ]]; then
+            elif [[ -f /etc/lsb-release && "$(< /etc/lsb-release)" == *CHROMEOS* ]]; then
                 distro="$(awk -F '=' '/NAME|VERSION/ {printf $2 " "}' /etc/lsb-release)"
 
-            elif [[ -f "/etc/os-release" || \
-                    -f "/usr/lib/os-release" || \
+            elif [[ -f /etc/os-release || \
+                    -f /usr/lib/os-release || \
                     -f "/etc/openwrt_release" ]]; then
-                files=("/etc/os-release" "/usr/lib/os-release" "/etc/openwrt_release")
+                files=(/etc/os-release /usr/lib/os-release "/etc/openwrt_release")
 
                 # Source the os-release file
                 for file in "${files[@]}"; do
@@ -921,9 +921,9 @@ get_distro() {
 
                 # Format the distro name.
                 case "$distro_shorthand" in
-                    "on")   distro="${NAME:-${DISTRIB_ID}} ${VERSION_ID:-${DISTRIB_RELEASE}}" ;;
-                    "tiny") distro="${NAME:-${DISTRIB_ID:-${TAILS_PRODUCT_NAME}}}" ;;
-                    "off")  distro="${PRETTY_NAME:-${DISTRIB_DESCRIPTION}} ${UBUNTU_CODENAME}" ;;
+                    on)   distro="${NAME:-${DISTRIB_ID}} ${VERSION_ID:-${DISTRIB_RELEASE}}" ;;
+                    tiny) distro="${NAME:-${DISTRIB_ID:-${TAILS_PRODUCT_NAME}}}" ;;
+                    off)  distro="${PRETTY_NAME:-${DISTRIB_DESCRIPTION}} ${UBUNTU_CODENAME}" ;;
                 esac
             else
                 for release_file in /etc/*-release; do
@@ -932,31 +932,31 @@ get_distro() {
 
                 if [[ -z "$distro" ]]; then
                     case "$distro_shorthand" in
-                        "on" | "tiny") distro="$kernel_name" ;;
+                        on | tiny) distro="$kernel_name" ;;
                         *) distro="$kernel_name $kernel_version" ;;
                     esac
                     distro="${distro/DragonFly/DragonFlyBSD}"
 
                     # Workarounds for FreeBSD based distros.
-                    [[ -f "/etc/pcbsd-lang" ]] &&  distro="PCBSD"
-                    [[ -f "/etc/trueos-lang" ]] && distro="TrueOS"
+                    [[ -f /etc/pcbsd-lang ]] &&  distro=PCBSD
+                    [[ -f /etc/trueos-lang ]] && distro=TrueOS
 
                     # /etc/pacbsd-release is an empty file
-                    [[ -f "/etc/pacbsd-release" ]] && distro="PacBSD"
+                    [[ -f /etc/pacbsd-release ]] && distro=PacBSD
                 fi
             fi
 
             if [[ "$(< /proc/version)" == *Microsoft* || "$kernel_version" == *Microsoft* ]]; then
                 case "$distro_shorthand" in
-                    "on")   distro+=" [Windows 10]" ;;
-                    "tiny") distro="Windows 10" ;;
+                    on)   distro+=" [Windows 10]" ;;
+                    tiny) distro="Windows 10" ;;
                     *)      distro+=" on Windows 10" ;;
                 esac
 
             elif [[ "$(< /proc/version)" == *chrome-bot* || -f "/dev/cros_ec" ]]; then
                 case "$distro_shorthand" in
-                    "on")   distro+=" [Chrome OS]" ;;
-                    "tiny") distro="Chrome OS" ;;
+                    on)   distro+=" [Chrome OS]" ;;
+                    tiny) distro="Chrome OS" ;;
                     *)      distro+=" on Chrome OS" ;;
                 esac
             fi
@@ -978,13 +978,13 @@ get_distro() {
                 "10.12"*) codename="macOS Sierra" ;;
                 "10.13"*) codename="macOS High Sierra" ;;
                 "10.14"*) codename="macOS Mojave" ;;
-                *)        codename="macOS" ;;
+                *)        codename=macOS ;;
             esac
             distro="$codename $osx_version $osx_build"
 
             case "$distro_shorthand" in
-                "on") distro="${distro/ ${osx_build}}" ;;
-                "tiny")
+                on) distro="${distro/ ${osx_build}}" ;;
+                tiny)
                     case "$osx_version" in
                         "10."[4-7]*)                distro="${distro/${codename}/Mac OS X}" ;;
                         "10."[8-9]* | "10.1"[0-1]*) distro="${distro/${codename}/OS X}" ;;
@@ -999,38 +999,38 @@ get_distro() {
             distro="iOS $osx_version"
 
             # "uname -m" doesn't print architecture on iOS so we force it off.
-            os_arch="off"
+            os_arch=off
         ;;
 
-        "Windows")
+        Windows)
             distro="$(wmic os get Caption)"
             distro="${distro/Caption}"
             distro="${distro/Microsoft }"
         ;;
 
-        "Solaris")
+        Solaris)
             case "$distro_shorthand" in
-                "on" | "tiny") distro="$(awk 'NR==1 {print $1,$3}' /etc/release)" ;;
+                on | tiny) distro="$(awk 'NR==1 {print $1,$3}' /etc/release)" ;;
                 *)             distro="$(awk 'NR==1 {print $1,$2,$3}' /etc/release)" ;;
             esac
             distro="${distro/\(*}"
         ;;
 
-        "Haiku")
+        Haiku)
             read -r name version _ < <(uname -sv)
             distro="$name $version"
         ;;
 
-        "AIX")
+        AIX)
             distro="AIX $(oslevel)"
         ;;
 
-        "IRIX")
+        IRIX)
             distro="IRIX ${kernel_version}"
         ;;
 
-        "FreeMiNT")
-            distro="FreeMiNT"
+        FreeMiNT)
+            distro=FreeMiNT
         ;;
     esac
 
@@ -1040,22 +1040,22 @@ get_distro() {
 
     # Get OS architecture.
     case "$os" in
-        "Solaris" | "AIX" | "Haiku" | "IRIX" | "FreeMiNT")
+        Solaris | AIX | Haiku | IRIX | FreeMiNT)
             machine_arch="$(uname -p)" ;;
         *)  machine_arch="$kernel_machine" ;;
     esac
 
-    [[ "$os_arch" == "on" ]] && \
+    [[ "$os_arch" == on ]] && \
         distro+=" $machine_arch"
 
-    [[ "${ascii_distro:-auto}" == "auto" ]] && \
+    [[ "${ascii_distro:-auto}" == auto ]] && \
         ascii_distro="$(trim "$distro")"
 }
 
 get_model() {
     case "$os" in
-        "Linux")
-            if [[ -d "/system/app/" && -d "/system/priv-app" ]]; then
+        Linux)
+            if [[ -d /system/app/ && -d /system/priv-app ]]; then
                 model="$(getprop ro.product.brand) $(getprop ro.product.model)"
 
             elif [[ -f "/sys/devices/virtual/dmi/id/product_name" ||
@@ -1063,16 +1063,16 @@ get_model() {
                 model="$(< /sys/devices/virtual/dmi/id/product_name)"
                 model+=" $(< /sys/devices/virtual/dmi/id/product_version)"
 
-            elif [[ -f "/sys/firmware/devicetree/base/model" ]]; then
+            elif [[ -f /sys/firmware/devicetree/base/model ]]; then
                 model="$(< /sys/firmware/devicetree/base/model)"
 
-            elif [[ -f "/tmp/sysinfo/model" ]]; then
+            elif [[ -f /tmp/sysinfo/model ]]; then
                 model="$(< /tmp/sysinfo/model)"
             fi
         ;;
 
         "Mac OS X")
-            if [[ "$(kextstat | grep -F -e "FakeSMC" -e "VirtualSMC")" != "" ]]; then
+            if [[ "$(kextstat | grep -F -e FakeSMC -e VirtualSMC)" != "" ]]; then
                 model="Hackintosh (SMBIOS: $(sysctl -n hw.model))"
             else
                 model="$(sysctl -n hw.model)"
@@ -1081,7 +1081,7 @@ get_model() {
 
         "iPhone OS")
             case "$kernel_machine" in
-                "iPad1,1"):     "iPad" ;;
+                "iPad1,1"):     iPad ;;
                 "iPad2,"[1-4]): "iPad 2" ;;
                 "iPad3,"[1-3]): "iPad 3" ;;
                 "iPad3,"[4-6]): "iPad 4" ;;
@@ -1100,7 +1100,7 @@ get_model() {
                     : "iPad 5"
                 ;;
 
-                "iPhone1,1"):     "iPhone" ;;
+                "iPhone1,1"):     iPhone ;;
                 "iPhone1,2"):     "iPhone 3G" ;;
                 "iPhone2,1"):     "iPhone 3GS" ;;
                 "iPhone3,"[1-3]): "iPhone 4" ;;
@@ -1130,25 +1130,25 @@ get_model() {
             model="$_"
         ;;
 
-        "BSD" | "MINIX")
+        BSD | MINIX)
             model="$(sysctl -n hw.vendor hw.product)"
         ;;
 
-        "Windows")
+        Windows)
             model="$(wmic computersystem get manufacturer,model)"
             model="${model/Manufacturer}"
             model="${model/Model}"
         ;;
 
-        "Solaris")
+        Solaris)
             model="$(prtconf -b | awk -F':' '/banner-name/ {printf $2}')"
         ;;
 
-        "AIX")
+        AIX)
             model="$(/usr/bin/uname -M)"
         ;;
 
-        "FreeMiNT")
+        FreeMiNT)
             model="$(sysctl -n hw.model)"
         ;;
     esac
@@ -1169,7 +1169,7 @@ get_model() {
 
     case "$model" in
         "Standard PC"*) model="KVM/QEMU (${model})" ;;
-        "OpenBSD"*)     model="vmm ($model)" ;;
+        OpenBSD*)     model="vmm ($model)" ;;
     esac
 }
 
@@ -1185,14 +1185,14 @@ get_kernel() {
     [[ "$os" =~ (AIX|IRIX) ]] && return
 
     case "$kernel_shorthand" in
-        "on")  kernel="$kernel_version" ;;
-        "off") kernel="$kernel_name $kernel_version" ;;
+        on)  kernel="$kernel_version" ;;
+        off) kernel="$kernel_name $kernel_version" ;;
     esac
 
     # Hide kernel info if it's identical to the distro info.
     if [[ "$os" =~ (BSD|MINIX) && "$distro" == *"$kernel_name"* ]]; then
         case "$distro_shorthand" in
-            "on" | "tiny") kernel="$kernel_version" ;;
+            on | tiny) kernel="$kernel_version" ;;
             *)             unset kernel ;;
         esac
     fi
@@ -1202,7 +1202,7 @@ get_uptime() {
     # Since Haiku's uptime cannot be fetched in seconds, a case outside
     # the usual case is needed.
     case "$os" in
-        "Haiku")
+        Haiku)
             uptime="$(uptime -u)"
             uptime="${uptime/up }"
         ;;
@@ -1210,12 +1210,12 @@ get_uptime() {
         *)
             # Get uptime in seconds.
             case "$os" in
-                "Linux" | "Windows" | "MINIX")
+                Linux | Windows | MINIX)
                     seconds="$(< /proc/uptime)"
                     seconds="${seconds/.*}"
                 ;;
 
-                "Mac OS X" | "iPhone OS" | "BSD" | "FreeMiNT")
+                "Mac OS X" | "iPhone OS" | BSD | FreeMiNT)
                     boot="$(sysctl -n kern.boottime)"
                     boot="${boot/\{ sec = }"
                     boot="${boot/,*}"
@@ -1225,15 +1225,15 @@ get_uptime() {
                     seconds="$((now - boot))"
                 ;;
 
-                "Solaris")
+                Solaris)
                     seconds="$(kstat -p unix:0:system_misc:snaptime | awk '{print $2}')"
                     seconds="${seconds/.*}"
                 ;;
 
-                "AIX" | "IRIX")
+                AIX | IRIX)
                     t="$(LC_ALL=POSIX ps -o etime= -p 1)"
-                    d="0" h="0"
-                    case "$t" in *"-"*) d="${t%%-*}"; t="${t#*-}";; esac
+                    d=0 h=0
+                    case "$t" in *-*) d="${t%%-*}"; t="${t#*-}";; esac
                     case "$t" in *":"*":"*) h="${t%%:*}"; t="${t#*:}";; esac
                     h="${h#0}" t="${t#0}"
                     seconds="$((d*86400 + h*3600 + ${t%%:*}*60 + ${t#*:}))"
@@ -1262,13 +1262,13 @@ get_uptime() {
 
     # Make the output of uptime smaller.
     case "$uptime_shorthand" in
-        "on")
+        on)
             uptime="${uptime/minutes/mins}"
             uptime="${uptime/minute/min}"
             uptime="${uptime/seconds/secs}"
         ;;
 
-        "tiny")
+        tiny)
             uptime="${uptime/ days/d}"
             uptime="${uptime/ day/d}"
             uptime="${uptime/ hours/h}"
@@ -1292,7 +1292,7 @@ get_packages() {
     tot() { IFS=$'\n' read -d "" -ra pkgs < <("$@");((packages+="${#pkgs[@]}"));pac "${#pkgs[@]}"; }
 
     # Redefine tot() for Bedrock Linux.
-    [[ -f "/bedrock/etc/bedrock-release" && "$PATH" == */bedrock/cross/* ]] && {
+    [[ -f /bedrock/etc/bedrock-release && "$PATH" == */bedrock/cross/* ]] && {
         tot() {
             IFS=$'\n' read -d "" -ra pkgs < <(for s in $(brl list); do strat -r "$s" "$@"; done)
             ((packages+="${#pkgs[@]}"))
@@ -1302,97 +1302,97 @@ get_packages() {
     }
 
     case "$os" in
-        "Linux" | "BSD" | "iPhone OS" | "Solaris")
+        Linux | BSD | "iPhone OS" | Solaris)
             # Package Manager Programs.
-            has "pacman-key" && tot pacman -Qq --color never
-            has "dpkg"       && tot dpkg-query -f '.\n' -W
-            has "rpm"        && tot rpm -qa
-            has "xbps-query" && tot xbps-query -l
-            has "apk"        && tot apk info
-            has "opkg"       && tot opkg list-installed
-            has "pacman-g2"  && tot pacman-g2 -Q
-            has "lvu"        && tot lvu installed
-            has "tce-status" && tot tce-status -i
-            has "pkg_info"   && tot pkg_info
-            has "tazpkg"     && tot tazpkg list && ((packages-=6))
-            has "sorcery"    && tot gaze installed
-            has "alps"       && tot alps showinstalled
-            has "butch"      && tot butch list
+            has pacman-key && tot pacman -Qq --color never
+            has dpkg       && tot dpkg-query -f '.\n' -W
+            has rpm        && tot rpm -qa
+            has xbps-query && tot xbps-query -l
+            has apk        && tot apk info
+            has opkg       && tot opkg list-installed
+            has pacman-g2  && tot pacman-g2 -Q
+            has lvu        && tot lvu installed
+            has tce-status && tot tce-status -i
+            has pkg_info   && tot pkg_info
+            has tazpkg     && tot tazpkg list && ((packages-=6))
+            has sorcery    && tot gaze installed
+            has alps       && tot alps showinstalled
+            has butch      && tot butch list
 
             # Counting files/dirs.
             # Variables need to be unquoted here. Only Bedrock Linux is affected.
             # $br_prefix is fixed and won't change based on user input so this is safe either way.
             # shellcheck disable=SC2086
             {
-            has "emerge"  && dir ${br_prefix}/var/db/pkg/*/*/
-            has "nix-env" && dir ${br_prefix}/nix/store/*/
-            has "guix"    && dir ${br_prefix}/gnu/store/*/
-            has "Compile" && dir ${br_prefix}/Programs/*/
-            has "eopkg"   && dir ${br_prefix}/var/lib/eopkg/package/*
-            has "crew"    && dir ${br_prefix}/usr/local/etc/crew/meta/*.filelist
-            has "pkgtool" && dir ${br_prefix}/var/log/packages/*
-            has "cave"    && dir ${br_prefix}/var/db/paludis/repositories/cross-installed/*/data/*/ \
+            has emerge  && dir ${br_prefix}/var/db/pkg/*/*/
+            has nix-env && dir ${br_prefix}/nix/store/*/
+            has guix    && dir ${br_prefix}/gnu/store/*/
+            has Compile && dir ${br_prefix}/Programs/*/
+            has eopkg   && dir ${br_prefix}/var/lib/eopkg/package/*
+            has crew    && dir ${br_prefix}/usr/local/etc/crew/meta/*.filelist
+            has pkgtool && dir ${br_prefix}/var/log/packages/*
+            has cave    && dir ${br_prefix}/var/db/paludis/repositories/cross-installed/*/data/*/ \
                                  ${br_prefix}/var/db/paludis/repositories/installed/data/*/
             }
 
             # Other (Needs complex command)
-            has "kpm-pkg" && ((packages+="$(kpm  --get-selections | grep -cv deinstall$)"))
+            has kpm-pkg && ((packages+="$(kpm  --get-selections | grep -cv deinstall$)"))
 
             # pkginfo is also the name of a python package manager which is painfully slow.
             # TODO: Fix this somehow.
             has pkginfo && tot pkginfo -i
 
             case "$kernel_name" in
-                "FreeBSD") has "pkg" && tot pkg info ;;
+                FreeBSD) has pkg && tot pkg info ;;
                 *)
-                    has "pkg" && dir /var/db/pkg/*
+                    has pkg && dir /var/db/pkg/*
 
                     ((packages == 0)) && \
-                        has "pkg" && tot pkg list
+                        has pkg && tot pkg list
                 ;;
             esac
 
             # List these last as they accompany regular package managers.
-            has "flatpak" && tot flatpak list
-            has "spm"     && tot spm list -i
-            has "puyo"    && dir ~/.puyo/installed
+            has flatpak && tot flatpak list
+            has spm     && tot spm list -i
+            has puyo    && dir ~/.puyo/installed
 
             # Snap hangs if the command is run without the daemon running.
             # Only run snap if the daemon is also running.
-            has "snap" && ps -e | grep -qFm 1 "snapd" >/dev/null && tot snap list && ((packages-=1))
+            has snap && ps -e | grep -qFm 1 snapd >/dev/null && tot snap list && ((packages-=1))
         ;;
 
-        "Mac OS X" | "MINIX")
-            has "port"    && tot port installed && ((packages-=1))
-            has "brew"    && dir /usr/local/Cellar/*
-            has "pkgin"   && tot pkgin list
-            has "nix-env" && dir /nix/store/*/
+        "Mac OS X" | MINIX)
+            has port    && tot port installed && ((packages-=1))
+            has brew    && dir /usr/local/Cellar/*
+            has pkgin   && tot pkgin list
+            has nix-env && dir /nix/store/*/
         ;;
 
-        "AIX"| "FreeMiNT")
-            has "lslpp" && ((packages+="$(lslpp -J -l -q | grep -cv '^#')"))
-            has "rpm"   && tot rpm -qa
+        AIX| FreeMiNT)
+            has lslpp && ((packages+="$(lslpp -J -l -q | grep -cv '^#')"))
+            has rpm   && tot rpm -qa
         ;;
 
-        "Windows")
+        Windows)
             case "$kernel_name" in
-                "CYGWIN"*) has "cygcheck" && tot cygcheck -cd ;;
-                "MSYS"*)   has "pacman"   && tot pacman -Qq --color never ;;
+                CYGWIN*) has cygcheck && tot cygcheck -cd ;;
+                MSYS*)   has pacman   && tot pacman -Qq --color never ;;
             esac
 
             # Scoop environment throws errors if `tot scoop list` is used
-            has "scoop" && dir ~/scoop/apps/* && ((packages-=1))
+            has scoop && dir ~/scoop/apps/* && ((packages-=1))
 
             # Count chocolatey packages.
-            [[ -d "/cygdrive/c/ProgramData/chocolatey/lib" ]] && \
+            [[ -d /cygdrive/c/ProgramData/chocolatey/lib ]] && \
                 dir /cygdrive/c/ProgramData/chocolatey/lib/*
         ;;
 
-        "Haiku")
-            has "pkgman" && dir /boot/system/package-links/*
+        Haiku)
+            has pkgman && dir /boot/system/package-links/*
         ;;
 
-        "IRIX")
+        IRIX)
             tot versions -b && ((packages-=3))
         ;;
     esac
@@ -1400,11 +1400,11 @@ get_packages() {
     if ((packages == 0)); then
         unset packages
 
-    elif [[ "$package_managers" == "on" ]]; then
+    elif [[ "$package_managers" == on ]]; then
         printf -v packages '%s, ' "${managers[@]}"
         packages="${packages%,*}"
 
-    elif [[ "$package_managers" == "tiny" ]]; then
+    elif [[ "$package_managers" == tiny ]]; then
         packages+=" (${manager_string%,*})"
     fi
 
@@ -1414,22 +1414,22 @@ get_packages() {
 
 get_shell() {
     case "$shell_path" in
-        "on")  shell="$SHELL " ;;
-        "off") shell="${SHELL##*/} " ;;
+        on)  shell="$SHELL " ;;
+        off) shell="${SHELL##*/} " ;;
     esac
 
-    if [[ "$shell_version" == "on" ]]; then
+    if [[ "$shell_version" == on ]]; then
         case "${shell_name:=${SHELL##*/}}" in
-            "bash") shell+="${BASH_VERSION/-*}" ;;
-            "sh" | "ash" | "dash") ;;
+            bash) shell+="${BASH_VERSION/-*}" ;;
+            sh | ash | dash) ;;
 
-            "mksh" | "ksh")
+            mksh | ksh)
                 shell+="$("$SHELL" -c "printf %s \"\$KSH_VERSION\"")"
                 shell="${shell/ * KSH}"
                 shell="${shell/version}"
             ;;
 
-            "tcsh")
+            tcsh)
                 shell+="$("$SHELL" -c "printf %s \$tcsh")"
             ;;
 
@@ -1452,23 +1452,23 @@ get_de() {
     ((de_run == 1)) && return
 
     case "$os" in
-        "Mac OS X") de="Aqua" ;;
-        "Windows")
+        "Mac OS X") de=Aqua ;;
+        Windows)
             case "$distro" in
                 "Windows 8"* | "Windows 10"*) de="Modern UI/Metro" ;;
-                *) de="Aero" ;;
+                *) de=Aero ;;
             esac
         ;;
 
-        "FreeMiNT")
+        FreeMiNT)
             freemint_wm=(/proc/*)
             case "${freemint_wm[*]}" in
-                *thing*)  de="Thing" ;;
-                *jinnee*) de="Jinnee" ;;
-                *tera*)   de="Teradesk" ;;
-                *neod*)   de="NeoDesk" ;;
-                *zdesk*)  de="zDesk" ;;
-                *mdesk*)  de="mDesk" ;;
+                *thing*)  de=Thing ;;
+                *jinnee*) de=Jinnee ;;
+                *tera*)   de=Teradesk ;;
+                *neod*)   de=NeoDesk ;;
+                *zdesk*)  de=zDesk ;;
+                *mdesk*)  de=mDesk ;;
             esac
         ;;
 
@@ -1484,13 +1484,13 @@ get_de() {
                 de="${DESKTOP_SESSION##*/}"
 
             elif [[ "$GNOME_DESKTOP_SESSION_ID" ]]; then
-                de="GNOME"
+                de=GNOME
 
             elif [[ "$MATE_DESKTOP_SESSION_ID" ]]; then
-                de="MATE"
+                de=MATE
 
             elif [[ "$TDE_FULL_SESSION" ]]; then
-                de="Trinity"
+                de=Trinity
             fi
 
             # When a window manager is started from a display manager
@@ -1508,16 +1508,16 @@ get_de() {
     # Format strings.
     case "$de" in
         "KDE_SESSION_VERSION"*) de="KDE${de/* = }" ;;
-        *"xfce4"*) de="Xfce4" ;;
-        *"xfce5"*) de="Xfce5" ;;
-        *"xfce"*)  de="Xfce" ;;
-        *"mate"*)  de="MATE" ;;
+        *xfce4*) de=Xfce4 ;;
+        *xfce5*) de=Xfce5 ;;
+        *xfce*)  de=Xfce ;;
+        *mate*)  de=MATE ;;
 
-        *"MUFFIN"* | "Cinnamon")
+        *MUFFIN* | Cinnamon)
             de="$(cinnamon --version)"; de="${de:-Cinnamon}"
         ;;
 
-        *"GNOME"*)
+        *GNOME*)
             de="$(gnome-shell --version)"
             de="${de/Shell }"
         ;;
@@ -1532,39 +1532,39 @@ get_wm() {
     ((wm_run == 1)) && return
 
     case "$uname" in
-        *"OpenBSD"*) ps_flags=(x -c) ;;
+        *OpenBSD*) ps_flags=(x -c) ;;
         *)           ps_flags=(-e) ;;
     esac
 
     if [[ "$WAYLAND_DISPLAY" ]]; then
         wm="$(ps "${ps_flags[@]}" | grep -m 1 -o -F \
-                           -e "arcan" \
-                           -e "asc" \
-                           -e "clayland" \
-                           -e "dwc" \
-                           -e "fireplace" \
-                           -e "greenfield" \
-                           -e "grefsen" \
-                           -e "lipstick" \
-                           -e "maynard" \
-                           -e "mazecompositor" \
-                           -e "motorcar" \
-                           -e "orbital" \
-                           -e "orbment" \
-                           -e "perceptia" \
-                           -e "rustland" \
-                           -e "sway" \
-                           -e "ulubis" \
-                           -e "velox" \
-                           -e "wavy" \
-                           -e "way-cooler" \
-                           -e "wayfire" \
-                           -e "wayhouse" \
-                           -e "westeros" \
-                           -e "westford" \
-                           -e "weston")"
+                           -e arcan \
+                           -e asc \
+                           -e clayland \
+                           -e dwc \
+                           -e fireplace \
+                           -e greenfield \
+                           -e grefsen \
+                           -e lipstick \
+                           -e maynard \
+                           -e mazecompositor \
+                           -e motorcar \
+                           -e orbital \
+                           -e orbment \
+                           -e perceptia \
+                           -e rustland \
+                           -e sway \
+                           -e ulubis \
+                           -e velox \
+                           -e wavy \
+                           -e way-cooler \
+                           -e wayfire \
+                           -e wayhouse \
+                           -e westeros \
+                           -e westford \
+                           -e weston)"
 
-    elif [[ "$DISPLAY" && "$os" != "Mac OS X" && "$os" != "FreeMiNT" ]]; then
+    elif [[ "$DISPLAY" && "$os" != "Mac OS X" && "$os" != FreeMiNT ]]; then
         if type -p xprop &>/dev/null; then
             id="$(xprop -root -notype _NET_SUPPORTING_WM_CHECK)"
             id="${id##* }"
@@ -1575,18 +1575,18 @@ get_wm() {
         fi
 
         # Rename window managers to their proper values.
-        [[ "$wm" =~ "WINDOWMAKER" ]] && wm="wmaker"
-        [[ "$wm" =~ "GNOME Shell" ]] && wm="Mutter"
+        [[ "$wm" =~ WINDOWMAKER ]] && wm=wmaker
+        [[ "$wm" =~ "GNOME Shell" ]] && wm=Mutter
 
         # Fallback for non-EWMH WMs.
         [[ -z "$wm" ]] && \
             wm="$(ps "${ps_flags[@]}" | grep -m 1 -o -F \
-                               -e "catwm" \
-                               -e "fvwm" \
-                               -e "dwm" \
-                               -e "2bwm" \
-                               -e "monsterwm" \
-                               -e "tinywm")"
+                               -e catwm \
+                               -e fvwm \
+                               -e dwm \
+                               -e 2bwm \
+                               -e monsterwm \
+                               -e tinywm)"
 
     else
         case "$os" in
@@ -1594,33 +1594,33 @@ get_wm() {
                 ps_line="$(ps -e | grep -o '[S]pectacle\|[A]methyst\|[k]wm\|[c]hun[k]wm')"
 
                 case "$ps_line" in
-                    *"chunkwm"*)   wm="chunkwm" ;;
-                    *"kwm"*)       wm="Kwm" ;;
-                    *"Amethyst"*)  wm="Amethyst" ;;
-                    *"Spectacle"*) wm="Spectacle" ;;
+                    *chunkwm*)   wm=chunkwm ;;
+                    *kwm*)       wm=Kwm ;;
+                    *Amethyst*)  wm=Amethyst ;;
+                    *Spectacle*) wm=Spectacle ;;
                     *)             wm="Quartz Compositor" ;;
                 esac
             ;;
 
-            "Windows")
+            Windows)
                 wm="$(tasklist | grep -m 1 -o -F \
-                                      -e "bugn" \
-                                      -e "Windawesome" \
-                                      -e "blackbox" \
-                                      -e "emerge" \
-                                      -e "litestep")"
+                                      -e bugn \
+                                      -e Windawesome \
+                                      -e blackbox \
+                                      -e emerge \
+                                      -e litestep)"
 
-                [[ "$wm" == "blackbox" ]] && wm="bbLean (Blackbox)"
+                [[ "$wm" == blackbox ]] && wm="bbLean (Blackbox)"
                 wm="${wm:+$wm, }Explorer"
             ;;
 
-            "FreeMiNT")
+            FreeMiNT)
                 freemint_wm=(/proc/*)
                 case "${freemint_wm[*]}" in
-                    *xaaes*) wm="XaAES" ;;
-                    *myaes*) wm="MyAES" ;;
+                    *xaaes*) wm=XaAES ;;
+                    *myaes*) wm=MyAES ;;
                     *naes*)  wm="N.AES" ;;
-                    geneva)  wm="Geneva" ;;
+                    geneva)  wm=Geneva ;;
                     *)       wm="Atari AES" ;;
                 esac
             ;;
@@ -1636,22 +1636,22 @@ get_wm_theme() {
     ((de_run != 1)) && get_de
 
     case "$wm"  in
-        "E16")
+        E16)
             wm_theme="$(awk -F "= " '/theme.name/ {print $2}' "${HOME}/.e16/e_config--0.0.cfg")"
         ;;
 
-        "Sawfish")
+        Sawfish)
             wm_theme="$(awk -F '\\(quote|\\)' '/default-frame-style/ {print $(NF-4)}' \
                         "${HOME}/.sawfish/custom")"
         ;;
 
-        "Cinnamon" | "Muffin" | "Mutter (Muffin)")
+        Cinnamon | Muffin | "Mutter (Muffin)")
             detheme="$(gsettings get org.cinnamon.theme name)"
             wm_theme="$(gsettings get org.cinnamon.desktop.wm.preferences theme)"
             wm_theme="$detheme (${wm_theme})"
         ;;
 
-        "Compiz" | "Mutter" | "GNOME Shell" | "Gala")
+        Compiz | Mutter | "GNOME Shell" | Gala)
             if type -p gsettings >/dev/null; then
                 wm_theme="$(gsettings get org.gnome.shell.extensions.user-theme name)"
 
@@ -1663,11 +1663,11 @@ get_wm_theme() {
             fi
         ;;
 
-        "Metacity"*)
-            if [[ "$de" == "Deepin" ]]; then
+        Metacity*)
+            if [[ "$de" == Deepin ]]; then
                 wm_theme="$(gsettings get com.deepin.wrap.gnome.desktop.wm.preferences theme)"
 
-            elif [[ "$de" == "MATE" ]]; then
+            elif [[ "$de" == MATE ]]; then
                 wm_theme="$(gsettings get org.mate.Marco.general theme)"
 
             else
@@ -1675,7 +1675,7 @@ get_wm_theme() {
             fi
         ;;
 
-        "E17" | "Enlightenment")
+        E17 | Enlightenment)
             if type -p eet >/dev/null; then
                 wm_theme="$(eet -d "${HOME}/.e/e/config/standard/e.cfg" config |\
                             awk '/value \"file\" string.*.edj/ {print $4}')"
@@ -1684,39 +1684,39 @@ get_wm_theme() {
             fi
         ;;
 
-        "Fluxbox")
+        Fluxbox)
             [[ -f "${HOME}/.fluxbox/init" ]] && \
-                wm_theme="$(awk -F "/" '/styleFile/ {print $NF}' "${HOME}/.fluxbox/init")"
+                wm_theme="$(awk -F / '/styleFile/ {print $NF}' "${HOME}/.fluxbox/init")"
         ;;
 
-        "IceWM"*)
+        IceWM*)
             [[ -f "${HOME}/.icewm/theme" ]] && \
                 wm_theme="$(awk -F "[\",/]" '!/#/ {print $2}' "${HOME}/.icewm/theme")"
         ;;
 
-        "Openbox")
-            if [[ "$de" == "LXDE" && -f "${HOME}/.config/openbox/lxde-rc.xml" ]]; then
-                ob_file="lxde-rc"
+        Openbox)
+            if [[ "$de" == LXDE && -f "${HOME}/.config/openbox/lxde-rc.xml" ]]; then
+                ob_file=lxde-rc
 
             elif [[ -f "${HOME}/.config/openbox/rc.xml" ]]; then
-                ob_file="rc"
+                ob_file=rc
             fi
 
             wm_theme="$(awk -F "[<,>]" '/<theme/ {getline; print $3}' \
                         "${XDG_CONFIG_HOME}/openbox/${ob_file}.xml")";
         ;;
 
-        "PekWM")
+        PekWM)
             [[ -f "${HOME}/.pekwm/config" ]] && \
-                wm_theme="$(awk -F "/" '/Theme/{gsub(/\"/,""); print $NF}' "${HOME}/.pekwm/config")"
+                wm_theme="$(awk -F / '/Theme/{gsub(/\"/,""); print $NF}' "${HOME}/.pekwm/config")"
         ;;
 
-        "Xfwm4")
+        Xfwm4)
             [[ -f "${HOME}/.config/xfce4/xfconf/xfce-perchannel-xml/xfwm4.xml" ]] && \
                 wm_theme="$(xfconf-query -c xfwm4 -p /general/theme)"
         ;;
 
-        "KWin"*)
+        KWin*)
             kde_config_dir
             kwinrc="${kde_config_dir}/kwinrc"
             kdebugrc="${kde_config_dir}/kdebugrc"
@@ -1755,25 +1755,25 @@ get_wm_theme() {
             wm_theme_color="$(PlistBuddy -c "Print AppleAquaColorVariant" "$global_preferences")"
 
             [[ -z "$wm_theme" ]] && \
-                wm_theme="Light"
+                wm_theme=Light
 
             [[ -z "$wm_theme_color" ]] || ((wm_theme_color == 1)) && \
-                wm_theme_color="Blue"
+                wm_theme_color=Blue
 
             wm_theme="${wm_theme_color:-Graphite} ($wm_theme)"
         ;;
 
-        *"Explorer")
+        *Explorer)
             path="/proc/registry/HKEY_CURRENT_USER/Software/Microsoft"
-            path+="/Windows/CurrentVersion/Themes/CurrentTheme"
+            path+=/Windows/CurrentVersion/Themes/CurrentTheme
 
             wm_theme="$(head -n1 "$path")"
             wm_theme="${wm_theme##*\\}"
             wm_theme="${wm_theme%.*}"
         ;;
 
-        "Blackbox" | "bbLean"*)
-            path="$(wmic process get ExecutablePath | grep -F "blackbox")"
+        Blackbox | bbLean*)
+            path="$(wmic process get ExecutablePath | grep -F blackbox)"
             path="${path//\\/\/}"
 
             wm_theme="$(grep '^session\.styleFile:' "${path/\.exe/.rc}")"
@@ -1788,20 +1788,20 @@ get_wm_theme() {
 
 get_cpu() {
     case "$os" in
-        "Linux" | "MINIX" | "Windows")
+        Linux | MINIX | Windows)
             # Get CPU name.
-            cpu_file="/proc/cpuinfo"
+            cpu_file=/proc/cpuinfo
 
             case "$kernel_machine" in
-                "frv" | "hppa" | "m68k" | "openrisc" | "or"* | "powerpc" | "ppc"* | "sparc"*)
+                frv | hppa | m68k | openrisc | or* | powerpc | ppc* | sparc*)
                     cpu="$(awk -F':' '/^cpu\t|^CPU/ {printf $2; exit}' "$cpu_file")"
                 ;;
 
-                "s390"*)
+                s390*)
                     cpu="$(awk -F'=' '/machine/ {print $4; exit}' "$cpu_file")"
                 ;;
 
-                "ia64" | "m32r")
+                ia64 | m32r)
                     cpu="$(awk -F':' '/model/ {print $2; exit}' "$cpu_file")"
                     [[ -z "$cpu" ]] && cpu="$(awk -F':' '/family/ {printf $2; exit}' "$cpu_file")"
                 ;;
@@ -1813,7 +1813,7 @@ get_cpu() {
                 ;;
             esac
 
-            speed_dir="/sys/devices/system/cpu/cpu0/cpufreq"
+            speed_dir=/sys/devices/system/cpu/cpu0/cpufreq
 
             # Select the right temperature file.
             for temp_dir in /sys/class/hwmon/*; do
@@ -1840,8 +1840,8 @@ get_cpu() {
 
             # Get CPU cores.
             case "$cpu_cores" in
-                "logical" | "on") cores="$(grep -c "^processor" "$cpu_file")" ;;
-                "physical") cores="$(awk '/^core id/&&!a[$0]++{++i} END {print i}' "$cpu_file")" ;;
+                logical | on) cores="$(grep -c "^processor" "$cpu_file")" ;;
+                physical) cores="$(awk '/^core id/&&!a[$0]++{++i} END {print i}' "$cpu_file")" ;;
             esac
         ;;
 
@@ -1850,8 +1850,8 @@ get_cpu() {
 
             # Get CPU cores.
             case "$cpu_cores" in
-                "logical" | "on") cores="$(sysctl -n hw.logicalcpu_max)" ;;
-                "physical")       cores="$(sysctl -n hw.physicalcpu_max)" ;;
+                logical | on) cores="$(sysctl -n hw.logicalcpu_max)" ;;
+                physical)       cores="$(sysctl -n hw.physicalcpu_max)" ;;
             esac
         ;;
 
@@ -1883,7 +1883,7 @@ get_cpu() {
             cpu="$_"
         ;;
 
-        "BSD")
+        BSD)
             # Get CPU name.
             cpu="$(sysctl -n hw.model)"
             cpu="${cpu/[0-9]\.*}"
@@ -1898,11 +1898,11 @@ get_cpu() {
 
             # Get CPU temp.
             case "$kernel_name" in
-                "FreeBSD"* | "DragonFly"* | "NetBSD"*)
+                FreeBSD* | DragonFly* | NetBSD*)
                     deg="$(sysctl -n dev.cpu.0.temperature)"
                     deg="${deg/C}"
                 ;;
-                "OpenBSD"* | "Bitrig"*)
+                OpenBSD* | Bitrig*)
                     deg="$(sysctl hw.sensors | \
                            awk -F '=| degC' '/lm0.temp|cpu0.temp/ {print $2; exit}')"
                     deg="${deg/00/0}"
@@ -1910,7 +1910,7 @@ get_cpu() {
             esac
         ;;
 
-        "Solaris")
+        Solaris)
             # Get CPU name.
             cpu="$(psrinfo -pv)"
             cpu="${cpu//*$'\n'}"
@@ -1923,12 +1923,12 @@ get_cpu() {
 
             # Get CPU cores.
             case "$cpu_cores" in
-                "logical" | "on") cores="$(kstat -m cpu_info | grep -c -F "chip_id")" ;;
-                "physical") cores="$(psrinfo -p)" ;;
+                logical | on) cores="$(kstat -m cpu_info | grep -c -F "chip_id")" ;;
+                physical) cores="$(psrinfo -p)" ;;
             esac
         ;;
 
-        "Haiku")
+        Haiku)
             # Get CPU name.
             cpu="$(sysinfo -cpu | awk -F '\\"' '/CPU #0/ {print $2}')"
             cpu="${cpu/@*}"
@@ -1941,7 +1941,7 @@ get_cpu() {
             cores="$(sysinfo -cpu | grep -c -F 'CPU #')"
         ;;
 
-        "AIX")
+        AIX)
             # Get CPU name.
             cpu="$(lsattr -El proc0 -a type | awk '{printf $2}')"
 
@@ -1951,17 +1951,17 @@ get_cpu() {
 
             # Get CPU cores.
             case "$cpu_cores" in
-                "logical" | "on")
+                logical | on)
                     cores="$(lparstat -i | awk -F':' '/Online Virtual CPUs/ {printf $2}')"
                 ;;
 
-                "physical")
+                physical)
                     cores="$(lparstat -i | awk -F':' '/Active Physical CPUs/ {printf $2}')"
                 ;;
             esac
         ;;
 
-        "IRIX")
+        IRIX)
             # Get CPU name.
             cpu="$(hinv -c processor | awk -F':' '/CPU:/ {printf $2}')"
 
@@ -1972,7 +1972,7 @@ get_cpu() {
             cores="$(sysconf NPROC_ONLN)"
         ;;
 
-        "FreeMiNT")
+        FreeMiNT)
             cpu="$(awk -F':' '/CPU:/ {printf $2}' /kern/cpuinfo)"
             speed="$(awk -F '[:.M]' '/Clocking:/ {printf $2}' /kern/cpuinfo)"
         ;;
@@ -2004,7 +2004,7 @@ get_cpu() {
     speed="${speed//[[:space:]]}"
 
     # Remove CPU brand from the output.
-    if [[ "$cpu_brand" == "off" ]]; then
+    if [[ "$cpu_brand" == off ]]; then
         cpu="${cpu/AMD }"
         cpu="${cpu/Intel }"
         cpu="${cpu/Core? Duo }"
@@ -2012,29 +2012,29 @@ get_cpu() {
     fi
 
     # Add CPU cores to the output.
-    [[ "$cpu_cores" != "off" && "$cores" ]] && \
+    [[ "$cpu_cores" != off && "$cores" ]] && \
         case "$os" in
             "Mac OS X") cpu="${cpu/@/(${cores}) @}" ;;
             *)          cpu="$cpu ($cores)" ;;
         esac
 
     # Add CPU speed to the output.
-    if [[ "$cpu_speed" != "off" && "$speed" ]]; then
+    if [[ "$cpu_speed" != off && "$speed" ]]; then
         if (( speed < 1000 )); then
             cpu="$cpu @ ${speed}MHz"
         else
-            [[ "$speed_shorthand" == "on" ]] && speed="$((speed / 100))"
+            [[ "$speed_shorthand" == on ]] && speed="$((speed / 100))"
             speed="${speed:0:1}.${speed:1}"
             cpu="$cpu @ ${speed}GHz"
         fi
     fi
 
     # Add CPU temp to the output.
-    if [[ "$cpu_temp" != "off" && "$deg" ]]; then
+    if [[ "$cpu_temp" != off && "$deg" ]]; then
         deg="${deg//.}"
 
         # Convert to Fahrenheit if enabled
-        [[ "$cpu_temp" == "F" ]] && deg="$((deg * 90 / 50 + 320))"
+        [[ "$cpu_temp" == F ]] && deg="$((deg * 90 / 50 + 320))"
 
         # Format the output
         deg="[${deg/${deg: -1}}.${deg: -1}°${cpu_temp:-C}]"
@@ -2044,7 +2044,7 @@ get_cpu() {
 
 get_cpu_usage() {
     case "$os" in
-        "Windows")
+        Windows)
             cpu_usage="$(wmic cpu get loadpercentage)"
             cpu_usage="${cpu_usage/LoadPercentage}"
             cpu_usage="${cpu_usage//[[:space:]]}"
@@ -2052,18 +2052,18 @@ get_cpu_usage() {
 
         *)
             # Get CPU cores if unset.
-            if [[ "$cpu_cores" != "logical" ]]; then
+            if [[ "$cpu_cores" != logical ]]; then
                 case "$os" in
-                    "Linux" | "MINIX") cores="$(grep -c "^processor" /proc/cpuinfo)" ;;
+                    Linux | MINIX) cores="$(grep -c "^processor" /proc/cpuinfo)" ;;
                     "Mac OS X")        cores="$(sysctl -n hw.logicalcpu_max)" ;;
-                    "BSD")             cores="$(sysctl -n hw.ncpu)" ;;
-                    "Solaris")         cores="$(kstat -m cpu_info | grep -c -F "chip_id")" ;;
-                    "Haiku")           cores="$(sysinfo -cpu | grep -c -F 'CPU #')" ;;
+                    BSD)             cores="$(sysctl -n hw.ncpu)" ;;
+                    Solaris)         cores="$(kstat -m cpu_info | grep -c -F "chip_id")" ;;
+                    Haiku)           cores="$(sysinfo -cpu | grep -c -F 'CPU #')" ;;
                     "iPhone OS")       cores="${cpu/*\(}"; cores="${cores/\)*}" ;;
-                    "IRIX")            cores="$(sysconf NPROC_ONLN)" ;;
-                    "FreeMiNT")        cores="$(sysctl -n hw.ncpu)" ;;
+                    IRIX)            cores="$(sysconf NPROC_ONLN)" ;;
+                    FreeMiNT)        cores="$(sysctl -n hw.ncpu)" ;;
 
-                    "AIX")
+                    AIX)
                         cores="$(lparstat -i | awk -F':' '/Online Virtual CPUs/ {printf $2}')"
                     ;;
                 esac
@@ -2076,16 +2076,16 @@ get_cpu_usage() {
 
     # Print the bar.
     case "$cpu_display" in
-        "bar")     cpu_usage="$(bar "$cpu_usage" 100)" ;;
-        "infobar") cpu_usage="${cpu_usage}% $(bar "$cpu_usage" 100)" ;;
-        "barinfo") cpu_usage="$(bar "$cpu_usage" 100)${info_color} ${cpu_usage}%" ;;
+        bar)     cpu_usage="$(bar "$cpu_usage" 100)" ;;
+        infobar) cpu_usage="${cpu_usage}% $(bar "$cpu_usage" 100)" ;;
+        barinfo) cpu_usage="$(bar "$cpu_usage" 100)${info_color} ${cpu_usage}%" ;;
         *)         cpu_usage="${cpu_usage}%" ;;
     esac
 }
 
 get_gpu() {
     case "$os" in
-        "Linux")
+        Linux)
             # Read GPUs into array.
             gpu_cmd="$(lspci -mm | awk -F '\\"|\\" \\"|\\(' \
                                           '/"Display|"3D|"VGA/ {a[$0] = $3 " " $4} END {for(i in a)
@@ -2103,12 +2103,12 @@ get_gpu() {
 
             for gpu in "${gpus[@]}"; do
                 # GPU shorthand tests.
-                [[ "$gpu_type" == "dedicated" && "$gpu" == *Intel* ]] || \
-                [[ "$gpu_type" == "integrated" && ! "$gpu" == *Intel* ]] && \
+                [[ "$gpu_type" == dedicated && "$gpu" == *Intel* ]] || \
+                [[ "$gpu_type" == integrated && ! "$gpu" == *Intel* ]] && \
                     { unset -v gpu; continue; }
 
                 case "$gpu" in
-                    *"advanced"*)
+                    *advanced*)
                         brand="${gpu/*AMD*ATI*/AMD ATI}"
                         brand="${brand:-${gpu/*AMD*/AMD}}"
                         brand="${brand:-${gpu/*ATI*/ATi}}"
@@ -2122,13 +2122,13 @@ get_gpu() {
                         gpu="$brand $gpu"
                     ;;
 
-                    *"nvidia"*)
+                    *nvidia*)
                         gpu="${gpu/*\[}"
                         gpu="${gpu/\]*}"
                         gpu="NVIDIA $gpu"
                     ;;
 
-                    *"intel"*)
+                    *intel*)
                         gpu="${gpu/*Intel/Intel}"
                         gpu="${gpu/\(R\)}"
                         gpu="${gpu/Corporation}"
@@ -2139,12 +2139,12 @@ get_gpu() {
                         [[ -z "$(trim "$gpu")" ]] && gpu="Intel Integrated Graphics"
                     ;;
 
-                    *"virtualbox"*)
+                    *virtualbox*)
                         gpu="VirtualBox Graphics Adapter"
                     ;;
                 esac
 
-                if [[ "$gpu_brand" == "off" ]]; then
+                if [[ "$gpu_brand" == off ]]; then
                     gpu="${gpu/AMD }"
                     gpu="${gpu/NVIDIA }"
                     gpu="${gpu/Intel }"
@@ -2166,7 +2166,7 @@ get_gpu() {
                 gpu="${gpu//\/ \$}"
                 gpu="${gpu%,*}"
 
-                cache "gpu" "$gpu"
+                cache gpu "$gpu"
             fi
         ;;
 
@@ -2203,20 +2203,20 @@ get_gpu() {
             gpu="$_"
         ;;
 
-        "Windows")
+        Windows)
             gpu="$(wmic path Win32_VideoController get caption)"
             gpu="${gpu//Caption}"
         ;;
 
-        "Haiku")
+        Haiku)
             gpu="$(listdev | grep -A2 -F 'device Display controller' |\
                    awk -F':' '/device beef/ {print $2}')"
         ;;
 
         *)
             case "$kernel_name" in
-                "FreeBSD"* | "DragonFly"*)
-                    gpu="$(pciconf -lv | grep -B 4 -F "VGA" | grep -F "device")"
+                FreeBSD* | DragonFly*)
+                    gpu="$(pciconf -lv | grep -B 4 -F VGA | grep -F device)"
                     gpu="${gpu/*device*= }"
                     gpu="$(trim_quotes "$gpu")"
                 ;;
@@ -2229,7 +2229,7 @@ get_gpu() {
         ;;
     esac
 
-    if [[ "$gpu_brand" == "off" ]]; then
+    if [[ "$gpu_brand" == off ]]; then
         gpu="${gpu/AMD}"
         gpu="${gpu/NVIDIA}"
         gpu="${gpu/Intel}"
@@ -2238,14 +2238,14 @@ get_gpu() {
 
 get_memory() {
     case "$os" in
-        "Linux" | "Windows")
+        Linux | Windows)
             # MemUsed = Memtotal + Shmem - MemFree - Buffers - Cached - SReclaimable
             # Source: https://github.com/KittyKatt/screenFetch/issues/386#issuecomment-249312716
             while IFS=":" read -r a b; do
                 case "$a" in
-                    "MemTotal") ((mem_used+=${b/kB})); mem_total="${b/kB}" ;;
-                    "Shmem") ((mem_used+=${b/kB}))  ;;
-                    "MemFree" | "Buffers" | "Cached" | "SReclaimable")
+                    MemTotal) ((mem_used+=${b/kB})); mem_total="${b/kB}" ;;
+                    Shmem) ((mem_used+=${b/kB}))  ;;
+                    MemFree | Buffers | Cached | SReclaimable)
                         mem_used="$((mem_used-=${b/kB}))"
                     ;;
                 esac
@@ -2264,20 +2264,20 @@ get_memory() {
             mem_used="$(((${mem_wired//.} + ${mem_active//.} + ${mem_compressed//.}) * 4 / 1024))"
         ;;
 
-        "BSD" | "MINIX")
+        BSD | MINIX)
             # Mem total.
             case "$kernel_name" in
-                "NetBSD"*) mem_total="$(($(sysctl -n hw.physmem64) / 1024 / 1024))" ;;
+                NetBSD*) mem_total="$(($(sysctl -n hw.physmem64) / 1024 / 1024))" ;;
                 *) mem_total="$(($(sysctl -n hw.physmem) / 1024 / 1024))" ;;
             esac
 
             # Mem free.
             case "$kernel_name" in
-                "NetBSD"*)
+                NetBSD*)
                     mem_free="$(($(awk -F ':|kB' '/MemFree:/ {printf $2}' /proc/meminfo) / 1024))"
                 ;;
 
-                "FreeBSD"* | "DragonFly"*)
+                FreeBSD* | DragonFly*)
                     hw_pagesize="$(sysctl -n hw.pagesize)"
                     mem_inactive="$(($(sysctl -n vm.stats.vm.v_inactive_count) * hw_pagesize))"
                     mem_unused="$(($(sysctl -n vm.stats.vm.v_free_count) * hw_pagesize))"
@@ -2285,18 +2285,18 @@ get_memory() {
                     mem_free="$(((mem_inactive + mem_unused + mem_cache) / 1024 / 1024))"
                 ;;
 
-                "MINIX")
+                MINIX)
                     mem_free="$(top -d 1 | awk -F ',' '/^Memory:/ {print $2}')"
                     mem_free="${mem_free/M Free}"
                 ;;
 
-                "OpenBSD"*) ;;
+                OpenBSD*) ;;
                 *) mem_free="$(($(vmstat | awk 'END {printf $5}') / 1024))" ;;
             esac
 
             # Mem used.
             case "$kernel_name" in
-                "OpenBSD"*)
+                OpenBSD*)
                     mem_used="$(vmstat | awk 'END {printf $3}')"
                     mem_used="${mem_used/M}"
                 ;;
@@ -2305,15 +2305,15 @@ get_memory() {
             esac
         ;;
 
-        "Solaris" | "AIX")
+        Solaris | AIX)
             hw_pagesize="$(pagesize)"
             case "$os" in
-                "Solaris")
+                Solaris)
                     pages_total="$(kstat -p unix:0:system_pages:pagestotal | awk '{print $2}')"
                     pages_free="$(kstat -p unix:0:system_pages:pagesfree | awk '{print $2}')"
                 ;;
 
-                "AIX")
+                AIX)
                     IFS=$'\n'"| " read -d "" -ra mem_stat <<< "$(svmon -G -O unit=page)"
                     pages_total="${mem_stat[11]}"
                     pages_free="${mem_stat[16]}"
@@ -2324,13 +2324,13 @@ get_memory() {
             mem_used="$((mem_total - mem_free))"
         ;;
 
-        "Haiku")
+        Haiku)
             mem_total="$(($(sysinfo -mem | awk -F '\\/ |)' '{print $2; exit}') / 1024 / 1024))"
             mem_used="$(sysinfo -mem | awk -F '\\/|)' '{print $2; exit}')"
             mem_used="$((${mem_used/max} / 1024 / 1024))"
         ;;
 
-        "IRIX")
+        IRIX)
             IFS=$'\n' read -d "" -ra mem_cmd <<< "$(pmem)"
             IFS=" " read -ra mem_stat <<< "${mem_cmd[0]}"
 
@@ -2339,7 +2339,7 @@ get_memory() {
             mem_used="$((mem_total - mem_free))"
         ;;
 
-        "FreeMiNT")
+        FreeMiNT)
             mem="$(awk -F ':|kB' '/MemTotal:|MemFree:/ {printf $2, " "}' /kern/meminfo)"
             mem_free="${mem/*  }"
             mem_total="${mem/  *}"
@@ -2350,61 +2350,61 @@ get_memory() {
 
     esac
 
-    [[ "$memory_percent" == "on" ]] && ((mem_perc=mem_used * 100 / mem_total))
+    [[ "$memory_percent" == on ]] && ((mem_perc=mem_used * 100 / mem_total))
 
     memory="${mem_used}${mem_label:-MiB} / ${mem_total}${mem_label:-MiB} ${mem_perc:+(${mem_perc}%)}"
 
     # Bars.
     case "$memory_display" in
-        "bar")     memory="$(bar "${mem_used}" "${mem_total}")" ;;
-        "infobar") memory="${memory} $(bar "${mem_used}" "${mem_total}")" ;;
-        "barinfo") memory="$(bar "${mem_used}" "${mem_total}")${info_color} ${memory}" ;;
+        bar)     memory="$(bar "${mem_used}" "${mem_total}")" ;;
+        infobar) memory="${memory} $(bar "${mem_used}" "${mem_total}")" ;;
+        barinfo) memory="$(bar "${mem_used}" "${mem_total}")${info_color} ${memory}" ;;
     esac
 }
 
 get_song() {
     players=(
-        "amarok"
-        "audacious"
-        "banshee"
-        "bluemindo"
-        "clementine"
-        "cmus"
-        "deadbeef"
-        "deepin-music"
-        "dragon"
-        "elisa"
-        "exaile"
-        "gnome-music"
-        "gmusicbrowser"
-        "guayadeque"
-        "iTunes"
-        "juk"
-        "lollypop"
-        "mocp"
-        "mopidy"
-        "mpd"
-        "netease-cloud-music"
-        "pogo"
-        "pragha"
-        "qmmp"
-        "quodlibet"
-        "rhythmbox"
-        "sayonara"
-        "smplayer"
-        "spotify"
-        "Spotify"
-        "tomahawk"
-        "vlc"
-        "xmms2d"
-        "yarock"
+        amarok
+        audacious
+        banshee
+        bluemindo
+        clementine
+        cmus
+        deadbeef
+        deepin-music
+        dragon
+        elisa
+        exaile
+        gnome-music
+        gmusicbrowser
+        guayadeque
+        iTunes
+        juk
+        lollypop
+        mocp
+        mopidy
+        mpd
+        netease-cloud-music
+        pogo
+        pragha
+        qmmp
+        quodlibet
+        rhythmbox
+        sayonara
+        smplayer
+        spotify
+        Spotify
+        tomahawk
+        vlc
+        xmms2d
+        yarock
     )
 
     printf -v players "|%s" "${players[@]}"
     player="$(ps aux | awk -v pattern="(${players:1})" \
         '!/ awk / && !/iTunesHelper/ && match($0,pattern){print substr($0,RSTART,RLENGTH); exit}')"
 
-    [[ "$music_player" && "$music_player" != "auto" ]] && player="$music_player"
+    [[ "$music_player" && "$music_player" != auto ]] && player="$music_player"
 
     get_song_dbus() {
         # Multiple players use an almost identical dbus command to get the information.
@@ -2419,33 +2419,33 @@ get_song() {
     }
 
     case "${player/*\/}" in
-        "mpd"*|"mopidy"*) song="$(mpc -f '%artist%\n%album%\n%title%' current "${mpc_args[@]}")" ;;
-        "mocp"*)          song="$(mocp -Q '%artist\n%album\n%song')" ;;
-        "deadbeef"*)      song="$(deadbeef --nowplaying-tf '%artist%\\n%album%\\n%title%')" ;;
-        "xmms2d"*)        song="$(xmms2 current -f "\${artist}"$'\n'"\${album}"$'\n'"\${title}")" ;;
-        "qmmp"*)          song="$(qmmp --nowplaying '%p\\n%a\\n%t')" ;;
-        "gnome-music"*)   get_song_dbus "GnomeMusic" ;;
-        "lollypop"*)      get_song_dbus "Lollypop" ;;
-        "clementine"*)    get_song_dbus "clementine" ;;
-        "juk"*)           get_song_dbus "juk" ;;
-        "bluemindo"*)     get_song_dbus "Bluemindo" ;;
-        "guayadeque"*)    get_song_dbus "guayadeque" ;;
-        "yarock"*)        get_song_dbus "yarock" ;;
-        "deepin-music"*)  get_song_dbus "DeepinMusic" ;;
-        "tomahawk"*)      get_song_dbus "tomahawk" ;;
-        "elisa"*)         get_song_dbus "elisa" ;;
-        "sayonara"*)      get_song_dbus "sayonara" ;;
-        "audacious"*)     get_song_dbus "audacious" ;;
-        "vlc"*)           get_song_dbus "vlc" ;;
-        "gmusicbrowser"*) get_song_dbus "gmusicbrowser" ;;
-        "pragha"*)        get_song_dbus "pragha" ;;
-        "amarok"*)        get_song_dbus "amarok" ;;
-        "dragon"*)        get_song_dbus "dragonplayer" ;;
-        "smplayer"*)      get_song_dbus "smplayer" ;;
-        "rhythmbox"*)     get_song_dbus "rhythmbox" ;;
-        "netease-cloud-music"*) get_song_dbus "netease-cloud-music" ;;
+        mpd*|mopidy*) song="$(mpc -f '%artist%\n%album%\n%title%' current "${mpc_args[@]}")" ;;
+        mocp*)          song="$(mocp -Q '%artist\n%album\n%song')" ;;
+        deadbeef*)      song="$(deadbeef --nowplaying-tf '%artist%\\n%album%\\n%title%')" ;;
+        xmms2d*)        song="$(xmms2 current -f "\${artist}"$'\n'"\${album}"$'\n'"\${title}")" ;;
+        qmmp*)          song="$(qmmp --nowplaying '%p\\n%a\\n%t')" ;;
+        gnome-music*)   get_song_dbus GnomeMusic ;;
+        lollypop*)      get_song_dbus Lollypop ;;
+        clementine*)    get_song_dbus clementine ;;
+        juk*)           get_song_dbus juk ;;
+        bluemindo*)     get_song_dbus Bluemindo ;;
+        guayadeque*)    get_song_dbus guayadeque ;;
+        yarock*)        get_song_dbus yarock ;;
+        deepin-music*)  get_song_dbus DeepinMusic ;;
+        tomahawk*)      get_song_dbus tomahawk ;;
+        elisa*)         get_song_dbus elisa ;;
+        sayonara*)      get_song_dbus sayonara ;;
+        audacious*)     get_song_dbus audacious ;;
+        vlc*)           get_song_dbus vlc ;;
+        gmusicbrowser*) get_song_dbus gmusicbrowser ;;
+        pragha*)        get_song_dbus pragha ;;
+        amarok*)        get_song_dbus amarok ;;
+        dragon*)        get_song_dbus dragonplayer ;;
+        smplayer*)      get_song_dbus smplayer ;;
+        rhythmbox*)     get_song_dbus rhythmbox ;;
+        netease-cloud-music*) get_song_dbus netease-cloud-music ;;
 
-        "cmus"*)
+        cmus*)
             song="$(cmus-remote -Q | awk 'BEGIN { ORS=" "};
                                           /tag artist/ {
                                               $1=$2=""; sub("  ", ""); a=$0
@@ -2459,45 +2459,45 @@ get_song() {
                                           END { print a "\n" b "\n" t }')"
         ;;
 
-        "spotify"*)
+        spotify*)
             case "$os" in
-                "Linux") get_song_dbus "spotify" ;;
+                Linux) get_song_dbus spotify ;;
 
                 "Mac OS X")
-                    song="$(osascript -e 'tell application "Spotify" to artist of current track as¬
+                    song="$(osascript -e 'tell application Spotify to artist of current track as¬
                                           string & "\n" & album of current track as¬
                                           string & "\n" & name of current track as string')"
                 ;;
             esac
         ;;
 
-        "itunes"*)
-            song="$(osascript -e 'tell application "iTunes" to artist of current track as¬
+        itunes*)
+            song="$(osascript -e 'tell application iTunes to artist of current track as¬
                                   string & "\n" & album of current track as¬
                                   string & "\n" & name of current track as string')"
         ;;
 
-        "banshee"*)
+        banshee*)
             song="$(banshee --query-artist --query-album --query-title |\
                     awk -F':' '/^artist/ {a=$2} /^album/ {b=$2} /^title/ {t=$2}
                                END {print a "\n" b "\n"t}')"
         ;;
 
-        "exaile"*)
+        exaile*)
             # NOTE: Exaile >= 4.0.0 will support mpris2.
             song="$(dbus-send --print-reply --dest=org.exaile.Exaile  /org/exaile/Exaile \
                     org.exaile.Exaile.Query |
                     awk -F':|,' '{if ($6 && $8 && $4) printf $6 "\n" $8 "\n" $4}')"
         ;;
 
-        "quodlibet"*)
+        quodlibet*)
             song="$(dbus-send --print-reply --dest=net.sacredchao.QuodLibet \
                     /net/sacredchao/QuodLibet net.sacredchao.QuodLibet.CurrentSong |\
                     awk -F'"' 'BEGIN {RS=" entry"}; /"artist"/ {a=$4} /"album"/ {b=$4}
                     /"title"/ {t=$4} END {print a "\n" b "\n" t}')"
         ;;
 
-        "pogo"*)
+        pogo*)
             song="$(dbus-send --print-reply --dest=org.mpris.pogo /Player \
                     org.freedesktop.MediaPlayer.GetMetadata |
                     awk -F'"' 'BEGIN {RS=" entry"}; /"artist"/ {a=$4} /"album"/ {b=$4}
@@ -2518,10 +2518,10 @@ get_song() {
     : "${artist:=Unknown Artist}" "${album:=Unknown Album}" "${title:=Unknown Song}"
 
     # Display Artist, Album and Title on separate lines.
-    if [[ "$song_shorthand" == "on" ]]; then
-        prin "Artist" "$artist"
-        prin "Album"  "$album"
-        prin "Song"   "$title"
+    if [[ "$song_shorthand" == on ]]; then
+        prin Artist "$artist"
+        prin Album  "$album"
+        prin Song   "$title"
     else
         song="${song_format/\%artist\%/$artist}"
         song="${song/\%album\%/$album}"
@@ -2538,7 +2538,7 @@ get_resolution() {
 
             else
                 resolution="$(system_profiler SPDisplaysDataType |\
-                              awk '/Resolution:/ {printf $2"x"$4" @ "$6"Hz, "}')"
+                              awk '/Resolution:/ {printf $2x$4" @ "$6"Hz, "}')"
             fi
 
             if [[ -e "/Library/Preferences/com.apple.windowserver.plist" ]]; then
@@ -2555,16 +2555,16 @@ get_resolution() {
             [[ "${scale_factor%.*}" == 2 ]] && \
                 resolution="${resolution// @/@2x @}"
 
-            if [[ "$refresh_rate" == "off" ]]; then
+            if [[ "$refresh_rate" == off ]]; then
                 resolution="${resolution// @ [0-9][0-9]Hz}"
                 resolution="${resolution// @ [0-9][0-9][0-9]Hz}"
             fi
 
-            [[ "$resolution" == *"0Hz"* ]] && \
+            [[ "$resolution" == *0Hz* ]] && \
                 resolution="${resolution// @ 0Hz}"
         ;;
 
-        "Windows")
+        Windows)
             local width=""
             width="$(wmic path Win32_VideoController get CurrentHorizontalResolution)"
             width="${width//CurrentHorizontalResolution/}"
@@ -2576,22 +2576,22 @@ get_resolution() {
             [[ "$(trim "$width")" ]] && resolution="${width//[[:space:]]}x${height//[[:space:]]}"
         ;;
 
-        "Haiku")
-            resolution="$(screenmode | awk -F ' |, ' '{printf $2 "x" $3 " @ " $6 $7}')"
+        Haiku)
+            resolution="$(screenmode | awk -F ' |, ' '{printf $2 x $3 " @ " $6 $7}')"
 
-            [[ "$refresh_rate" == "off" ]] && resolution="${resolution/ @*}"
+            [[ "$refresh_rate" == off ]] && resolution="${resolution/ @*}"
         ;;
 
         *)
             if type -p xrandr >/dev/null; then
                 case "$refresh_rate" in
-                    "on")
+                    on)
                         resolution="$(xrandr --nograb --current |\
                                       awk 'match($0,/[0-9]*\.[0-9]*\*/) {
                                            printf $1 " @ " substr($0,RSTART,RLENGTH) "Hz, "}')"
                     ;;
 
-                    "off")
+                    off)
                         resolution="$(xrandr --nograb --current |\
                                       awk -F 'connected |\\+|\\(' \
                                              '/ connected/ && $2 {printf $2 ", "}')"
@@ -2625,7 +2625,7 @@ get_style() {
 
         # Check for DE Theme.
         case "$de" in
-            "KDE"*)
+            KDE*)
                 kde_config_dir
 
                 if [[ -f "${kde_config_dir}/kdeglobals" ]]; then
@@ -2633,7 +2633,7 @@ get_style() {
 
                     kde_theme="$(grep "^${kde}" "$kde_config_file")"
                     kde_theme="${kde_theme/*=}"
-                    if [[ "$kde" == "font" ]]; then
+                    if [[ "$kde" == font ]]; then
                         kde_font_size="${kde_theme#*,}"
                         kde_font_size="${kde_font_size/,*}"
                         kde_theme="${kde_theme/,*} ${kde_theme/*,} ${kde_font_size}"
@@ -2644,14 +2644,14 @@ get_style() {
                 fi
             ;;
 
-            *"Cinnamon"*)
+            *Cinnamon*)
                 if type -p gsettings >/dev/null; then
                     gtk3_theme="$(gsettings get org.cinnamon.desktop.interface "$gsettings")"
                     gtk2_theme="$gtk3_theme"
                 fi
             ;;
 
-            "Gnome"* | "Unity"* | "Budgie"*)
+            Gnome* | Unity* | Budgie*)
                 if type -p gsettings >/dev/null; then
                     gtk3_theme="$(gsettings get org.gnome.desktop.interface "$gsettings")"
                     gtk2_theme="$gtk3_theme"
@@ -2661,12 +2661,12 @@ get_style() {
                 fi
             ;;
 
-            "Mate"*)
+            Mate*)
                 gtk3_theme="$(gsettings get org.mate.interface "$gsettings")"
                 gtk2_theme="$gtk3_theme"
             ;;
 
-            "Xfce"*)
+            Xfce*)
                 type -p xfconf-query >/dev/null && \
                     gtk2_theme="$(xfconf-query -c xsettings -p "$xfconf")"
             ;;
@@ -2715,8 +2715,8 @@ get_style() {
         gtk3_theme="$(trim_quotes "$gtk3_theme")"
 
         # Toggle visibility of GTK themes.
-        [[ "$gtk2" == "off" ]] && unset gtk2_theme
-        [[ "$gtk3" == "off" ]] && unset gtk3_theme
+        [[ "$gtk2" == off ]] && unset gtk2_theme
+        [[ "$gtk3" == off ]] && unset gtk3_theme
 
         # Format the string based on which themes exist.
         if [[ "$gtk2_theme" && "$gtk2_theme" == "$gtk3_theme" ]]; then
@@ -2737,7 +2737,7 @@ get_style() {
         theme="${theme%, }"
 
         # Make the output shorter by removing "[GTKX]" from the string.
-        if [[ "$gtk_shorthand" == "on" ]]; then
+        if [[ "$gtk_shorthand" == on ]]; then
             theme="${theme// '[GTK'[0-9]']'}"
             theme="${theme/ '[GTK2/3]'}"
             theme="${theme/ '[KDE]'}"
@@ -2746,32 +2746,32 @@ get_style() {
 }
 
 get_theme() {
-    name="gtk-theme-name"
-    gsettings="gtk-theme"
+    name=gtk-theme-name
+    gsettings=gtk-theme
     gconf="gtk_theme"
-    xfconf="/Net/ThemeName"
-    kde="Name"
+    xfconf=/Net/ThemeName
+    kde=Name
 
     get_style
 }
 
 get_icons() {
-    name="gtk-icon-theme-name"
+    name=gtk-icon-theme-name
     gsettings="icon-theme"
     gconf="icon_theme"
-    xfconf="/Net/IconThemeName"
-    kde="Theme"
+    xfconf=/Net/IconThemeName
+    kde=Theme
 
     get_style
     icons="$theme"
 }
 
 get_font() {
-    name="gtk-font-name"
+    name=gtk-font-name
     gsettings="font-name"
     gconf="font_theme"
-    xfconf="/Gtk/FontName"
-    kde="font"
+    xfconf=/Gtk/FontName
+    kde=font
 
     get_style
     font="$theme"
@@ -2784,14 +2784,14 @@ get_term() {
     # Workaround for macOS systems that
     # don't support the block below.
     case "$TERM_PROGRAM" in
-        "iTerm.app")    term="iTerm2" ;;
+        "iTerm.app")    term=iTerm2 ;;
         "Terminal.app") term="Apple Terminal" ;;
-        "Hyper")        term="HyperTerm" ;;
+        Hyper)        term=HyperTerm ;;
         *)              term="${TERM_PROGRAM/\.app}" ;;
     esac
 
     # Most likely TosWin2 on FreeMiNT - quick check
-    [[ "$TERM" == "tw52" || "$TERM" == "tw100" ]] && term="TosWin2"
+    [[ "$TERM" == tw52 || "$TERM" == tw100 ]] && term=TosWin2
     [[ "$SSH_CONNECTION" ]] && term="$SSH_TTY"
 
     # Check $PPID for terminal emulator.
@@ -2801,20 +2801,20 @@ get_term() {
         name="$(get_process_name "$parent")"
 
         case "${name// }" in
-            "${SHELL/*\/}"|*"sh"|"screen"|"su"*) ;;
+            "${SHELL/*\/}"|*sh|screen|su*) ;;
 
-            "login"*|*"Login"*|"init"|"(init)")
+            login*|*Login*|init|"(init)")
                 term="$(tty)"
             ;;
 
-            "ruby"|"1"|"tmux"*|"systemd"|"sshd"*|"python"*|"USER"*"PID"*|"kdeinit"*|"launchd"*)
+            ruby|1|tmux*|systemd|sshd*|python*|USER*PID*|kdeinit*|launchd*)
                 break
             ;;
 
-            "gnome-terminal-") term="gnome-terminal" ;;
-            "urxvtd")          term="urxvt" ;;
-            *"nvim")           term="Neovim Terminal" ;;
-            *"NeoVimServer"*)  term="VimR Terminal" ;;
+            gnome-terminal-) term=gnome-terminal ;;
+            urxvtd)          term=urxvt ;;
+            *nvim)           term="Neovim Terminal" ;;
+            *NeoVimServer*)  term="VimR Terminal" ;;
             *)                 term="${name##*/}" ;;
         esac
     done
@@ -2827,7 +2827,7 @@ get_term_font() {
     ((term_run != 1)) && get_term
 
     case "$term" in
-        "alacritty"*)
+        alacritty*)
             shopt -s nullglob
             confs=({$XDG_CONFIG_HOME,$HOME}/{alacritty,}/{.,}alacritty.ym?)
             shopt -u nullglob
@@ -2842,12 +2842,12 @@ get_term_font() {
 
         "Apple_Terminal")
             term_font="$(osascript <<END
-                         tell application "Terminal" to font name of window frontmost
+                         tell application Terminal to font name of window frontmost
 END
 )"
         ;;
 
-        "iTerm2")
+        iTerm2)
             # Unfortunately the profile name is not unique, but it seems to be the only thing
             # that identifies an active profile. There is the "id of current session of current win-
             # dow" though, but that does not match to a guid in the plist.
@@ -2867,7 +2867,7 @@ END
 
             # Count Guids in "New Bookmarks"; they should be unique
             profiles_count="$(PlistBuddy -c "Print ':New Bookmarks:'" "$font_file" | \
-                              grep -w -c "Guid")"
+                              grep -w -c Guid)"
 
             for ((i=0; i<profiles_count; i++)); do
                 profile_name="$(PlistBuddy -c "Print ':New Bookmarks:${i}:Name:'" "$font_file")"
@@ -2883,7 +2883,7 @@ END
                     diff_font="$(PlistBuddy -c "Print ':New Bookmarks:${i}:Use Non-ASCII Font:'" \
                                  "$font_file")"
 
-                    if [[ "$diff_font" == "true" ]]; then
+                    if [[ "$diff_font" == true ]]; then
                         non_ascii="$(PlistBuddy -c "Print ':New Bookmarks:${i}:Non Ascii Font:'" \
                                      "$font_file")"
 
@@ -2894,7 +2894,7 @@ END
             done
         ;;
 
-        "deepin-terminal"*)
+        deepin-terminal*)
             term_font="$(awk -F '=' '/font=/ {a=$2} /font_size/ {b=$2} END {print a,b}' \
                          "${XDG_CONFIG_HOME}/deepin/deepin-terminal/config.conf")"
         ;;
@@ -2905,19 +2905,19 @@ END
                           "${HOME}/GNUstep/Defaults/Terminal.plist")"
         ;;
 
-        "Hyper"*)
+        Hyper*)
             term_font="$(awk -F':|,' '/fontFamily/ {print $2; exit}' "${HOME}/.hyper.js")"
             term_font="$(trim_quotes "$term_font")"
         ;;
 
-        "kitty"*)
+        kitty*)
             kitty_config="$(kitty --debug-config)"
             [[ "$kitty_config" != *font_family* ]] && return
 
             term_font="$(awk '/^font_family|^font_size/ {printf $2 " "}' <<< "$kitty_config")"
         ;;
 
-        "konsole" | "yakuake")
+        konsole | yakuake)
             # Get Process ID of current konsole window / tab
             child="$(get_ppid "$$")"
 
@@ -2945,18 +2945,18 @@ END
                 term_font="$(awk -F '=|,' '/Font=/ {print $2,$3}' "$profile_filename")"
         ;;
 
-        "lxterminal"*)
+        lxterminal*)
             term_font="$(awk -F '=' '/fontname=/ {print $2; exit}' \
                          "${XDG_CONFIG_HOME}/lxterminal/lxterminal.conf")"
         ;;
 
-        "mate-terminal")
+        mate-terminal)
             # To get the actual config we have to create a temporarily file with the
             # --save-config option.
             mateterm_config="/tmp/mateterm.cfg"
 
             # Ensure /tmp exists and we do not overwrite anything.
-            if [[ -d "/tmp" && ! -f "$mateterm_config" ]]; then
+            if [[ -d /tmp && ! -f "$mateterm_config" ]]; then
                 mate-terminal --save-config="$mateterm_config"
 
                 role="$(xprop -id "${WINDOWID}" WM_WINDOW_ROLE)"
@@ -2978,20 +2978,20 @@ END
                    gsettings get org.mate.terminal.profile:/org/mate/terminal/profiles/"$1"/ "$2"
                 }
 
-                if [[ "$(mate_get "$profile" "use-system-font")" == "true" ]]; then
+                if [[ "$(mate_get "$profile" use-system-font)" == true ]]; then
                     term_font="$(gsettings get org.mate.interface monospace-font-name)"
                 else
-                    term_font="$(mate_get "$profile" "font")"
+                    term_font="$(mate_get "$profile" font)"
                 fi
                 term_font="$(trim_quotes "$term_font")"
             fi
         ;;
 
-        "mintty")
+        mintty)
             term_font="$(awk -F '=' '!/^($|#)/ && /Font/ {printf $2; exit}' "${HOME}/.minttyrc")"
         ;;
 
-        "pantheon"*)
+        pantheon*)
             term_font="$(gsettings get org.pantheon.terminal.settings font)"
 
             [[ -z "${term_font//\'}" ]] && \
@@ -3000,18 +3000,18 @@ END
             term_font="$(trim_quotes "$term_font")"
         ;;
 
-        "qterminal")
+        qterminal)
             term_font="$(awk -F '=' '/fontFamily=/ {a=$2} /fontSize=/ {b=$2} END {print a,b}' \
                          "${XDG_CONFIG_HOME}/qterminal.org/qterminal.ini")"
         ;;
 
-        "sakura"*)
+        sakura*)
             term_font="$(awk -F '=' '/^font=/ {print $2; exit}' \
                          "${XDG_CONFIG_HOME}/sakura/sakura.conf")"
         ;;
 
-        "st")
-            term_font="$(ps -o command= -p "$parent" | grep -F -- "-f")"
+        st)
+            term_font="$(ps -o command= -p "$parent" | grep -F -- -f)"
 
             if [[ "$term_font" ]]; then
                 term_font="${term_font/*-f/}"
@@ -3039,14 +3039,14 @@ END
             term_font="${term_font/:*}"
         ;;
 
-        "terminology")
+        terminology)
             term_font="$(strings "${XDG_CONFIG_HOME}/terminology/config/standard/base.cfg" |\
                          awk '/^font\.name$/{print a}{a=$0}')"
             term_font="${term_font/.pcf}"
             term_font="${term_font/:*}"
         ;;
 
-        "termite")
+        termite)
             [[ -f "${XDG_CONFIG_HOME}/termite/config" ]] && \
                 termite_config="${XDG_CONFIG_HOME}/termite/config"
 
@@ -3056,11 +3056,11 @@ END
                                       /^\s*font/ {
                                           if(opt==1) a=$2;
                                           opt=0
-                                      } END {print a}' "/etc/xdg/termite/config" \
+                                      } END {print a}' /etc/xdg/termite/config \
                          "$termite_config")"
         ;;
 
-        "urxvt" | "urxvtd" | "rxvt-unicode" | "xterm")
+        urxvt | urxvtd | rxvt-unicode | xterm)
             xrdb="$(xrdb -query)"
             term_font="$(grep -im 1 -e "^${term/d}"'\**\.*font' -e '^\*font' <<< "$xrdb")"
             term_font="${term_font/*"*font:"}"
@@ -3068,7 +3068,7 @@ END
             term_font="${term_font/*"*.font:"}"
             term_font="$(trim "$term_font")"
 
-            [[ -z "$term_font" && "$term" == "xterm" ]] && \
+            [[ -z "$term_font" && "$term" == xterm ]] && \
                 term_font="$(grep '^XTerm.vt100.faceName' <<< "$xrdb")"
 
             term_font="$(trim "${term_font/*"faceName:"}")"
@@ -3091,7 +3091,7 @@ END
             esac
         ;;
 
-        "xfce4-terminal")
+        xfce4-terminal)
             term_font="$(awk -F '=' '/^FontName/{a=$2}/^FontUseSystem=TRUE/{a=$0} END {print a}' \
                          "${XDG_CONFIG_HOME}/xfce4/terminal/terminalrc")"
 
@@ -3113,11 +3113,11 @@ get_disk() {
     df_version="$(df --version 2>&1)"
 
     case "$df_version" in
-        *"IMitv"*)   df_flags=(-P -g) ;; # AIX
-        *"befhikm"*) df_flags=(-P -k) ;; # IRIX
-        *"hiklnP"*) df_flags=(-h) ;; # OpenBSD
+        *IMitv*)   df_flags=(-P -g) ;; # AIX
+        *befhikm*) df_flags=(-P -k) ;; # IRIX
+        *hiklnP*) df_flags=(-h) ;; # OpenBSD
 
-        *"Tracker"*) # Haiku
+        *Tracker*) # Haiku
             err "Your version of df cannot be used due to the non-standard flags"
             return
         ;;
@@ -3142,7 +3142,7 @@ get_disk() {
         disk_perc="${disk_info[4]/\%}"
 
         case "$df_version" in
-            *"befhikm"*)
+            *befhikm*)
                 disk="$((disk_info[2]/1024/1024))G / $((disk_info[1]/1024/1024))G (${disk_perc}%)"
             ;;
 
@@ -3153,11 +3153,11 @@ get_disk() {
 
         # Subtitle.
         case "$disk_subtitle" in
-            "name")
+            name)
                 disk_sub="${disk_info[0]}"
             ;;
 
-            "dir")
+            dir)
                 disk_sub="${disk_info[5]/*\/}"
                 disk_sub="${disk_sub:-${disk_info[5]}}"
             ;;
@@ -3169,10 +3169,10 @@ get_disk() {
 
         # Bar.
         case "$disk_display" in
-            "bar")     disk="$(bar "$disk_perc" "100")" ;;
-            "infobar") disk+=" $(bar "$disk_perc" "100")" ;;
-            "barinfo") disk="$(bar "$disk_perc" "100")${info_color} $disk" ;;
-            "perc")    disk="${disk_perc}% $(bar "$disk_perc" "100")" ;;
+            bar)     disk="$(bar "$disk_perc" 100)" ;;
+            infobar) disk+=" $(bar "$disk_perc" 100)" ;;
+            barinfo) disk="$(bar "$disk_perc" 100)${info_color} $disk" ;;
+            perc)    disk="${disk_perc}% $(bar "$disk_perc" 100)" ;;
         esac
 
         # Append '(disk mount point)' to the subtitle.
@@ -3186,7 +3186,7 @@ get_disk() {
 
 get_battery() {
     case "$os" in
-        "Linux")
+        Linux)
             # We use 'prin' here so that we can do multi battery support
             # with a single battery per line.
             for bat in "/sys/class/power_supply/"{BAT,axp288_fuel_gauge,CMB}*; do
@@ -3197,9 +3197,9 @@ get_battery() {
                     battery="${capacity}% [${status}]"
 
                     case "$battery_display" in
-                        "bar")     battery="$(bar "$capacity" 100)" ;;
-                        "infobar") battery+=" $(bar "$capacity" 100)" ;;
-                        "barinfo") battery="$(bar "$capacity" 100)${info_color} ${battery}" ;;
+                        bar)     battery="$(bar "$capacity" 100)" ;;
+                        infobar) battery+=" $(bar "$capacity" 100)" ;;
+                        barinfo) battery="$(bar "$capacity" 100)${info_color} ${battery}" ;;
                     esac
 
                     bat="${bat/*axp288_fuel_gauge}"
@@ -3209,19 +3209,19 @@ get_battery() {
             return
         ;;
 
-        "BSD")
+        BSD)
             case "$kernel_name" in
-                "FreeBSD"* | "DragonFly"*)
+                FreeBSD* | DragonFly*)
                     battery="$(acpiconf -i 0 | awk -F ':\t' '/Remaining capacity/ {print $2}')"
                     battery_state="$(acpiconf -i 0 | awk -F ':\t\t\t' '/State/ {print $2}')"
                 ;;
 
-                "NetBSD"*)
+                NetBSD*)
                     battery="$(envstat | awk '\\(|\\)' '/charge:/ {print $2}')"
                     battery="${battery/\.*/%}"
                 ;;
 
-                "OpenBSD"* | "Bitrig"*)
+                OpenBSD* | Bitrig*)
                     battery0full="$(sysctl -n   hw.sensors.acpibat0.watthour0\
                                                 hw.sensors.acpibat0.amphour0)"
                     battery0full="${battery0full%% *}"
@@ -3234,7 +3234,7 @@ get_battery() {
                     state="${state##? (battery }"
                     state="${state%)*}"
 
-                    [[ "${state}" == "charging" ]] && battery_state="charging"
+                    [[ "${state}" == charging ]] && battery_state=charging
                     [[ "$battery0full" ]] && \
                     battery="$((100 * ${battery0now/\.} / ${battery0full/\.}))%"
                 ;;
@@ -3244,16 +3244,16 @@ get_battery() {
         "Mac OS X")
             battery="$(pmset -g batt | grep -o '[0-9]*%')"
             state="$(pmset -g batt | awk '/;/ {print $4}')"
-            [[ "$state" == "charging;" ]] && battery_state="charging"
+            [[ "$state" == "charging;" ]] && battery_state=charging
         ;;
 
-        "Windows")
+        Windows)
             battery="$(wmic Path Win32_Battery get EstimatedChargeRemaining)"
             battery="${battery/EstimatedChargeRemaining}"
             battery="$(trim "$battery")%"
         ;;
 
-        "Haiku")
+        Haiku)
             battery0full="$(awk -F '[^0-9]*' 'NR==2 {print $4}' /dev/power/acpi_battery/0)"
             battery0now="$(awk -F '[^0-9]*' 'NR==5 {print $4}' /dev/power/acpi_battery/0)"
             battery="$((battery0full * 100 / battery0now))%"
@@ -3263,21 +3263,21 @@ get_battery() {
     [[ "$battery_state" ]] && battery+=" Charging"
 
     case "$battery_display" in
-        "bar")     battery="$(bar "${battery/\%*}" 100)" ;;
-        "infobar") battery="${battery} $(bar "${battery/\%*}" 100)" ;;
-        "barinfo") battery="$(bar "${battery/\%*}" 100)${info_color} ${battery}" ;;
+        bar)     battery="$(bar "${battery/\%*}" 100)" ;;
+        infobar) battery="${battery} $(bar "${battery/\%*}" 100)" ;;
+        barinfo) battery="$(bar "${battery/\%*}" 100)${info_color} ${battery}" ;;
     esac
 }
 
 get_local_ip() {
     case "$os" in
-        "Linux" | "BSD" | "Solaris" | "AIX" | "IRIX")
+        Linux | BSD | Solaris | AIX | IRIX)
             local_ip="$(ip route get 1 | awk -F'src' '{print $2; exit}')"
             local_ip="${local_ip/uid*}"
             [[ -z "$local_ip" ]] && local_ip="$(ifconfig -a | awk '/broadcast/ {print $2; exit}')"
         ;;
 
-        "MINIX")
+        MINIX)
             local_ip="$(ifconfig | awk '{printf $3; exit}')"
         ;;
 
@@ -3286,12 +3286,12 @@ get_local_ip() {
             [[ -z "$local_ip" ]] && local_ip="$(ipconfig getifaddr en1)"
         ;;
 
-        "Windows")
+        Windows)
             local_ip="$(ipconfig | awk -F ': ' '/IPv4 Address/ {printf $2 ", "}')"
             local_ip="${local_ip%\,*}"
         ;;
 
-        "Haiku")
+        Haiku)
             local_ip="$(ifconfig | awk -F ': ' '/Bcast/ {print $2}')"
             local_ip="${local_ip/, Bcast}"
         ;;
@@ -3324,12 +3324,12 @@ get_locale() {
 
 get_gpu_driver() {
     case "$os" in
-        "Linux")
+        Linux)
             gpu_driver="$(lspci -nnk | awk -F ': ' \
                           '/Display|3D|VGA/{nr[NR+2]}; NR in nr {printf $2 ", "}')"
             gpu_driver="${gpu_driver%, }"
 
-            if [[ "$gpu_driver" == *"nvidia"* ]]; then
+            if [[ "$gpu_driver" == *nvidia* ]]; then
                 gpu_driver="$(< /proc/driver/nvidia/version)"
                 gpu_driver="${gpu_driver/*Module  }"
                 gpu_driver="NVIDIA ${gpu_driver/  *}"
@@ -3337,7 +3337,7 @@ get_gpu_driver() {
         ;;
 
         "Mac OS X")
-            if [[ "$(kextstat | grep "GeForceWeb")" != "" ]]; then
+            if [[ "$(kextstat | grep GeForceWeb)" != "" ]]; then
                 gpu_driver="NVIDIA Web Driver"
             else
                 gpu_driver="macOS Default Graphics Driver"
@@ -3349,7 +3349,7 @@ get_gpu_driver() {
 get_cols() {
     local blocks blocks2 cols
 
-    if [[ "$color_blocks" == "on" ]]; then
+    if [[ "$color_blocks" == on ]]; then
         # Convert the width to space chars.
         printf -v block_width "%${block_width}s"
 
@@ -3389,7 +3389,7 @@ get_cols() {
 
     # TosWin2 on FreeMiNT is terrible at this,
     # so we'll reset colors arbitrarily.
-    [[ "$term" == "TosWin2" ]] && printf '\e[30;47m'
+    [[ "$term" == TosWin2 ]] && printf '\e[30;47m'
 
     # Tell info() that we printed manually.
     prin=1
@@ -3398,15 +3398,15 @@ get_cols() {
 # IMAGES
 
 image_backend() {
-    [[ "$image_backend" != "off" ]] && ! type -p convert &>/dev/null && \
-        { image_backend="ascii"; err "Image: Imagemagick not found, falling back to ascii mode."; }
+    [[ "$image_backend" != off ]] && ! type -p convert &>/dev/null && \
+        { image_backend=ascii; err "Image: Imagemagick not found, falling back to ascii mode."; }
 
     case "${image_backend:-off}" in
-        "ascii") print_ascii ;;
-        "off") image_backend="off" ;;
+        ascii) print_ascii ;;
+        off) image_backend=off ;;
 
-        "caca" | "chafa" | "jp2a" | "iterm2" | "termpix" |\
-        "tycat" | "w3m" | "sixel" | "pixterm" | "kitty")
+        caca | chafa | jp2a | iterm2 | termpix |\
+        tycat | w3m | sixel | pixterm | kitty)
             get_image_source
 
             [[ ! -f "$image" ]] && {
@@ -3438,13 +3438,13 @@ image_backend() {
     esac
 
     # Set cursor position next image/ascii.
-    [[ "$image_backend" != "off" ]] && printf '\e[%sA\e[9999999D' "${lines:-0}"
+    [[ "$image_backend" != off ]] && printf '\e[%sA\e[9999999D' "${lines:-0}"
 }
 
 print_ascii() {
     if [[ -f "$image_source" && ! "$image_source" =~ (png|jpg|jpeg|jpe|svg|gif) ]]; then
         ascii_data="$(< "$image_source")"
-    elif [[ "$image_source" == "ascii" || $image_source == auto ]]; then
+    elif [[ "$image_source" == ascii || $image_source == auto ]]; then
         :
     else
         ascii_data="$image_source"
@@ -3477,7 +3477,7 @@ print_ascii() {
 
 get_image_source() {
     case "$image_source" in
-        "auto" | "wall" | "wallpaper")
+        auto | wall | wallpaper)
             get_wallpaper
         ;;
 
@@ -3509,7 +3509,7 @@ END
 )"
         ;;
 
-        "Windows")
+        Windows)
             case "$distro" in
                 "Windows XP")
                     image="/c/Documents and Settings/${USER}"
@@ -3518,7 +3518,7 @@ END
                     [[ "$kernel_name" == *CYGWIN* ]] && image="/cygdrive${image}"
                 ;;
 
-                "Windows"*)
+                Windows*)
                     image="${APPDATA}/Microsoft/Windows/Themes/TranscodedWallpaper.jpg"
                 ;;
             esac
@@ -3532,21 +3532,21 @@ END
                 { image="$(< "${HOME}/.cache/wal/wal")"; return; }
 
             case "$de" in
-                "MATE"*)
+                MATE*)
                     image="$(gsettings get org.mate.background picture-filename)"
                 ;;
 
-                "Xfce"*)
+                Xfce*)
                     image="$(xfconf-query -c xfce4-desktop -p \
-                             "/backdrop/screen0/monitor0/workspace0/last-image")"
+                             /backdrop/screen0/monitor0/workspace0/last-image)"
                 ;;
 
-                "Cinnamon"*)
+                Cinnamon*)
                     image="$(gsettings get org.cinnamon.desktop.background picture-uri)"
                     image="$(decode_url "$image")"
                 ;;
 
-                "GNOME"*)
+                GNOME*)
                     image="$(gsettings get org.gnome.desktop.background picture-uri)"
                     image="$(decode_url "$image")"
                 ;;
@@ -3578,7 +3578,7 @@ END
     esac
 
     # If image is an xml file, don't use it.
-    [[ "${image/*\./}" == "xml" ]] && image=""
+    [[ "${image/*\./}" == xml ]] && image=""
 }
 
 get_w3m_img_path() {
@@ -3596,7 +3596,7 @@ get_w3m_img_path() {
 get_window_size() {
     # This functions gets the current window size in
     # pixels.
-    [[ "$image_backend" == "kitty" ]] &&
+    [[ "$image_backend" == kitty ]] &&
         IFS=x read -r term_width term_height < <(kitty +kitten icat --print-window-size)
 
     # Get terminal width/height.
@@ -3650,7 +3650,7 @@ get_image_size() {
     get_term_size
 
     case "$image_size" in
-        "auto")
+        auto)
             image_size="$((columns * font_width / 2))"
             term_height="$((term_height - term_height / 4))"
 
@@ -3666,7 +3666,7 @@ get_image_size() {
                 image_size="$((percent * term_height / 100))"
         ;;
 
-        "none")
+        none)
             # Get image size so that we can do a better crop.
             read -r width height <<< "$(identify -format "%w %h" "$image")"
 
@@ -3674,14 +3674,14 @@ get_image_size() {
                 ((width=width/2,height=height/2))
             done
 
-            crop_mode="none"
+            crop_mode=none
         ;;
 
         *)  image_size="${image_size/px}" ;;
     esac
 
     # Check for terminal padding.
-    [[ "$image_backend" == "w3m" ]] && term_padding
+    [[ "$image_backend" == w3m ]] && term_padding
 
     width="${width:-$image_size}"
     height="${height:-$image_size}"
@@ -3695,7 +3695,7 @@ make_thumbnail() {
 
     # Handle file extensions.
     case "${image##*.}" in
-        "eps"|"pdf"|"svg"|"gif"|"png")
+        eps|pdf|svg|gif|png)
             image_name+=".png" ;;
         *)  image_name+=".jpg" ;;
     esac
@@ -3711,7 +3711,7 @@ make_thumbnail() {
         }
 
         case "$crop_mode" in
-            "fit")
+            fit)
                 c="$(convert "$image" \
                     -colorspace srgb \
                     -format "%[pixel:p{0,0}]" info:)"
@@ -3727,7 +3727,7 @@ make_thumbnail() {
                     "${thumbnail_dir}/${image_name}"
             ;;
 
-            "fill")
+            fill)
                 convert \
                     -background none \
                     "$image" \
@@ -3737,7 +3737,7 @@ make_thumbnail() {
                     "${thumbnail_dir}/${image_name}"
             ;;
 
-            "none")
+            none)
                 cp "$image" "${thumbnail_dir}/${image_name}"
             ;;
 
@@ -3760,7 +3760,7 @@ make_thumbnail() {
 
 display_image() {
     case "$image_backend" in
-        "caca")
+        caca)
             img2txt \
                 -W "$((width / font_width))" \
                 -H "$((height / font_height))" \
@@ -3768,11 +3768,11 @@ display_image() {
             "$image"
         ;;
 
-        "chafa")
+        chafa)
             chafa --size="$((width / font_width))x$((height / font_height))" "$image"
         ;;
 
-        "jp2a")
+        jp2a)
             jp2a \
                 --colors \
                 --width="$((width / font_width))" \
@@ -3780,35 +3780,35 @@ display_image() {
             "$image"
         ;;
 
-        "kitty")
+        kitty)
             kitty +kitten icat \
                 --align left \
                 --place "$((width/font_width))x$((height/font_height))@${xoffset}x${yoffset}" \
             "$image"
         ;;
 
-        "pixterm")
+        pixterm)
             pixterm \
                 -tc "$((width / font_width))" \
                 -tr "$((height / font_height))" \
             "$image"
         ;;
 
-        "sixel")
+        sixel)
             img2sixel \
                 -w "$width" \
                 -h "$height" \
             "$image"
         ;;
 
-        "termpix")
+        termpix)
             termpix \
                 --width "$((width / font_width))" \
                 --height "$((height / font_height))" \
             "$image"
         ;;
 
-        "iterm2")
+        iterm2)
             printf -v iterm_cmd '\e]1337;File=width=%spx;height=%spx;inline=1:%s' \
                 "$width" "$height" "$(base64 < "$image")"
 
@@ -3818,13 +3818,13 @@ display_image() {
             printf '%b\a\n' "$iterm_cmd"
         ;;
 
-        "tycat")
+        tycat)
             tycat \
                 -g "${width}x${height}" \
             "$image"
         ;;
 
-        "w3m")
+        w3m)
             get_w3m_img_path
             zws='\xE2\x80\x8B\x20'
 
@@ -3839,7 +3839,7 @@ display_image() {
 
 to_ascii() {
     err "$1"
-    image_backend="ascii"
+    image_backend=ascii
     print_ascii
 
     # Set cursor position next image/ascii.
@@ -3848,7 +3848,7 @@ to_ascii() {
 
 to_off() {
     err "$1"
-    image_backend="off"
+    image_backend=off
     text_padding=
 }
 
@@ -3917,7 +3917,7 @@ prin() {
 }
 
 get_underline() {
-    if [[ "$underline_enabled" == "on" ]]; then
+    if [[ "$underline_enabled" == on ]]; then
         printf -v underline "%${length}s"
         printf '%b%b\n' "${text_padding:+\e[${text_padding}C}${zws}${underline_color}" \
                         "${underline// /$underline_char}${reset} "
@@ -3930,13 +3930,13 @@ get_underline() {
 
 get_bold() {
     case "$ascii_bold" in
-        "on")  ascii_bold='\e[1m' ;;
-        "off") ascii_bold="" ;;
+        on)  ascii_bold='\e[1m' ;;
+        off) ascii_bold="" ;;
     esac
 
     case "$bold" in
-        "on")  bold='\e[1m' ;;
-        "off") bold="" ;;
+        on)  bold='\e[1m' ;;
+        off) bold="" ;;
     esac
 }
 
@@ -3973,11 +3973,11 @@ set_colors() {
     c5="$(color "$5")${ascii_bold}"
     c6="$(color "$6")${ascii_bold}"
 
-    [[ "$color_text" != "off" ]] && set_text_colors "$@"
+    [[ "$color_text" != off ]] && set_text_colors "$@"
 }
 
 set_text_colors() {
-    if [[ "${colors[0]}" == "distro" ]]; then
+    if [[ "${colors[0]}" == distro ]]; then
         title_color="$(color "$1")"
         at_color="$reset"
         underline_color="$reset"
@@ -4002,7 +4002,7 @@ set_text_colors() {
     fi
 
     # Bar colors.
-    if [[ "$bar_color_elapsed" == "distro" ]]; then
+    if [[ "$bar_color_elapsed" == distro ]]; then
         bar_color_elapsed="$(color fg)"
     else
         bar_color_elapsed="$(color "$bar_color_elapsed")"
@@ -4018,7 +4018,7 @@ set_text_colors() {
 color() {
     case "$1" in
         [0-6])    printf '%b\e[3%sm'   "$reset" "$1" ;;
-        7 | "fg") printf '\e[37m%b'    "$reset" ;;
+        7 | fg) printf '\e[37m%b'    "$reset" ;;
         *)        printf '\e[38;5;%bm' "$1" ;;
     esac
 }
@@ -4026,7 +4026,7 @@ color() {
 # OTHER
 
 stdout() {
-    image_backend="off"
+    image_backend=off
     unset subtitle_color colon_color info_color underline_color bold title_color at_color \
           text_padding zws reset color_blocks bar_color_elapsed bar_color_total \
           c1 c2 c3 c4 c5 c6 c7 c8
@@ -4103,7 +4103,7 @@ bar() {
     bar+="${bar_color_total}${total// /${bar_char_total}}"
 
     # Borders.
-    [[ "$bar_border" == "on" ]] && \
+    [[ "$bar_border" == on ]] && \
         bar="$(color fg)[${bar}$(color fg)]"
 
     printf "%b" "${bar}${info_color}"
@@ -4118,8 +4118,8 @@ cache() {
 
 get_cache_dir() {
     case "$os" in
-        "Mac OS X") cache_dir="/Library/Caches" ;;
-        *)          cache_dir="/tmp" ;;
+        "Mac OS X") cache_dir=/Library/Caches ;;
+        *)          cache_dir=/tmp ;;
     esac
 }
 
@@ -4153,7 +4153,7 @@ term_padding() {
     [[ -z "$term" ]] && get_term
 
     case "$term" in
-        urxvt*|"rxvt-unicode")
+        urxvt*|rxvt-unicode)
             [[ -z "$xrdb" ]] &&
                 xrdb="$(xrdb -query)"
 
@@ -4170,9 +4170,9 @@ term_padding() {
 }
 
 dynamic_prompt() {
-    [[ "$image_backend" == "off" ]]   && { printf '\n'; return; }
-    [[ "$image_backend" != "ascii" ]] && ((lines=(height + yoffset) / font_height + 1))
-    [[ "$image_backend" == "w3m" ]]   && ((lines=lines + padding / font_height + 1))
+    [[ "$image_backend" == off ]]   && { printf '\n'; return; }
+    [[ "$image_backend" != ascii ]] && ((lines=(height + yoffset) / font_height + 1))
+    [[ "$image_backend" == w3m ]]   && ((lines=lines + padding / font_height + 1))
 
     # If the ascii art is taller than the info.
     ((lines=lines>info_height?lines-info_height+1:1))
@@ -4190,7 +4190,7 @@ cache_uname() {
     kernel_version="${uname[1]}"
     kernel_machine="${uname[2]}"
 
-    if [[ "$kernel_name" == "Darwin" ]]; then
+    if [[ "$kernel_name" == Darwin ]]; then
         IFS=$'\n' read -d "" -ra sw_vers < <(awk -F'<|>' '/string/ {print $3}' \
                             "/System/Library/CoreServices/SystemVersion.plist")
         darwin_name="${sw_vers[2]}"
@@ -4202,12 +4202,12 @@ cache_uname() {
 get_ppid() {
     # Get parent process ID of PID.
     case "$os" in
-        "Windows")
+        Windows)
             ppid="$(ps -p "${1:-$PPID}" | awk '{printf $2}')"
             ppid="${ppid/PPID}"
         ;;
 
-        "Linux")
+        Linux)
             ppid="$(grep -i -F "PPid:" "/proc/${1:-$PPID}/status")"
             ppid="$(trim "${ppid/PPid:}")"
         ;;
@@ -4223,13 +4223,13 @@ get_ppid() {
 get_process_name() {
     # Get PID name.
     case "$os" in
-        "Windows")
+        Windows)
             name="$(ps -p "${1:-$PPID}" | awk '{printf $8}')"
             name="${name/COMMAND}"
             name="${name/*\/}"
         ;;
 
-        "Linux")
+        Linux)
             name="$(< "/proc/${1:-$PPID}/comm")"
         ;;
 
@@ -4497,8 +4497,8 @@ get_args() {
             "--gpu_type") gpu_type="$2" ;;
             "--refresh_rate") refresh_rate="$2" ;;
             "--gtk_shorthand") gtk_shorthand="$2" ;;
-            "--gtk2") gtk2="$2" ;;
-            "--gtk3") gtk3="$2" ;;
+            --gtk2) gtk2="$2" ;;
+            --gtk3) gtk3="$2" ;;
             "--shell_path") shell_path="$2" ;;
             "--shell_version") shell_version="$2" ;;
             "--ip_host") public_ip_host="$2" ;;
@@ -4509,7 +4509,7 @@ get_args() {
             "--memory_percent") memory_percent="$2" ;;
             "--cpu_temp")
                 cpu_temp="$2"
-                [[ "$cpu_temp" == "on" ]] && cpu_temp="C"
+                [[ "$cpu_temp" == on ]] && cpu_temp=C
             ;;
 
             "--disk_subtitle") disk_subtitle="$2" ;;
@@ -4524,10 +4524,10 @@ get_args() {
                 done
             ;;
 
-            "--disable")
+            --disable)
                 for func in "$@"; do
                     case "$func" in
-                        "--disable") continue ;;
+                        --disable) continue ;;
                         "-"*) break ;;
                         *)
                             ((bash_version >= 4)) && func="${func,,}"
@@ -4538,7 +4538,7 @@ get_args() {
             ;;
 
             # Text Colors
-            "--colors")
+            --colors)
                 unset colors
                 for arg in "$2" "$3" "$4" "$5" "$6" "$7"; do
                     case "$arg" in
@@ -4550,10 +4550,10 @@ get_args() {
             ;;
 
             # Text Formatting
-            "--underline") underline_enabled="$2" ;;
+            --underline) underline_enabled="$2" ;;
             "--underline_char") underline_char="$2" ;;
-            "--bold") bold="$2" ;;
-            "--separator") separator="$2" ;;
+            --bold) bold="$2" ;;
+            --separator) separator="$2" ;;
 
             # Color Blocks
             "--color_blocks") color_blocks="$2" ;;
@@ -4580,10 +4580,10 @@ get_args() {
             "--disk_display") disk_display="$2" ;;
 
             # Image backend
-            "--backend") image_backend="$2" ;;
-            "--source") image_source="$2" ;;
-            "--ascii" | "--caca" | "--chafa" | "--jp2a" | "--iterm2" | "--off" | "--pixterm" |\
-            "--sixel" | "--termpix" | "--tycat" | "--w3m" | "--kitty")
+            --backend) image_backend="$2" ;;
+            --source) image_source="$2" ;;
+            --ascii | --caca | --chafa | --jp2a | --iterm2 | --off | --pixterm |\
+            --sixel | --termpix | --tycat | --w3m | --kitty)
                 image_backend="${1/--}"
                 case "$2" in
                     "-"* | "") ;;
@@ -4592,18 +4592,18 @@ get_args() {
             ;;
 
             # Image options
-            "--loop") image_loop="on" ;;
-            "--image_size" | "--size") image_size="$2" ;;
+            --loop) image_loop=on ;;
+            "--image_size" | --size) image_size="$2" ;;
             "--crop_mode") crop_mode="$2" ;;
             "--crop_offset") crop_offset="$2" ;;
-            "--xoffset") xoffset="$2" ;;
-            "--yoffset") yoffset="$2" ;;
+            --xoffset) xoffset="$2" ;;
+            --yoffset) yoffset="$2" ;;
             "--background_color" | "--bg_color") background_color="$2" ;;
-            "--gap") gap="$2" ;;
-            "--clean")
+            --gap) gap="$2" ;;
+            --clean)
                 [[ -d "$thumbnail_dir" ]] && rm -rf "$thumbnail_dir"
-                rm -rf "/Library/Caches/neofetch/"
-                rm -rf "/tmp/neofetch/"
+                rm -rf /Library/Caches/neofetch/
+                rm -rf /tmp/neofetch/
                 exit
             ;;
 
@@ -4611,7 +4611,7 @@ get_args() {
                 unset ascii_colors
                 for arg in "$2" "$3" "$4" "$5" "$6" "$7"; do
                     case "$arg" in
-                        "-"*) break ;;
+                        -*) break ;;
                         *) ascii_colors+=("$arg")
                     esac
                 done
@@ -4619,43 +4619,43 @@ get_args() {
             ;;
 
             "--ascii_distro")
-                image_backend="ascii"
+                image_backend=ascii
                 ascii_distro="$2"
             ;;
 
             "--ascii_bold") ascii_bold="$2" ;;
-            "--logo" | "-L")
-                image_backend="ascii"
+            --logo | -L)
+                image_backend=ascii
                 print_info() { printf '\n'; }
             ;;
 
             # Other
-            "--config")
+            --config)
                 case "$2" in
-                    "none" | "off" | "") ;;
+                    none | off | "") ;;
                     *)
                         config_file="$(get_full_path "$2")"
                         get_user_config
                     ;;
                 esac
             ;;
-            "--stdout") stdout="on" ;;
-            "-v") verbose="on" ;;
+            --stdout) stdout=on ;;
+            -v) verbose=on ;;
             "--print_config") printf '%s\n' "$config"; exit ;;
-            "-vv") set -x; verbose="on" ;;
-            "--help") usage ;;
-            "--version")
+            -vv) set -x; verbose=on ;;
+            --help) usage ;;
+            --version)
                 printf '%s\n' "Neofetch $version"
                 exit 1
             ;;
-            "--gen-man")
+            --gen-man)
                 help2man -n "A fast, highly customizable system info script" \
                           -N ./neofetch -o neofetch.1
                 exit 1
             ;;
 
-            "--json")
-                json="on"
+            --json)
+                json=on
                 unset -f get_title get_cols get_underline
 
                 printf '{\n'
@@ -4665,56 +4665,56 @@ get_args() {
                 exit
             ;;
 
-            "--travis")
+            --travis)
                 print_info() {
                     info title
                     info underline
 
-                    info "OS" distro
-                    info "Host" model
-                    info "Kernel" kernel
-                    info "Uptime" uptime
-                    info "Packages" packages
-                    info "Shell" shell
-                    info "Resolution" resolution
-                    info "DE" de
-                    info "WM" wm
+                    info OS distro
+                    info Host model
+                    info Kernel kernel
+                    info Uptime uptime
+                    info Packages packages
+                    info Shell shell
+                    info Resolution resolution
+                    info DE de
+                    info WM wm
                     info "WM Theme" wm_theme
-                    info "Theme" theme
-                    info "Icons" icons
-                    info "Terminal" term
+                    info Theme theme
+                    info Icons icons
+                    info Terminal term
                     info "Terminal Font" term_font
-                    info "CPU" cpu
-                    info "GPU" gpu
+                    info CPU cpu
+                    info GPU gpu
                     info "GPU Driver" gpu_driver
-                    info "Memory" memory
+                    info Memory memory
 
                     info "CPU Usage" cpu_usage
-                    info "Disk" disk
-                    info "Battery" battery
-                    info "Font" font
-                    info "Song" song
+                    info Disk disk
+                    info Battery battery
+                    info Font font
+                    info Song song
                     info "Local IP" local_ip
                     info "Public IP" public_ip
-                    info "Users" users
+                    info Users users
 
                     info cols
 
                     # Testing.
-                    prin "prin"
-                    prin "prin" "prin"
+                    prin prin
+                    prin prin prin
 
                     # Testing no subtitles.
                     info uptime
                     info disk
                 }
 
-                refresh_rate="on"
-                shell_version="on"
-                cpu_display="infobar"
-                memory_display="infobar"
-                disk_display="infobar"
-                cpu_temp="C"
+                refresh_rate=on
+                shell_version=on
+                cpu_display=infobar
+                memory_display=infobar
+                disk_display=infobar
+                cpu_temp=C
 
                 # Known implicit unused variables.
                 mpc_args=()
@@ -4728,7 +4728,7 @@ get_args() {
 
 get_simple() {
     while [[ "$1" ]]; do
-        [[ "$(type -t "get_$1")" == "function" ]] && {
+        [[ "$(type -t "get_$1")" == function ]] && {
             get_distro
             stdout
             simple=1
@@ -4749,7 +4749,7 @@ get_distro_ascii() {
     #
     # $ascii_distro is the same as $distro.
     case "$(trim "$ascii_distro")" in
-        "AIX"*)
+        AIX*)
             set_colors 2 7
             read -rd '' ascii_data <<'EOF'
 ${c1}           `:+ssssossossss+-`
@@ -4787,7 +4787,7 @@ ${c2}//      ${c1}\\  \\
 EOF
         ;;
 
-        "Alpine"*)
+        Alpine*)
             set_colors 4 5 7 6
             read -rd '' ascii_data <<'EOF'
 ${c1}       .hddddddddddddddddddddddh.
@@ -4813,7 +4813,7 @@ hdddyo+ohddyosdddddddddho+oydddy++ohdddh
 EOF
         ;;
 
-        "Amazon"*)
+        Amazon*)
             set_colors 3 7
             read -rd '' ascii_data <<'EOF'
 ${c1}             `-/oydNNdyo:.`
@@ -4838,7 +4838,7 @@ dMMMMMMMMMMMMMMMMh    yMMMMMMMMMMMMMMMMd
 EOF
         ;;
 
-        "Anarchy"*)
+        Anarchy*)
             set_colors 7 4
             read -rd '' ascii_data <<'EOF'
                          ${c2}..${c1}
@@ -4872,7 +4872,7 @@ EOF
 EOF
         ;;
 
-        "Android"*)
+        Android*)
             set_colors 2 7
             read -rd '' ascii_data <<'EOF'
 ${c1}         -o          o-
@@ -4896,7 +4896,7 @@ ${c1}         -o          o-
 EOF
         ;;
 
-        "Antergos"*)
+        Antergos*)
             set_colors 4 6
             read -rd '' ascii_data <<'EOF'
 ${c2}              `.-/::/-``
@@ -4921,7 +4921,7 @@ dmmmdddddddhhhyso${c1}++++++${c2}shhhhhddddddmmmmh
 EOF
         ;;
 
-        "antiX"*)
+        antiX*)
             set_colors 1 7 3
             read -rd '' ascii_data <<'EOF'
 ${c1}
@@ -4940,7 +4940,7 @@ ${c1}
 EOF
         ;;
 
-        "AOSC"*)
+        AOSC*)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
 ${c2}             .:+syhhhhys+:.
@@ -4966,7 +4966,7 @@ ${c2}             .:+syhhhhys+:.
 EOF
         ;;
 
-        "Apricity"*)
+        Apricity*)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
 ${c2}                                    ./o-
@@ -5007,7 +5007,7 @@ ooooo          ${c1}<oooo>${c2}
 EOF
         ;;
 
-        "ArcoLinux"*)
+        ArcoLinux*)
             set_colors 7 4
             read -rd '' ascii_data <<'EOF'
 ${c2}                    /-
@@ -5068,7 +5068,7 @@ ${c1}?KGHE ${c2}\_-#DASDFLSV='${c1}    'EF
 EOF
         ;;
 
-        "ArchBox"*)
+        ArchBox*)
             set_colors 2 7 1
             read -rd '' ascii_data <<'EOF'
 ${c1}              ...:+oh/:::..
@@ -5093,7 +5093,7 @@ ${c1}              ...:+oh/:::..
 EOF
         ;;
 
-        "ARCHlabs"*)
+        ARCHlabs*)
             set_colors 6 6 7 1
             read -rd '' ascii_data <<'EOF'
 ${c1}                     'c'
@@ -5120,7 +5120,7 @@ ${c1}                     'c'
 EOF
         ;;
 
-        *"XFerience"*)
+        *XFerience*)
             set_colors 6 6 7 1
             read -rd '' ascii_data <<'EOF'
 ${c1}           ``--:::::::-.`
@@ -5145,7 +5145,7 @@ ${c1}           ``--:::::::-.`
 EOF
         ;;
 
-        "ArchMerge"*)
+        ArchMerge*)
             set_colors 6 6 7 1
             read -rd '' ascii_data <<'EOF'
 ${c1}                    y:
@@ -5171,7 +5171,7 @@ ${c1}                    y:
 EOF
         ;;
 
-        "Arch"*)
+        Arch*)
             set_colors 6 6 7 1
             read -rd '' ascii_data <<'EOF'
 ${c1}                   -`
@@ -5196,7 +5196,7 @@ ${c2}        .oossssso-````/ossssss+`
 EOF
         ;;
 
-        "Artix"*)
+        Artix*)
             set_colors 6 6 7 1
             read -rd '' ascii_data <<'EOF'
 ${c1}              .'
@@ -5218,7 +5218,7 @@ ${c1}              .'
 EOF
         ;;
 
-        "Arya"*)
+        Arya*)
             set_colors 2 1
             read -rd '' ascii_data <<'EOF'
 ${c1}                `oyyy/${c2}-yyyyyy+
@@ -5239,7 +5239,7 @@ ${c1}:syyyyyy/     :yyyyyy/${c2}-yyo.:syyyyyyyyyyy
 EOF
         ;;
 
-        "Bedrock"*)
+        Bedrock*)
             set_colors 8 7
             read -rd '' ascii_data <<'EOF'
 ${c1}--------------------------------------
@@ -5262,7 +5262,7 @@ ${c1}--------------------------------------
 EOF
         ;;
 
-        "Bitrig"*)
+        Bitrig*)
             set_colors 2 7
             read -rd '' ascii_data <<'EOF'
 ${c1}   `hMMMMN+
@@ -5285,7 +5285,7 @@ sm/         /ms
 EOF
         ;;
 
-        "BLAG"*)
+        BLAG*)
             set_colors 5 7
             read -rd '' ascii_data <<'EOF'
 ${c1}             d
@@ -5308,7 +5308,7 @@ ${c1}             d
 EOF
         ;;
 
-        "BlankOn"*)
+        BlankOn*)
             set_colors 1 7 3
             read -rd '' ascii_data <<'EOF'
 ${c2}        `./ohdNMMMMNmho+.` ${c1}       .+oo:`
@@ -5331,7 +5331,7 @@ ${c2}           `.:/++++/:.`           ${c1}:oys+.
 EOF
         ;;
 
-        "BlueLight"*)
+        BlueLight*)
             set_colors 7 4
             read -rd '' ascii_data <<'EOF'
 ${c1}              oMMNMMMMMMMMMMMMMMMMMMMMMM
@@ -5356,7 +5356,7 @@ ${c1}              oMMNMMMMMMMMMMMMMMMMMMMMMM
 EOF
         ;;
 
-       "BSD")
+       BSD)
             set_colors 1 7 4 3 6
             read -rd '' ascii_data <<'EOF'
 ${c1}             ,        ,
@@ -5381,7 +5381,7 @@ ${c4}<----|====${c1}O)))${c4}==${c1}) \) /${c4}====|
 EOF
         ;;
 
-        "BunsenLabs"*)
+        BunsenLabs*)
             set_colors fg 7
             read -rd '' ascii_data <<'EOF'
 ${c1}        `++
@@ -5407,7 +5407,7 @@ ${c1}        `++
 EOF
         ;;
 
-        "Calculate"*)
+        Calculate*)
             set_colors 7 3
             read -rd '' ascii_data <<'EOF'
 ${c1}                              ......
@@ -5433,7 +5433,7 @@ ${c1}                              ......
 EOF
         ;;
 
-        "CentOS"*)
+        CentOS*)
             set_colors 3 2 4 5 7
             read -rd '' ascii_data <<'EOF'
 ${c1}                 ..
@@ -5458,7 +5458,7 @@ ${c2}              <><><><>
 EOF
         ;;
 
-        "Chakra"*)
+        Chakra*)
             set_colors 4 5 7 6
             read -rd '' ascii_data <<'EOF'
 ${c1}     _ _ _        "kkkkkkkk.
@@ -5482,7 +5482,7 @@ ${c1}     _ _ _        "kkkkkkkk.
 EOF
         ;;
 
-        "ChaletOS"*)
+        ChaletOS*)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
 ${c1}             `.//+osso+/:``
@@ -5508,7 +5508,7 @@ ${c1}             `.//+osso+/:``
 EOF
         ;;
 
-        "Chapeau"*)
+        Chapeau*)
             set_colors 2 7
             read -rd '' ascii_data <<'EOF'
 ${c1}               .-/-.
@@ -5532,7 +5532,7 @@ ${c1}               .-/-.
 EOF
         ;;
 
-        "Chrom"*)
+        Chrom*)
             set_colors 2 1 3 4 7
             read -rd '' ascii_data <<'EOF'
 ${c2}            .,:loool:,.
@@ -5556,7 +5556,7 @@ ${c1}            ..,:${c3}dOkxl:.
 EOF
         ;;
 
-        "ClearOS"*)
+        ClearOS*)
             set_colors 2
             read -rd '' ascii_data <<'EOF'
 ${c1}             `.--::::::--.`
@@ -5608,7 +5608,7 @@ ${c4}GG${c3}WWWWWWWWWWWWWWWW
 EOF
         ;;
 
-        "Clover"*)
+        Clover*)
             set_colors 2 6
             read -rd '' ascii_data <<'EOF'
 ${c1}               `omo``omo`
@@ -5634,7 +5634,7 @@ oNMMMMMMMMMMMNs`  `sy`  `oNMMMMMMMMMMMNo
 EOF
         ;;
 
-        "Condres"*)
+        Condres*)
             set_colors 2 3 6
             read -rd '' ascii_data <<'EOF'
 ${c1}syyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy+${c3}.+.
@@ -5696,7 +5696,7 @@ ${c2}\/${c1}-____${c2}\/
 EOF
         ;;
 
-        "CRUX"*)
+        CRUX*)
             set_colors 4 5 7 6
             read -rd '' ascii_data <<'EOF'
 ${c1}         odddd
@@ -5732,7 +5732,7 @@ ${c1}  _____
 EOF
         ;;
 
-        "Debian"*)
+        Debian*)
             set_colors 1 7 3
             read -rd '' ascii_data <<'EOF'
 ${c2}       _,met$$$$$gg.
@@ -5755,7 +5755,7 @@ ${c2}  `Y$$
 EOF
         ;;
 
-        "Deepin"*)
+        Deepin*)
             set_colors 2 7
             read -rd '' ascii_data <<'EOF'
 ${c1}             ............
@@ -5779,7 +5779,7 @@ ${c1}             ............
 EOF
         ;;
 
-        "DesaOS")
+        DesaOS)
             set_colors 2 7
             read -rd '' ascii_data <<'EOF'
 ${c1}███████████████████████
@@ -5801,7 +5801,7 @@ ${c1}███████████████████████
 EOF
         ;;
 
-        "Devuan"*)
+        Devuan*)
             set_colors 5 7
             read -rd '' ascii_data <<'EOF'
 ${c1}   ..,,;;;::;,..
@@ -5822,7 +5822,7 @@ ${c1}   ..,,;;;::;,..
 EOF
         ;;
 
-        "DracOS"*)
+        DracOS*)
             set_colors 1 7 3
             read -rd '' ascii_data <<'EOF'
 ${c1}       `-:/-
@@ -5875,7 +5875,7 @@ ${c1}  |
 EOF
         ;;
 
-        "DragonFly"*)
+        DragonFly*)
             set_colors 1 7 3
             read -rd '' ascii_data <<'EOF'
 ${c2},--,           ${c1}|           ${c2},--,
@@ -5896,7 +5896,7 @@ ${c1}              | |
 EOF
         ;;
 
-        "Elementary"*)
+        Elementary*)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
 ${c2}         eeeeeeeeeeeeeeeee
@@ -5919,7 +5919,7 @@ eee    eeeeeeeeee     eeeeee    eee
 EOF
         ;;
 
-        "Endless"*)
+        Endless*)
             set_colors 1 7
             read -rd '' ascii_data <<'EOF'
 ${c1}           `:+yhmNMMMMNmhy+:`
@@ -5945,7 +5945,7 @@ dMm     `/++/-``/yNNh+/sdNMNddMm-    mMd
 EOF
         ;;
 
-        "Exherbo"*)
+        Exherbo*)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
 ${c2} ,
@@ -5973,7 +5973,7 @@ KX  '0XdKMMK;.xMMMk, .0MMMMMXx;  ...
 EOF
         ;;
 
-        "Fedora"* | "RFRemix"*)
+        Fedora* | RFRemix*)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
 ${c1}          /:-------------:\\
@@ -6009,7 +6009,7 @@ ${c1} /\\ _____ /\\
 EOF
         ;;
 
-        "FreeBSD"*)
+        FreeBSD*)
             set_colors 1 7 3
             read -rd '' ascii_data <<'EOF'
    ${c2}```                        ${c1}`
@@ -6030,7 +6030,7 @@ EOF
 EOF
         ;;
 
-        "FreeMiNT"*)
+        FreeMiNT*)
             # Don't explicitly set colors since
             # TosWin2 doesn't reset well.
             read -rd '' ascii_data <<'EOF'
@@ -6052,7 +6052,7 @@ ${c1}          ##
 EOF
         ;;
 
-        "Frugalware"*)
+        Frugalware*)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
 ${c1}          `++/::-.`
@@ -6081,7 +6081,7 @@ ${c1}          `++/::-.`
 EOF
         ;;
 
-        "Funtoo"*)
+        Funtoo*)
             set_colors 5 7
             read -rd '' ascii_data <<'EOF'
 ${c1}   .dKXXd                         .
@@ -6097,7 +6097,7 @@ xXXXXXX, cXXXNNNXXXXNNXXXXXXXXNNNNKOOK; d0O .k
 EOF
         ;;
 
-        "GalliumOS"*)
+        GalliumOS*)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
 ${c1}sooooooooooooooooooooooooooooooooooooo+:
@@ -6135,7 +6135,7 @@ ${c2} \        )
 EOF
         ;;
 
-        "Gentoo"*)
+        Gentoo*)
             set_colors 5 7
             read -rd '' ascii_data <<'EOF'
 ${c1}         -/oyddmdhs+:.
@@ -6159,7 +6159,7 @@ yM${c2}MNNNNNNNmmmmmNNMmhs+/${c1}-`
 EOF
         ;;
 
-        "Pentoo"*)
+        Pentoo*)
             set_colors 5 7
             read -rd '' ascii_data <<'EOF'
 ${c2}           `:oydNNMMMMNNdyo:`
@@ -6186,7 +6186,7 @@ MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
 EOF
         ;;
 
-        "gNewSense"*)
+        gNewSense*)
             set_colors 4 5 7 6
             read -rd '' ascii_data <<'EOF'
 ${c1}                     ..,,,,..
@@ -6204,7 +6204,7 @@ ollllllh          +llllllllllll+          hllllllo
 EOF
         ;;
 
-        "GNU")
+        GNU)
             set_colors fg 7
             read -rd '' ascii_data <<'EOF'
 ${c1}    _-`````-,           ,- '- .
@@ -6228,7 +6228,7 @@ ${c1}    _-`````-,           ,- '- .
 EOF
         ;;
 
-        "GoboLinux"*)
+        GoboLinux*)
             set_colors 5 4 6 2
             read -rd '' ascii_data <<'EOF'
 ${c1}  _____       _
@@ -6240,7 +6240,7 @@ ${c1}  _____       _
 EOF
         ;;
 
-        "Grombyang"*)
+        Grombyang*)
             set_colors 4 2 1
             read -rd '' ascii_data <<'EOF'
 ${c1}            eeeeeeeeeeee
@@ -6264,7 +6264,7 @@ eee        ${c2}//  \\ooo/  \\\        ${c1}eee
 EOF
         ;;
 
-        "GuixSD"*)
+        GuixSD*)
             set_colors 3 7 6 1 8
             read -rd '' ascii_data <<'EOF'
 ${c1} ..                             `.
@@ -6280,7 +6280,7 @@ ${c1} ..                             `.
 EOF
         ;;
 
-        "Haiku"*)
+        Haiku*)
             set_colors 2 8
             read -rd '' ascii_data <<'EOF'
 ${c2}          :dc'
@@ -6303,7 +6303,7 @@ ${c2}          :dc'
 EOF
         ;;
 
-        "Huayra"*)
+        Huayra*)
             set_colors 4 7
             read -rd '' ascii_data <<'EOF'
 ${c2}                     `
@@ -6326,7 +6326,7 @@ ${c2}                     `
 EOF
         ;;
 
-        "Hyperbola"*)
+        Hyperbola*)
             set_colors 8
             read -rd '' ascii_data <<'EOF'
 ${c1}                     WW
@@ -6348,7 +6348,7 @@ WW                           W
 EOF
         ;;
 
-        "januslinux"*|"janus"*)
+        januslinux*|janus*)
             set_colors 4 7 4
             read -rd '' ascii_data <<'EOF'
 ${c1}oooooooooooooooooooooooooooooooo
@@ -6370,7 +6370,7 @@ oooooooooollllllllllllcccccccccc
 EOF
         ;;
 
-        "Kali"*)
+        Kali*)
             set_colors 4 8
             read -rd '' ascii_data <<'EOF'
 ${c1}..............
@@ -6397,7 +6397,7 @@ ${c1}..............
 EOF
         ;;
 
-        "KaOS"*)
+        KaOS*)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
 ${c1}                     ..
@@ -6419,7 +6419,7 @@ KKKKKKS. .SSAA..
 EOF
         ;;
 
-        "KDE"*)
+        KDE*)
             set_colors 2 7
             read -rd '' ascii_data <<'EOF'
 ${c1}             `..---+/---..`
@@ -6444,7 +6444,7 @@ ${c1}             `..---+/---..`
 EOF
         ;;
 
-        "Kibojoe"*)
+        Kibojoe*)
             set_colors 2 7 4
             read -rd '' ascii_data <<'EOF'
             ${c3}           ./+oooooo+/.
@@ -6463,7 +6463,7 @@ ods+/:-----://+oyydmNMMMMMMMMMMMMMMMMMN-
 EOF
         ;;
 
-        "Kogaion"*)
+        Kogaion*)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
 ${c1}            ;;      ,;
@@ -6489,7 +6489,7 @@ ${c1}            ;;      ,;
 EOF
         ;;
 
-        "Korora"*)
+        Korora*)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
 ${c2}                ____________
@@ -6511,7 +6511,7 @@ ${c2}                ____________
 EOF
         ;;
 
-        "KSLinux"*)
+        KSLinux*)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
 ${c1} K   K U   U RRRR   ooo
@@ -6528,7 +6528,7 @@ ${c2}  SSS   AAA  W   W  AAA
 EOF
         ;;
 
-        "Kubuntu"*)
+        Kubuntu*)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
 ${c1}           `.:/ossyyyysso/:.
@@ -6554,7 +6554,7 @@ oyyyyysos${c2}dy${c1}yyyyyyyyyyyyyyyyyy${c2}dMMMMy${c1}syyyo
 EOF
         ;;
 
-        "LEDE"*)
+        LEDE*)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
     ${c1} _________
@@ -6569,7 +6569,7 @@ EOF
 EOF
         ;;
 
-        "Linux")
+        Linux)
             set_colors fg 8 3
             read -rd '' ascii_data <<'EOF'
 ${c2}        #####
@@ -6613,7 +6613,7 @@ ${c1}          ,xXc
 EOF
         ;;
 
-        "LMDE"*)
+        LMDE*)
             set_colors 2 7
             read -rd '' ascii_data <<'EOF'
          ${c2}`.-::---..
@@ -6636,7 +6636,7 @@ ${c1}       ${c2}.${c1}:+-.
 EOF
         ;;
 
-        "Lubuntu"*)
+        Lubuntu*)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
 ${c1}           `-mddhhhhhhhhhddmss`
@@ -6662,7 +6662,7 @@ hhhhhhy/ `syyyssyyyyhhhhhh: :yhhhhhhhhhhs
 EOF
         ;;
 
-        "Lunar"*)
+        Lunar*)
             set_colors 4 7 3
             read -rd '' ascii_data <<'EOF'
 ${c1}`-.                                 `-.
@@ -6681,7 +6681,7 @@ ${c3}          __
 EOF
         ;;
 
-        "mac"*"_small")
+        mac*"_small")
             set_colors 2 3 1 5 4
             read -rd '' ascii_data <<'EOF'
 ${c1}       .:'
@@ -6695,7 +6695,7 @@ ${c5}  `._.-._.'
 EOF
         ;;
 
-        "mac" | "Darwin")
+        mac | Darwin)
             set_colors 2 3 1 1 5 4
             read -rd '' ascii_data <<'EOF'
 ${c1}                    'c.
@@ -6718,7 +6718,7 @@ ${c4}.MMMMMMMMMMMMMMMMMMMMMMMMX.
 EOF
         ;;
 
-        "Mageia"*)
+        Mageia*)
             set_colors 6 7
             read -rd '' ascii_data <<'EOF'
 ${c1}        .°°.
@@ -6743,7 +6743,7 @@ lOO.                .OO:
 EOF
         ;;
 
-        "MagpieOS"*)
+        MagpieOS*)
             set_colors 2 1 3 5
             read -rd '' ascii_data <<'EOF'
 ${c1}        ;00000     :000Ol
@@ -6769,7 +6769,7 @@ o00.              k0O${c2}dddddd${c1}occ
 EOF
         ;;
 
-        "Mandriva"*)
+        Mandriva*)
             set_colors 4 3
             read -rd '' ascii_data <<'EOF'
 ${c2}                        ``
@@ -6790,7 +6790,7 @@ ${c1}    -/+ooo+/-.              ${c2}`
 EOF
         ;;
 
-        "Manjaro"*)
+        Manjaro*)
             set_colors 2 7
             read -rd '' ascii_data <<'EOF'
 ${c1}██████████████████  ████████
@@ -6810,7 +6810,7 @@ ${c1}██████████████████  ██████�
 EOF
         ;;
 
-        "Maui"*)
+        Maui*)
             set_colors 6 7
             read -rd '' ascii_data <<'EOF'
 ${c1}             `.-://////:--`
@@ -6836,7 +6836,7 @@ ${c1}             `.-://////:--`
 EOF
         ;;
 
-        "Mer"*)
+        Mer*)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
 ${c1}                         dMs
@@ -6869,7 +6869,7 @@ NNd   sNN-  -NNs  -mMNs-.--..:dMMh`  dNN
 EOF
         ;;
 
-        "Minix"*)
+        Minix*)
             set_colors 1 7 3
             read -rd '' ascii_data <<'EOF'
 ${c2}   -sdhyo+:-`                -/syymm:
@@ -6892,7 +6892,7 @@ ${c2}   -sdhyo+:-`                -/syymm:
 EOF
         ;;
 
-        "Linux Mint"* | "LinuxMint"*)
+        "Linux Mint"* | LinuxMint*)
             set_colors 2 7
             read -rd '' ascii_data <<'EOF'
 ${c1}MMMMMMMMMMMMMMMMMMMMMMMMMmds+.
@@ -6914,7 +6914,7 @@ ddddMMh  ${c2}dMM   :hNMNMNhNMNMNh: ${c1}`NMm
 EOF
         ;;
 
-        "MX"*)
+        MX*)
             set_colors 4 6 7
             read -rd '' ascii_data <<'EOF'
 ${c3}MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMNMMMMMMMMM
@@ -6937,7 +6937,7 @@ MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
 EOF
         ;;
 
-        "Namib"*)
+        Namib*)
             set_colors 1
             read -rd '' ascii_data <<'EOF'
 ${c1}          .:+shysyhhhhysyhs+:.
@@ -6963,7 +6963,7 @@ sd yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy ds
 EOF
         ;;
 
-        "NetBSD"*)
+        NetBSD*)
             set_colors 5 7
             read -rd '' ascii_data <<'EOF'
 ${c1}                     `-/oshdmNMNdhyo+:-`
@@ -6986,7 +6986,7 @@ ${c2}     :M+
 EOF
         ;;
 
-        "Netrunner"*)
+        Netrunner*)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
 ${c1}           .:oydmMMMMMMmdyo:`
@@ -7012,7 +7012,7 @@ mMMMMMMMMMMMMMMMMMs    -NMMMMMMMMMMMMMMd
 EOF
         ;;
 
-        "Nitrux"*)
+        Nitrux*)
             set_colors 4
             read -rd '' ascii_data <<'EOF'
 ${c1}`:/.
@@ -7049,7 +7049,7 @@ EOF
 EOF
         ;;
 
-        "NixOS"*)
+        NixOS*)
             set_colors 4 6
             read -rd '' ascii_data <<'EOF'
 ${c1}          ::::.    ${c2}':::::     ::::'
@@ -7074,7 +7074,7 @@ ${c1}         .::::      ::::      ${c2}'::::.
 EOF
         ;;
 
-        "Nurunner"*)
+        Nurunner*)
             set_colors 4
             read -rd '' ascii_data <<'EOF'
 ${c1}                  ,xc
@@ -7099,7 +7099,7 @@ ${c1}                  ,xc
 EOF
         ;;
 
-        "NuTyX"*)
+        NuTyX*)
             set_colors 4 1
             read -rd '' ascii_data <<'EOF'
 ${c1}                                      .
@@ -7128,7 +7128,7 @@ ${c1}                                      .
 EOF
         ;;
 
-        "OBRevenge"*)
+        OBRevenge*)
             set_colors 1 7 3
             read -rd '' ascii_data <<'EOF'
 ${c1}   __   __
@@ -7165,7 +7165,7 @@ ${c1}      _____
 EOF
         ;;
 
-        "OpenBSD"*)
+        OpenBSD*)
             set_colors 3 7 6 1 8
             read -rd '' ascii_data <<'EOF'
 ${c3}                                     _
@@ -7194,7 +7194,7 @@ ${c1} `-|.'   /_.          ${c4}\_|  ${c1} F
 EOF
         ;;
 
-        "OpenIndiana"*)
+        OpenIndiana*)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
 ${c2}                         .sy/
@@ -7217,7 +7217,7 @@ EOF
         ;;
 
 
-        "OpenMandriva"*)
+        OpenMandriva*)
             set_colors 4
             read -rd '' ascii_data <<'EOF'
 ${c1}                  ``````
@@ -7245,7 +7245,7 @@ ${c1}                  ``````
 EOF
         ;;
 
-        "OpenWrt"*)
+        OpenWrt*)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
 ${c1} _______
@@ -7260,7 +7260,7 @@ ${c1} _______
 EOF
         ;;
 
-        "Open Source Media Center"* | "osmc")
+        "Open Source Media Center"* | osmc)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
 ${c1}            -+shdmNNNNmdhs+-
@@ -7286,7 +7286,7 @@ yM+         dM/+NNo`     :Md         +My
 EOF
         ;;
 
-        "Oracle"*)
+        Oracle*)
             set_colors 1 7 3
             read -rd '' ascii_data <<'EOF'
 ${c1}
@@ -7304,7 +7304,7 @@ ${c1}
 EOF
         ;;
 
-        "PacBSD"*)
+        PacBSD*)
             set_colors 1 7 3
             read -rd '' ascii_data <<'EOF'
 ${c1}      :+sMs.
@@ -7334,7 +7334,7 @@ ${c1}      :+sMs.
 EOF
         ;;
 
-        "Parabola"*)
+        Parabola*)
             set_colors 5 7
             read -rd '' ascii_data <<'EOF'
 ${c1}                          `.-.    `.
@@ -7356,7 +7356,7 @@ ${c1}                          `.-.    `.
 EOF
         ;;
 
-        "Pardus"*)
+        Pardus*)
             set_colors 3 7 6 1 8
             read -rd '' ascii_data <<'EOF'
 ${c1} .smNdy+-    `.:/osyyso+:.`    -+ydmNs.
@@ -7380,7 +7380,7 @@ mN.     oMdyy- -y          `-dMo     .Nm
 EOF
         ;;
 
-        "Parrot"*)
+        Parrot*)
             set_colors 6 7
             read -rd '' ascii_data <<'EOF'
 ${c1}  `:oho/-`
@@ -7410,7 +7410,7 @@ ${c1}  `:oho/-`
 EOF
         ;;
 
-        "Parsix"*)
+        Parsix*)
             set_colors 3 1 7 8
             read -rd '' ascii_data <<'EOF'
                  ${c2}-/+/:.
@@ -7437,7 +7437,7 @@ ${c3}-/:::::::::/:${c4}`:-.      .-:${c3}`:///////////-
 EOF
         ;;
 
-        "PCBSD"* | "TrueOS"*)
+        PCBSD* | TrueOS*)
             set_colors 1 7 3
             read -rd '' ascii_data <<'EOF'
 ${c1}                       ..
@@ -7470,7 +7470,7 @@ h-  `+ymMMMMMMMM--M+hMMN/    +MMMMy   -h
 EOF
         ;;
 
-        "PCLinuxOS"*)
+        PCLinuxOS*)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
             ${c1}mhhhyyyyhhhdN
@@ -7495,7 +7495,7 @@ yyhh-   ${c2}ymm-       /dmdyosyd`  ${c1}`yhh+
 EOF
         ;;
 
-        "Peppermint"*)
+        Peppermint*)
             set_colors 1 7 3
             read -rd '' ascii_data <<'EOF'
 ${c1}          8ZZZZZZ${c2}MMMMM
@@ -7546,7 +7546,7 @@ ${c1}             /////////////
 EOF
         ;;
 
-        "Porteus"*)
+        Porteus*)
             set_colors 6 7
             read -rd '' ascii_data <<'EOF'
 ${c1}             `.-:::-.`
@@ -7590,7 +7590,7 @@ ${c1}        /\\
 EOF
         ;;
 
-        "PostMarketOS"*)
+        PostMarketOS*)
             set_colors 2 7
             read -rd '' ascii_data <<'EOF'
 ${c1}                 /\\
@@ -7614,7 +7614,7 @@ ${c1}                 /\\
 EOF
         ;;
 
-        "Puppy"* | "Quirky Werewolf"* | "Precise Puppy"*)
+        Puppy* | "Quirky Werewolf"* | "Precise Puppy"*)
             set_colors 4 7
             read -rd '' ascii_data <<'EOF'
 ${c1}           `-/osyyyysosyhhhhhyys+-
@@ -7638,7 +7638,7 @@ ${c1}           `-/osyyyysosyhhhhhyys+-
 EOF
         ;;
 
-        "PureOS"*)
+        PureOS*)
             set_colors 2 7 7
             read -rd '' ascii_data <<'EOF'
 ${c1}dmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmd
@@ -7656,7 +7656,7 @@ dmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmd
 EOF
         ;;
 
-        "Qubes"*)
+        Qubes*)
             set_colors 4 5 7 6
             read -rd '' ascii_data <<'EOF'
 ${c1}               `..--..`
@@ -7683,7 +7683,7 @@ ${c1}               `..--..`
 EOF
         ;;
 
-        "Radix"*)
+        Radix*)
             set_colors 1 2
             read -rd '' ascii_data <<'EOF'
 ${c2}                .:oyhdmNo
@@ -7707,7 +7707,7 @@ yMMMMMMMMMMMMMMMMNNh.
 EOF
         ;;
 
-        "Raspbian"*)
+        Raspbian*)
             set_colors 2 1
             read -rd '' ascii_data <<'EOF'
 ${c1}  `.::///+:/-.        --///+//-:``
@@ -7736,7 +7736,7 @@ ${c1}  `.::///+:/-.        --///+//-:``
 EOF
         ;;
 
-        "Reborn OS"* | "Reborn"*)
+        "Reborn OS"* | Reborn*)
             set_colors 2 2 8
             read -rd '' ascii_data <<'EOF'
 ${c3}
@@ -7760,7 +7760,7 @@ NM  ${c1}dd  hh   ${c3}mMMMMMMMMMMm   ${c1}hh  dd  ${c3}MN
 EOF
         ;;
 
-        "Red Star"* | "Redstar"*)
+        "Red Star"* | Redstar*)
             set_colors 1 7 3
             read -rd '' ascii_data <<'EOF'
 ${c1}                    ..
@@ -7784,7 +7784,7 @@ ${c1}                    ..
 EOF
         ;;
 
-        "Redcore"*)
+        Redcore*)
             set_colors 1
             read -rd '' ascii_data <<'EOF'
 ${c1}                 RRRRRRRRR
@@ -7806,7 +7806,7 @@ RRRR     RRRRRRRRRRRRRRRRRRR  R   RRRR
 EOF
         ;;
 
-        "Redhat"* | "Red Hat"* | "rhel"*)
+        Redhat* | "Red Hat"* | rhel*)
             set_colors 1 7 3
             read -rd '' ascii_data <<'EOF'
 ${c1}             `.-..........`
@@ -7852,7 +7852,7 @@ ${c2}                             A
 EOF
         ;;
 
-        "Regata"*)
+        Regata*)
             set_colors 7 1 4 5 3 2
             read -rd '' ascii_data <<'EOF'
 ${c1}            ddhso+++++osydd
@@ -7878,7 +7878,7 @@ d/hhhhhhhhhhhh${c3}`-/osyso+-`${c1}hhhhhhhhhhhh.h
 EOF
         ;;
 
-        "Rosa"*)
+        Rosa*)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
 ${c1}           ROSAROSAROSAROSAR
@@ -7904,7 +7904,7 @@ RO  ROSA  ROS     ROSAROSAR  ROSARO  RO
 EOF
         ;;
 
-        "sabotage"*)
+        sabotage*)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
 ${c2} .|'''.|      |     '||''|.    ..|''||
@@ -7921,7 +7921,7 @@ ${c2} .|'''.|      |     '||''|.    ..|''||
 EOF
         ;;
 
-        "Sabayon"*)
+        Sabayon*)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
 ${c1}            ...........
@@ -7945,7 +7945,7 @@ ${c1}            ...........
 EOF
         ;;
 
-        "SailfishOS"*)
+        SailfishOS*)
             set_colors 4 5 7 6
             read -rd '' ascii_data <<'EOF'
 ${c1}              .+eWWW
@@ -7969,7 +7969,7 @@ ${c1}              .+eWWW
 EOF
         ;;
 
-        "SalentOS"*)
+        SalentOS*)
             set_colors 2 1 3 7
             read -rd '' ascii_data <<'EOF'
 ${c1}                 ``..``
@@ -7995,7 +7995,7 @@ ${c2}             `:smMM${c4}yy${c3}MMNy/`
 EOF
         ;;
 
-        "Scientific"*)
+        Scientific*)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
 ${c1}                 =/;;/-
@@ -8021,7 +8021,7 @@ M-       ,=;;;#:,      ,:#;;:=,       ,@
 EOF
         ;;
 
-        "SharkLinux"*)
+        SharkLinux*)
             set_colors 4 7
             read -rd '' ascii_data <<'EOF'
 ${c1}                              `:shd/
@@ -8042,7 +8042,7 @@ ${c1}                              `:shd/
 EOF
         ;;
 
-        "Siduction"*)
+        Siduction*)
             set_colors 4 4
             read -rd '' ascii_data <<'EOF'
 ${c1}                _aass,
@@ -8068,7 +8068,7 @@ _Qh;.nm       .QWc. {QL      ]QQp;..vmQ/
 EOF
         ;;
 
-        "Slackware"*)
+        Slackware*)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
 ${c1}                  :::::::
@@ -8095,7 +8095,7 @@ ${c1}                  :::::::
 EOF
         ;;
 
-        "SliTaz"*)
+        SliTaz*)
             set_colors 3 3
             read -rd '' ascii_data <<'EOF'
 ${c1}        @    @(               @
@@ -8118,7 +8118,7 @@ ${c1}        @    @(               @
 EOF
         ;;
 
-        "SmartOS"*)
+        SmartOS*)
             set_colors 6 7
             read -rd '' ascii_data <<'EOF'
 ${c1}yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
@@ -8141,7 +8141,7 @@ yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
 EOF
         ;;
 
-        "Solus"*)
+        Solus*)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
 ${c2}            -```````````
@@ -8194,7 +8194,7 @@ ${c2}       :ymNMNho.
 EOF
         ;;
 
-        "Sparky"*)
+        Sparky*)
             set_colors 1 7
             read -rd '' ascii_data <<'EOF'
 ${c1}
@@ -8221,7 +8221,7 @@ ${c1}
 EOF
         ;;
 
-        "Star"*)
+        Star*)
             set_colors 7
             read -rd '' ascii_data <<'EOF'
 ${c1}                   ./
@@ -8246,7 +8246,7 @@ ${c1}                   ./
 EOF
         ;;
 
-        "SteamOS"*)
+        SteamOS*)
             set_colors 5 7
             read -rd '' ascii_data <<'EOF'
 ${c1}              .,,,,.
@@ -8270,7 +8270,7 @@ ${c2},',.         ';  ,+##############'
 EOF
         ;;
 
-        "SunOS" | "Solaris")
+        SunOS | Solaris)
             set_colors 3 7
             read -rd '' ascii_data <<'EOF'
 ${c1}                 `-     `
@@ -8303,7 +8303,7 @@ ${c2}                                     ......
 EOF
         ;;
 
-        "openSUSE"* | "open SUSE"* | "SUSE"*)
+        openSUSE* | "open SUSE"* | SUSE*)
             set_colors 2 7
             read -rd '' ascii_data <<'EOF'
 ${c2}           .;ldkO0000Okdl;.
@@ -8327,7 +8327,7 @@ dKK${c1}KKKKKKKKKK;.;oOKx,..${c2}^${c1}..;kKKK0.${c2}  dKd
 EOF
         ;;
 
-        "SwagArch"*)
+        SwagArch*)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
 ${c2}        .;ldkOKXXNNNNXXK0Oxoc,.
@@ -8348,7 +8348,7 @@ ${c2} `':ldxO0KXXXXXK0Okdo${c1}cccc.     :cccccccc.
 EOF
         ;;
 
-        "Tails"*)
+        Tails*)
             set_colors 5 7
             read -rd '' ascii_data <<'EOF'
 ${c1}      ``
@@ -8373,7 +8373,7 @@ Nsyh+-..+y+-   yMMMMd   :mMM+
 EOF
         ;;
 
-        "Trisquel"*)
+        Trisquel*)
             set_colors 4 6
             read -rd '' ascii_data <<'EOF'
 ${c1}                         ▄▄▄▄▄▄
@@ -8397,7 +8397,7 @@ ${c1}  ▀█████████    ███████${c2}███▀�
 EOF
         ;;
 
-        "Ubuntu-Budgie"*)
+        Ubuntu-Budgie*)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
 ${c2}           ./oydmMMMMMMmdyo/.
@@ -8423,7 +8423,7 @@ oMm/        .dMMMMMMMMh:      :dMMMMMMMo
 EOF
         ;;
 
-        "Ubuntu-GNOME"*)
+        Ubuntu-GNOME*)
             set_colors 4 5 7 6
             read -rd '' ascii_data <<'EOF'
 ${c3}          ./o.
@@ -8445,7 +8445,7 @@ ${c4}       `soooo.     .oooo`
 EOF
         ;;
 
-        "Ubuntu-MATE"*)
+        Ubuntu-MATE*)
             set_colors 2 7
             read -rd '' ascii_data <<'EOF'
 ${c1}           `:+shmNNMMNNmhs+:`
@@ -8495,7 +8495,7 @@ ${c3}                         `oo++.
 EOF
         ;;
 
-        "Ubuntu-Studio")
+        Ubuntu-Studio)
             set_colors 6 7
             read -rd '' ascii_data <<'EOF'
 ${c1}              ..-::::::-.`
@@ -8521,7 +8521,7 @@ ${c1}              ..-::::::-.`
 EOF
         ;;
 
-        "Ubuntu"*)
+        Ubuntu*)
             set_colors 1 7 3
             read -rd '' ascii_data <<'EOF'
 ${c1}            .-/+oossssoo+/-.
@@ -8560,7 +8560,7 @@ ${c1}    _______
 EOF
         ;;
 
-        "Void"*)
+        Void*)
             set_colors 2 8
             read -rd '' ascii_data <<'EOF'
 ${c1}                __.;=====;.__
@@ -8585,7 +8585,7 @@ EOF
         ;;
 
         *"[Windows 10]"*|*"on Windows 10"*|"Windows 8"*|\
-        "Windows 10"* |"windows10"|"windows8")
+        "Windows 10"* |windows10|windows8)
             set_colors 6 7
             read -rd '' ascii_data <<'EOF'
 ${c1}                                ..,
@@ -8610,7 +8610,7 @@ llllllllllllll  lllllllllllllllllll
 EOF
         ;;
 
-        "Windows"*)
+        Windows*)
             set_colors 1 2 4 3
             read -rd '' ascii_data <<'EOF'
 ${c1}        ,.=:!!t3Z3z.,
@@ -8632,7 +8632,7 @@ ${c3}             `${c4} :EEEEtttt::::z7
 EOF
         ;;
 
-        "Xubuntu"*)
+        Xubuntu*)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
 ${c1}           `-/osyhddddhyso/-`
@@ -8658,7 +8658,7 @@ sddddddy                        ydddddds
 EOF
         ;;
 
-        "Zorin"*)
+        Zorin*)
             set_colors 4 6
             read -rd '' ascii_data <<'EOF'
 ${c1}        `osssssssssssssssssssso`
@@ -8683,7 +8683,7 @@ EOF
 
         *)
             case "$kernel_name" in
-                *"BSD")
+                *BSD)
                     set_colors 1 7 4 3 6
                     read -rd '' ascii_data <<'EOF'
 ${c1}             ,        ,
@@ -8708,7 +8708,7 @@ ${c4}<----|====${c1}O)))${c4}==${c1}) \) /${c4}====|
 EOF
                 ;;
 
-                "Darwin")
+                Darwin)
                     set_colors 2 3 1 1 5 4
                     read -rd '' ascii_data <<'EOF'
 ${c1}                    'c.
@@ -8731,7 +8731,7 @@ ${c4}.MMMMMMMMMMMMMMMMMMMMMMMMX.
 EOF
                 ;;
 
-                "GNU"*)
+                GNU*)
                     set_colors fg 7
                     read -rd '' ascii_data <<'EOF'
 ${c1}    _-`````-,           ,- '- .
@@ -8755,7 +8755,7 @@ ${c1}    _-`````-,           ,- '- .
 EOF
                 ;;
 
-                "Linux")
+                Linux)
                     set_colors fg 8 3
                     read -rd '' ascii_data <<'EOF'
 ${c2}        #####
@@ -8773,7 +8773,7 @@ ${c3}  #####${c2}#######${c3}#####
 EOF
                 ;;
 
-                "SunOS")
+                SunOS)
                     set_colors 3 7
                     read -rd '' ascii_data <<'EOF'
 ${c1}                 `-     `
@@ -8787,7 +8787,7 @@ ${c1}                 `-     `
 EOF
                 ;;
 
-                "IRIX"*)
+                IRIX*)
                     set_colors 4 7
                     read -rd '' ascii_data <<'EOF'
 ${c1}           ./ohmNd/  +dNmho/-


### PR DESCRIPTION
Operation performed using vim command: %s/"\([-a-zA-Z0-9/]\+\)"/\1/g
Certain subtitutions were manually reverted.

## Description

## Features

## Issues

Literals containing underscores were omitted.

## TODO

Process literals including underscore.
