### PR TITLE
Small tweak to the colours used for the Feren OS Logo

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -6110,7 +6110,7 @@ EOF
         ;;
 
         "Feren"*)
-            set_colors 6 6 7 1
+            set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
 ${c1} `----------`
  :+ooooooooo+.


### PR DESCRIPTION
Changed the blue used in the Feren OS logo as most colour schemes made the logo appear to be teal instead of blue.

## Description

Following on from the change that added the Feren OS Logo, I installed Neofetch from Git Master to check what the logo looked like, and the only issue I can see with it is its colour choice before applying this Pull Request's changes. On most colour schemes in Feren OS Next, for instance, the current colour choices led to the logo being displayed in a teal colour, which looks odd for a blue logo. Having then checked the Fedora ASCII Logo (which is above this logo in the code), I realised that that blue fits better for the Feren OS Logo than the teal does.

On all the colour schemes I've tried thus far with this change the blue used perfectly fits with the Feren OS logo after this change is put in effect. The images below demonstrate the Logo ASCII colour before and after this change on the 'Breeze Colours' colour scheme in Konsole, however the other colour schemes I've tried remain faithful to these colours:

Before: ![image](https://user-images.githubusercontent.com/11057934/61485810-ffe81100-a999-11e9-91c8-eeb73a636223.png)
After: ![image](https://user-images.githubusercontent.com/11057934/61485844-0e362d00-a99a-11e9-9c19-8fe82f236c77.png)


## Features

## Issues

## TODO
