### PR TITLE
support uptime from Android 9+

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1211,8 +1211,14 @@ get_uptime() {
             # Get uptime in seconds.
             case "$os" in
                 "Linux" | "Windows" | "MINIX")
-                    seconds="$(< /proc/uptime)"
-                    seconds="${seconds/.*}"
+                    if [ -f /proc/uptime ]; then
+                        seconds="$(< /proc/uptime)"
+                        seconds="${seconds/.*}"
+                    else # Android >= 9 denies /proc/uptime access
+                        boot=$(date -d"$(uptime -s)" +%s) \
+                            && now="$(date +%s)" \
+                            && seconds="$((now - boot))"
+                    fi
                 ;;
 
                 "Mac OS X" | "iPhone OS" | "BSD" | "FreeMiNT")

--- a/neofetch
+++ b/neofetch
@@ -1211,13 +1211,13 @@ get_uptime() {
             # Get uptime in seconds.
             case "$os" in
                 "Linux" | "Windows" | "MINIX")
-                    if [ -f /proc/uptime ]; then
+                    if [[ -r /proc/uptime ]]; then
                         seconds="$(< /proc/uptime)"
                         seconds="${seconds/.*}"
-                    else # Android >= 9 denies /proc/uptime access
-                        boot=$(date -d"$(uptime -s)" +%s) \
-                            && now="$(date +%s)" \
-                            && seconds="$((now - boot))"
+                    else
+                        boot="$(date -d"$(uptime -s)" +%s)"
+                        now="$(date +%s)"
+                        seconds="$((now - boot))"
                     fi
                 ;;
 


### PR DESCRIPTION
## Description
Since Android 9 the uptime is returned as empty string.

This is due to new permissions restrictions (see https://www.cl.cam.ac.uk/~rja14/Papers/interrupts_pets16-1.pdf)

The proposed change fails back in these cases to the uptime command and has been tested with `/system/bin/uptime` (which supports the -s option in Android 9), the uptime busybox applet (Termux) as well as the uptime command from procps-ng.