### PR TITLE
Fix kitty font parsing when font name has whitespaces

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2981,7 +2981,7 @@ END
             kitty_config="$(kitty --debug-config)"
             [[ "$kitty_config" != *font_family* ]] && return
 
-            term_font="$(awk '/^font_family|^font_size/ {printf $2 " "}' <<< "$kitty_config")"
+            term_font="$(awk '/^font_family|^font_size/ {$1="";gsub("^ *","",$0);print $0}' <<< "$kitty_config")"
         ;;
 
         "konsole" | "yakuake")

--- a/neofetch
+++ b/neofetch
@@ -2981,7 +2981,8 @@ END
             kitty_config="$(kitty --debug-config)"
             [[ "$kitty_config" != *font_family* ]] && return
 
-            term_font="$(awk '/^font_family|^font_size/ {$1="";gsub("^ *","",$0);print $0}' <<< "$kitty_config")"
+            term_font="$(awk '/^font_family|^font_size/ {$1="";gsub("^ *","",$0);print $0}' \
+                         <<< "$kitty_config")"
         ;;
 
         "konsole" | "yakuake")


### PR DESCRIPTION
## Description

As mentioned in #1193, the current implementation doesn't work for me. In my settings, the font is Iosevka Term SS08. And if I won't get the full font name.