### PR TITLE
support other versions of ksh

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1460,7 +1460,7 @@ get_shell() {
             "bash") shell+="${BASH_VERSION/-*}" ;;
             "sh" | "ash" | "dash") ;;
 
-            "mksh" | "ksh")
+            *"ksh")
                 shell+="$("$SHELL" -c "printf %s \"\$KSH_VERSION\"")"
                 shell="${shell/ * KSH}"
                 shell="${shell/version}"


### PR DESCRIPTION
`ksh` and `mksh` are not the only versions of ksh. 

there are also `pdksh`, `oksh`, `loksh`, `ksh{95,98,?}`, etc... While their bin *may* be named `ksh`, its not guaranteed.

This glob allows for detection of any `*ksh` shell, whatever its bin name is.

before: http://ix.io/1Px8.png
after:   http://ix.io/1Px9.png