### PR TITLE
Works for multiple GPUs now

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2135,9 +2135,9 @@ get_gpu() {
     case "$os" in
         "Linux")
             # Read GPUs into array.
-            gpu_cmd="$(lspci -mm | awk -F '\\"|\\" \\"|\\(' \
-                                          '/"Display|"3D|"VGA/ {a[$0] = $3 " " $4} END {for(i in a)
-                                           {if(!seen[a[i]]++) print a[i]}}')"
+            gpu_cmd="$(lspci -mm | awk -F '\"|\" \"|\\(' \
+                                          '/"Display|"3D|"VGA/ {a[$0] = $1 " " $3 " " $4}
+                                           END {for(i in a) {if(!seen[a[i]]++) print a[i]}}')"
             IFS=$'\n' read -d "" -ra gpus <<< "$gpu_cmd"
 
             # Remove duplicate Intel Graphics outputs.


### PR DESCRIPTION
Work for multiple GPUs now
   
1. Replace `\\"` with `\"`, otherwise awk warns `\"' is not a
   known regexp operator
2. Use the slot number of `lspci -mm` return value to
   determine whether two video cards are in different PCI slots,
   and therefore are two different GPUS.