### PR TITLE
Update crew detection logic

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1329,7 +1329,7 @@ get_packages() {
             has "guix"    && dir ${br_prefix}/gnu/store/*/
             has "Compile" && dir ${br_prefix}/Programs/*/
             has "eopkg"   && dir ${br_prefix}/var/lib/eopkg/package/*
-            has "crew"    && dir ${br_prefix}/usr/local/etc/crew/meta/*.filelist
+            has "crew"    && dir ${br_prefix}"$(crew const CREW_PREFIX | cut -d= -f2)"/etc/crew/meta/*.filelist
             has "pkgtool" && dir ${br_prefix}/var/log/packages/*
             has "cave"    && dir ${br_prefix}/var/db/paludis/repositories/cross-installed/*/data/*/ \
                                  ${br_prefix}/var/db/paludis/repositories/installed/data/*/


### PR DESCRIPTION
Fix Chromebrew detection logic with newly added custom `CREW_PREFIX` support.