### PR TITLE
Handle GTK2_RC_FILES with multiple values

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2683,7 +2683,7 @@ get_style() {
 
         # Check for general GTK2 Theme.
         if [[ -z "$gtk2_theme" ]]; then
-            if [[ -n "${GTK2_RC_FILES}" ]]; then
+            if [[ -n "$GTK2_RC_FILES" ]]; then
                 IFS=: read -ra rc_files <<< "$GTK2_RC_FILES"
                 gtk2_theme="$(grep "^[^#]*${name}" "${rc_files[@]}")"
             elif [[ -f "${HOME}/.gtkrc-2.0"  ]]; then

--- a/neofetch
+++ b/neofetch
@@ -2684,12 +2684,8 @@ get_style() {
         # Check for general GTK2 Theme.
         if [[ -z "$gtk2_theme" ]]; then
             if [[ -n "${GTK2_RC_FILES}" ]]; then
-                for gtkrc in ${GTK2_RC_FILES//:/ }; do
-                    _gtk2_theme="$(grep "^[^#]*${name}" "${gtkrc}")"
-                    [[ -n "${_gtk2_theme}" ]] && gtk2_theme="${_gtk2_theme}"
-                done
-                unset _gtk2_theme
-
+                IFS=: read -ra rc_files <<< "$GTK2_RC_FILES"
+                gtk2_theme="$(grep "^[^#]*${name}" "${rc_files[@]}")"
             elif [[ -f "${HOME}/.gtkrc-2.0"  ]]; then
                 gtk2_theme="$(grep "^[^#]*${name}" "${HOME}/.gtkrc-2.0")"
 
@@ -2701,7 +2697,7 @@ get_style() {
 
             fi
 
-            gtk2_theme="${gtk2_theme/${name}*=}"
+            gtk2_theme="${gtk2_theme/*${name}*=}"
         fi
 
         # Check for general GTK3 Theme.

--- a/neofetch
+++ b/neofetch
@@ -2683,8 +2683,15 @@ get_style() {
 
         # Check for general GTK2 Theme.
         if [[ -z "$gtk2_theme" ]]; then
-            if [[ -f "${GTK2_RC_FILES:-${HOME}/.gtkrc-2.0}" ]]; then
-                gtk2_theme="$(grep "^[^#]*${name}" "${GTK2_RC_FILES:-${HOME}/.gtkrc-2.0}")"
+            if [[ -n "${GTK2_RC_FILES}" ]]; then
+                for gtkrc in ${GTK2_RC_FILES//:/ }; do
+                    _gtk2_theme="$(grep "^[^#]*${name}" "${gtkrc}")"
+                    [[ -n "${_gtk2_theme}" ]] && gtk2_theme="${_gtk2_theme}"
+                done
+                unset _gtk2_theme
+
+            elif [[ -f "${HOME}/.gtkrc-2.0"  ]]; then
+                gtk2_theme="$(grep "^[^#]*${name}" "${HOME}/.gtkrc-2.0")"
 
             elif [[ -f "/etc/gtk-2.0/gtkrc" ]]; then
                 gtk2_theme="$(grep "^[^#]*${name}" /etc/gtk-2.0/gtkrc)"


### PR DESCRIPTION
## Description

https://github.com/dylanaraps/neofetch/pull/185 just use `[ -f "${GTK2_RC_FILES:-$HOME/.gtkrc-2.0}" ]` as the condition which will fail when `${GTK2_RC_FILES}` have multiple values.

For me, it is `/etc/gtk-2.0/gtkrc:/home/edward/.gtkrc-2.0:/home/edward/.config/gtkrc-2.0`, which causes wrong GTK2 theme detected.

## Features
![image](https://user-images.githubusercontent.com/7891089/55291868-6f9bb580-5416-11e9-8f47-51f17a893453.png)


## Issues
Fixed GTK2 theme ditection when ${GTK2_RC_FILES} contains multiple values.
## TODO
