### PR TITLE
give precedence to "Hardware" entry in /proc/cpuinfo

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1816,9 +1816,9 @@ get_cpu() {
                 ;;
 
                 *)
-                    cpu="$(awk -F ': | @' \
+                    cpu="$(awk -F '\\s*: | @' \
                             '/model name|Hardware|Processor|^cpu model|chip type|^cpu type/ {
-                            printf $2; exit}' "$cpu_file")"
+                            cpu=$2; if ($1 == "Hardware") exit } END { print cpu }' "$cpu_file")"
                 ;;
             esac
 


### PR DESCRIPTION
## Description

A [recent commit](https://github.com/dylanaraps/neofetch/commit/60d3aa3f10f8f17ef25d2adab91cb60f5cc65a49) simplified the CPU name fetch. However, in ARM platforms it returns now a too generic name. The proposed change gives precedence to the "Hardware" setting, if found.

In the 3 phones tested, the CPU output name will change (from → to):

ARMv7 Processor rev 3 → Hisilicon Kirin 920
ARMv7 Processor rev 3 → Qualcomm MSM8926
AArch64 Processor rev 12 → Qualcomm SDM845

Which in fact was just the previous output (I find it more adequated) to report these devices's CPU.