### PR TITLE
 update Red Hat with new 2019 logo

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -7898,24 +7898,26 @@ EOF
         ;;
 
         "Redhat"* | "Red Hat"* | "rhel"*)
-            set_colors 1 7 3
+            set_colors 1
             read -rd '' ascii_data <<'EOF'
-${c1}             `.-..........`
-            `////////::.`-/.
-            -: ....-////////.
-            //:-::///////////`
-     `--::: `-://////////////:
-     //////-    ``.-:///////// .`
-     `://////:-.`    :///////::///:`
-       .-/////////:---/////////////:
-          .-://////////////////////.
-${c2}         yMN+`.-${c1}::///////////////-`
-${c2}      .-`:NMMNMs`  `..-------..`
-       MN+/mMMMMMhoooyysshsss
-MMM    MMMMMMMMMMMMMMyyddMMM+
- MMMM   MMMMMMMMMMMMMNdyNMMh`     hyhMMM
-  MMMMMMMMMMMMMMMMyoNNNMMM+.   MMMMMMMM
-   MMNMMMNNMMMMMNM+ mhsMNyyyyMNMMMMsMM
+${c1}           .MMM..:MMMMMMM
+          MMMMMMMMMMMMMMMMMM
+          MMMMMMMMMMMMMMMMMMMM.
+         MMMMMMMMMMMMMMMMMMMMMM
+        ,MMMMMMMMMMMMMMMMMMMMMM:
+        MMMMMMMMMMMMMMMMMMMMMMMM
+  .MMMM'  MMMMMMMMMMMMMMMMMMMMMM
+ MMMMMM    `MMMMMMMMMMMMMMMMMMMM.
+MMMMMMMM      MMMMMMMMMMMMMMMMMM .
+MMMMMMMMM.       `MMMMMMMMMMMMM' MM.
+MMMMMMMMMMM.                     MMMM
+`MMMMMMMMMMMMM.                 ,MMMMM.
+ `MMMMMMMMMMMMMMMMM.          ,MMMMMMMM.
+    MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
+      MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM:
+         MMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
+            `MMMMMMMMMMMMMMMMMMMMMMMM:
+                ``MMMMMMMMMMMMMMMMM'
 EOF
         ;;
 


### PR DESCRIPTION
## Description

Red Hat recently (May 2019) updated its official logo and brand standards, and the new logo is now a slightly different shaped fedora _without_ the shadowman figure beneath it. 

You can see the new logo here: https://www.redhat.com/en/about/brand/standards

This PR just swaps the old logo with a representation of the new logo. I used an online image-to-ASCII generator with Red Hat's new logo and then cleaned up some bits by hand.

## Features

<img width="773" alt="Screen Shot 2019-05-08 at 12 47 49 PM" src="https://user-images.githubusercontent.com/1472326/57392719-88bf2100-718f-11e9-8213-5fe40185cdf1.png">

## Issues

## TODO
