### PR TITLE
add MX definition

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -949,6 +949,15 @@ get_distro() {
                     [[ -f "/etc/pacbsd-release" ]] && distro="PacBSD"
                 fi
             fi
+            
+            #mx-linux
+             if [[ -f "/etc/mx-version" ]]; then
+			 case "$distro_shorthand" in
+				"on" | "tiny") distro="MX" ;;
+				*) distro="MX"
+			 esac
+			 fi
+			 #mx-linux
 
             if [[ "$(< /proc/version)" == *Microsoft* || "$kernel_version" == *Microsoft* ]]; then
                 case "$distro_shorthand" in


### PR DESCRIPTION
## Description

add MX definition, which due to changes in the way debian apt system is linked into os-release, means we want to avoid overwriting our information into that file.  also, lsb_release in debian no longer sources /etc/lsb-release.


