### PR TITLE
packages: Check brew on Linux

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1347,6 +1347,7 @@ get_packages() {
             # shellcheck disable=SC2086
             {
             shopt -s nullglob
+            has "brew"    && dir $(brew --cellar)/*
             has "emerge"  && dir ${br_prefix}/var/db/pkg/*/*/
             has "Compile" && dir ${br_prefix}/Programs/*/
             has "eopkg"   && dir ${br_prefix}/var/lib/eopkg/package/*

--- a/neofetch
+++ b/neofetch
@@ -1347,7 +1347,7 @@ get_packages() {
             # shellcheck disable=SC2086
             {
             shopt -s nullglob
-            has "brew"    && dir $(brew --cellar)/*
+            has "brew"    && dir "$(brew --cellar)"/*
             has "emerge"  && dir ${br_prefix}/var/db/pkg/*/*/
             has "Compile" && dir ${br_prefix}/Programs/*/
             has "eopkg"   && dir ${br_prefix}/var/lib/eopkg/package/*


### PR DESCRIPTION
## Description

Homebrew officially supports Linux since 2.0.0 release.

I used `brew --cellar` instead of a fixed directory, because one can install Homebrew on Linux in whatever directory one desires, though `/home/linuxbrew/.linuxbrew` is the blessed one.

## Features

Show brew packages count on Linux.