### PR TITLE
Rename GuixSD to Guix System

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -925,8 +925,8 @@ get_distro() {
 
             elif type -p guix >/dev/null; then
                 case "$distro_shorthand" in
-                    "on" | "tiny") distro="GuixSD" ;;
-                    *) distro="GuixSD $(guix system -V | awk 'NR==1{printf $5}')"
+                    "on" | "tiny") distro="Guix System" ;;
+                    *) distro="Guix System $(guix system -V | awk 'NR==1{printf $5}')"
                 esac
 
             else


### PR DESCRIPTION
## Description

GuixSD is known as Guix System these days¹, so I updated the script accordingly.

1. https://guix.gnu.org/download/