### PR TITLE
add support for kagami package manager

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1351,6 +1351,7 @@ get_packages() {
             has "eopkg"   && dir ${br_prefix}/var/lib/eopkg/package/*
             has "crew"    && dir ${br_prefix}/usr/local/etc/crew/meta/*.filelist
             has "pkgtool" && dir ${br_prefix}/var/log/packages/*
+            has "kagami"  && dir ${br_prefix}/var/lib/kagami/pkgs/*
             has "cave"    && dir ${br_prefix}/var/db/paludis/repositories/cross-installed/*/data/*/ \
                                  ${br_prefix}/var/db/paludis/repositories/installed/data/*/
             shopt -u nullglob


### PR DESCRIPTION
Recently Ataraxia Linux moved to kagami package manager. And I've added support for it!
![Screenshot from 2019-07-18 18-52-09](https://user-images.githubusercontent.com/47295761/61448118-4420e480-a98d-11e9-874c-452385d2556d.png)
