### PR TITLE
display_image: Allow Chafa backend to stretch image to desired size

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3864,7 +3864,7 @@ display_image() {
         ;;
 
         "chafa")
-            chafa --size="$((width / font_width))x$((height / font_height))" "$image"
+            chafa --stretch --size="$((width / font_width))x$((height / font_height))" "$image"
         ;;
 
         "jp2a")


### PR DESCRIPTION
Fixes issue #1295.
