### PR TITLE
Added support for Novus (Upcoming APT based package manager for macOS and added support for macOS Catalina)

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1392,6 +1392,7 @@ get_packages() {
 
         "Mac OS X" | "MINIX")
             has "port"    && tot port installed && ((packages-=1))
+            has "nvs"    && tot dpkg-query -f '.\n' -W
             has "brew"    && dir /usr/local/Cellar/*
             has "pkgin"   && tot pkgin list
 

--- a/neofetch
+++ b/neofetch
@@ -981,6 +981,7 @@ get_distro() {
                 "10.12"*) codename="macOS Sierra" ;;
                 "10.13"*) codename="macOS High Sierra" ;;
                 "10.14"*) codename="macOS Mojave" ;;
+                "10.15"*) codename="macOS Catalina" ;;
                 *)        codename="macOS" ;;
             esac
             distro="$codename $osx_version $osx_build"


### PR DESCRIPTION
## Description

I added support for Novus that is a upcoming package manager based on APT, and now it detects Catalina

## Features

## Issues

## TODO