### PR TITLE
Added a case for displaying the Ubuntu logo for i3buntu.

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -8549,7 +8549,7 @@ ${c1}              ..-::::::-.`
 EOF
         ;;
 
-        "Ubuntu"*)
+        "Ubuntu"* | "i3buntu"*)
             set_colors 1 7 3
             read -rd '' ascii_data <<'EOF'
 ${c1}            .-/+oossssoo+/-.


### PR DESCRIPTION
## Description
a patch for supporting i3buntu, an ubuntu-based distro that doesnt have an own logo

## Features
displays the ubuntu logo for i3buntu