### PR TITLE
Retrieve public IP info via drill

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3371,6 +3371,11 @@ get_public_ip() {
        [[ "$public_ip" =~ ^\; ]] && unset public_ip
     fi
 
+    if [[ -z "$public_ip" ]] && type -p drill >/dev/null; then
+        public_ip="$(drill myip.opendns.com @resolver1.opendns.com | \
+                     awk '/^myip\./ && $3 == "IN" {print $5}')"
+    fi
+
     if [[ -z "$public_ip" ]] && type -p curl >/dev/null; then
         public_ip="$(curl --max-time "$public_ip_timeout" -w '\n' "$public_ip_host")"
     fi


### PR DESCRIPTION
## Description

This adds an option for public IP retrieval via lightweight `drill(1)` from the [ldns](https://nlnetlabs.nl/projects/ldns/about/) package.

`drill` is a minimalistic, still feature-rich alternative to `dig` from developers of [NSD](https://nlnetlabs.nl/projects/nsd/about/).

## Features

- public_ip via `drill(1)`

## Notes

- it doesn't have any "short" option, hence an `awk` hack