### PR TITLE
Added BlackArch

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -5437,6 +5437,33 @@ sm/         /ms
 EOF
         ;;
 
+        "BlackArch"*)
+            set_colors 1 1 0 1
+            read -rd '' ascii_data <<'EOF'
+${c3}                   00
+                   11
+                  ====${c1}
+                  .${c3}//${c1}
+                 `o${c3}//${c1}:
+                `+o${c3}//${c1}o:
+               `+oo${c3}//${c1}oo:
+               -+oo${c3}//${c1}oo+:
+             `/:-:+${c3}//${c1}ooo+:
+            `/+++++${c3}//${c1}+++++:
+           `/++++++${c3}//${c1}++++++:
+          `/+++o${c2}ooo${c3}//${c2}ooo${c1}oooo/`
+${c2}         ${c1}./${c2}ooosssso${c3}//${c2}osssssso${c1}+`
+${c2}        .oossssso-`${c3}//${c1}`/ossssss+`
+       -osssssso.  ${c3}//${c1}  :ssssssso.
+      :osssssss/   ${c3}//${c1}   osssso+++.
+     /ossssssss/   ${c3}//${c1}   +ssssooo/-
+   `/ossssso+/:-   ${c3}//${c1}   -:/+osssso+-
+  `+sso+:-`        ${c3}//${c1}       `.-/+oso:
+ `++:.             ${c3}//${c1}            `-/+/
+ .`                ${c3}/${c1}                `/
+EOF
+        ;;
+
         "BLAG"*)
             set_colors 5 7
             read -rd '' ascii_data <<'EOF'


### PR DESCRIPTION
## Description

Added ASCII art for BlackArch as mentioned in issue #1311 

As BlackArch has two logos - one is a red Arch logo with a black medieval sword (as seen here [BlackArch Guide PDF](https://www.blackarch.org/blackarch-guide-en.pdf)) and the other a neon blue version with a japanese katana (seen here [BlackArch home page](https://www.blackarch.org/) ) - I did go with a middle thing.

Image of how it looks if needed: 
![Screenshot_2019-09-14_05-35-38](https://user-images.githubusercontent.com/36206434/64903010-ef11fe00-d6b1-11e9-856f-dd0c205d6e75.png)

## Features

## Issues

## TODO
