### PR TITLE
Linux / Resolution: Use DRM modes as fallback

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2691,7 +2691,7 @@ get_resolution() {
         ;;
 
         *)
-            if type -p xrandr >/dev/null && [ -n "$DISPLAY" ]; then
+            if type -p xrandr >/dev/null && [ -n "$DISPLAY" ] && [ -z "$WAYLAND_DISPLAY" ]; then
                 case "$refresh_rate" in
                     "on")
                         resolution="$(xrandr --nograb --current |\
@@ -2708,12 +2708,12 @@ get_resolution() {
                 esac
                 resolution="${resolution//\*}"
 
-            elif type -p xwininfo >/dev/null && [ -n "$DISPLAY" ]; then
+            elif type -p xwininfo >/dev/null && [ -n "$DISPLAY" ] && [ -z "$WAYLAND_DISPLAY" ]; then
                 read -r w h \
                     <<< "$(xwininfo -root | awk -F':' '/Width|Height/ {printf $2}')"
                 resolution="${w}x${h}"
 
-            elif type -p xdpyinfo >/dev/null && [ -n "$DISPLAY" ]; then
+            elif type -p xdpyinfo >/dev/null && [ -n "$DISPLAY" ] && [ -z "$WAYLAND_DISPLAY" ]; then
                 resolution="$(xdpyinfo | awk '/dimensions:/ {printf $2}')"
             elif [ "$os" == "Linux" ]; then
                 for dev in /sys/class/drm/*/modes; do

--- a/neofetch
+++ b/neofetch
@@ -2691,7 +2691,7 @@ get_resolution() {
         ;;
 
         *)
-            if type -p xrandr >/dev/null; then
+            if type -p xrandr >/dev/null && [ -n "$DISPLAY" ]; then
                 case "$refresh_rate" in
                     "on")
                         resolution="$(xrandr --nograb --current |\
@@ -2708,13 +2708,18 @@ get_resolution() {
                 esac
                 resolution="${resolution//\*}"
 
-            elif type -p xwininfo >/dev/null; then
+            elif type -p xwininfo >/dev/null && [ -n "$DISPLAY" ]; then
                 read -r w h \
                     <<< "$(xwininfo -root | awk -F':' '/Width|Height/ {printf $2}')"
                 resolution="${w}x${h}"
 
-            elif type -p xdpyinfo >/dev/null; then
+            elif type -p xdpyinfo >/dev/null && [ -n "$DISPLAY" ]; then
                 resolution="$(xdpyinfo | awk '/dimensions:/ {printf $2}')"
+            elif [ "$os" == "Linux" ]; then
+                for dev in /sys/class/drm/*/modes; do
+                    [[ "$(awk 'FNR <= 1' "$dev")" ]] && \
+                        resolution="${resolution}$(awk 'FNR <= 1' "$dev"), "
+                done
             fi
         ;;
     esac


### PR DESCRIPTION
## Description

This allows getting resolution pretty much anywhere, even from a TTY.
It only gets the maximum supported resolution though, not the current.

Also helps with Wayland compositors, since Sway for example sets
Xwayland on scaled outputs to its scaled resolution instead of
the actual resolution.
I'm not sure though if this method should always be preferred on Wayland
(that would fix https://github.com/dylanaraps/neofetch/issues/1301 though)

I also have no idea if this works with NVIDIA.