### PR TITLE
Strip color codes for ascii length calc

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3450,6 +3450,25 @@ image_backend() {
     [[ "$image_backend" != "off" ]] && printf '\e[%sA\e[9999999D' "${lines:-0}"
 }
 
+strip_escape_codes() {
+    local input="${1//\"/\\\"}" output="" i char within_code=0
+    for ((i=0; i < ${#input}; ++i)); do
+        char="${input:i:1}"
+        if (( within_code == 1 )); then
+            case "${char}" in
+                [a-zA-Z]) within_code=0 ;;
+            esac
+            continue
+        fi
+        if [[ "${char}" == $'\e' ]]; then
+            within_code=1
+            continue
+        fi
+        output+="${char}"
+    done
+    eval "$2=\"${output}\""
+}
+
 print_ascii() {
     if [[ -f "$image_source" && ! "$image_source" =~ (png|jpg|jpeg|jpe|svg|gif) ]]; then
         ascii_data="$(< "$image_source")"
@@ -3464,7 +3483,7 @@ print_ascii() {
 
     # Calculate size of ascii file in line length / line count.
     while IFS=$'\n' read -r line; do
-        line="${line//\\\\/\\}"
+        strip_escape_codes "${line}" line
         ((++lines,${#line}>ascii_len)) && ascii_len="${#line}"
     done <<< "${ascii_data//\$\{??\}}"
 


### PR DESCRIPTION
Ascii images with lots of color codes would result in too large of a gap between the image and information. This uses a function to strip out color codes during the routine that determines ascii_len (and ultimately, text_padding) for ascii images.