### PR TITLE
Linux: Fix ASCII for Sailfish OS

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -8117,7 +8117,7 @@ EOF
         "Sailfish"*)
             set_colors 4 5 7 6
             read -rd '' ascii_data <<'EOF'
-                 _a@b
+${c1}                 _a@b
               _#b (b
             _@@   @_         _,
           _#^@ _#*^^*gg,aa@^^


### PR DESCRIPTION
Fixed wrong offset and missing colour for SailfishOS which also closes and finishes #1270
