### PR TITLE
Added font detection for ConEmu

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3208,7 +3208,7 @@ END
             local ce_arg_idx
             local ce_conf
 
-            # Could have used `eval set -- "$ConEmuArgs"` instead for arg parsing but eval is evil...
+            # Could have used `eval set -- "$ConEmuArgs"` instead for arg parsing
             readarray -t ce_arg_list < <(xargs -n1 printf "%s\n" <<< "${ConEmuArgs-}")
 
             for ce_arg_idx in "${!ce_arg_list[@]}"; do
@@ -3237,13 +3237,14 @@ END
                 [[ ! -f "$ce_conf" ]] && continue
 
                 # Very basic XML parsing
-                term_font="$(awk '/name="FontName"/ && match($0, /data="([^"]*)"/) {print substr($0, RSTART+6, RLENGTH-7)}' "$ce_conf")"
+                term_font="$(awk '/name="FontName"/ && match($0, /data="([^"]*)"/) \
+                    {print substr($0, RSTART+6, RLENGTH-7)}' "$ce_conf")"
                 break
             done
 
-            # Null-terminated contents in /proc/registry files triggers a Bash warning. Use read instead
-            [[ -z "$term_font" ]] && \
-                read -r term_font < /proc/registry/HKEY_CURRENT_USER/Software/ConEmu/.Vanilla/FontName
+            # Null-terminated contents in /proc/registry files triggers a Bash warning
+            [[ -z "$term_font" ]] && read -r term_font < \
+                /proc/registry/HKEY_CURRENT_USER/Software/ConEmu/.Vanilla/FontName
         ;;
     esac
 }

--- a/neofetch
+++ b/neofetch
@@ -3203,7 +3203,7 @@ END
             [[ -z "$term_font" ]] && term_font="Monospace 12"
         ;;
 
-        "conemu-"*)
+        conemu-*)
             local ce_arg_list
             local ce_arg_idx
             local ce_conf
@@ -3213,37 +3213,28 @@ END
 
             for ce_arg_idx in "${!ce_arg_list[@]}"; do
                 # Search for "-LoadCfgFile" arg
-                [[ "${ce_arg_list[$ce_arg_idx]}" != -LoadCfgFile ]] && continue
-
-                # Conf path is the next arg
-                ((++ce_arg_idx))
-                ce_conf="${ce_arg_list[$ce_arg_idx]}"
-                break
+                [[ "${ce_arg_list[$ce_arg_idx]}" == -LoadCfgFile ]] && {
+                    # Conf path is the next arg
+                    ce_conf=${ce_arg_list[++ce_arg_idx]}
+                    break
+                }
             done
 
             # https://conemu.github.io/en/ConEmuXml.html#search-sequence
-            local ce_seq=(
-                "$ce_conf"
-                "$ConEmuDir\ConEmu.xml"
-                "$ConEmuDir\.ConEmu.xml"
-                "$ConEmuBaseDir\ConEmu.xml"
-                "$ConEmuBaseDir\.ConEmu.xml"
-                "$APPDATA\ConEmu.xml"
-                "$APPDATA\.ConEmu.xml"
-            )
-
-            for ce_conf in "${ce_seq[@]}"; do
+            for ce_conf in "$ce_conf" "${ConEmuDir-}\ConEmu.xml" "${ConEmuDir-}\.ConEmu.xml" \
+                           "${ConEmuBaseDir-}\ConEmu.xml" "${ConEmuBaseDir-}\.ConEmu.xml" \
+                           "$APPDATA\ConEmu.xml" "$APPDATA\.ConEmu.xml"; do
                 # Search for first conf file available
-                [[ ! -f "$ce_conf" ]] && continue
-
-                # Very basic XML parsing
-                term_font="$(awk '/name="FontName"/ && match($0, /data="([^"]*)"/) \
-                    {print substr($0, RSTART+6, RLENGTH-7)}' "$ce_conf")"
-                break
+                [[ -f "$ce_conf" ]] && {
+                    # Very basic XML parsing
+                    term_font="$(awk '/name="FontName"/ && match($0, /data="([^"]*)"/) {
+                        print substr($0, RSTART+6, RLENGTH-7)}' "$ce_conf")"
+                    break
+                }
             done
 
             # Null-terminated contents in /proc/registry files triggers a Bash warning
-            [[ -z "$term_font" ]] && read -r term_font < \
+            [[ "$term_font" ]] || read -r term_font < \
                 /proc/registry/HKEY_CURRENT_USER/Software/ConEmu/.Vanilla/FontName
         ;;
     esac

--- a/neofetch
+++ b/neofetch
@@ -3202,6 +3202,49 @@ END
             # Default fallback font hardcoded in terminal-preferences.c
             [[ -z "$term_font" ]] && term_font="Monospace 12"
         ;;
+
+        "conemu-"*)
+            local ce_arg_list
+            local ce_arg_idx
+            local ce_conf
+
+            # Could have used `eval set -- "$ConEmuArgs"` instead for arg parsing but eval is evil...
+            readarray -t ce_arg_list < <(xargs -n1 printf "%s\n" <<< "${ConEmuArgs-}")
+
+            for ce_arg_idx in "${!ce_arg_list[@]}"; do
+                # Search for "-LoadCfgFile" arg
+                [[ "${ce_arg_list[$ce_arg_idx]}" != -LoadCfgFile ]] && continue
+
+                # Conf path is the next arg
+                ((++ce_arg_idx))
+                ce_conf="${ce_arg_list[$ce_arg_idx]}"
+                break
+            done
+
+            # https://conemu.github.io/en/ConEmuXml.html#search-sequence
+            local ce_seq=(
+                "$ce_conf"
+                "$ConEmuDir\ConEmu.xml"
+                "$ConEmuDir\.ConEmu.xml"
+                "$ConEmuBaseDir\ConEmu.xml"
+                "$ConEmuBaseDir\.ConEmu.xml"
+                "$APPDATA\ConEmu.xml"
+                "$APPDATA\.ConEmu.xml"
+            )
+
+            for ce_conf in "${ce_seq[@]}"; do
+                # Search for first conf file available
+                [[ ! -f "$ce_conf" ]] && continue
+
+                # Very basic XML parsing
+                term_font="$(awk '/name="FontName"/ && match($0, /data="([^"]*)"/) {print substr($0, RSTART+6, RLENGTH-7)}' "$ce_conf")"
+                break
+            done
+
+            # Null-terminated contents in /proc/registry files triggers a Bash warning. Use read instead
+            [[ -z "$term_font" ]] && \
+                read -r term_font < /proc/registry/HKEY_CURRENT_USER/Software/ConEmu/.Vanilla/FontName
+        ;;
     esac
 }
 


### PR DESCRIPTION
## Description

This PR enhances `get_term_font()` by checking if `$term` matches with `conemu-*` and sets `$term_font` accordingly. Settings scanning is done according to [ConEmu's settings search sequence](https://conemu.github.io/en/ConEmuXml.html#search-sequence)

* `$APPDATA/ConEmu.xml` file :

![2019-09-22@17-05-43](https://user-images.githubusercontent.com/4513358/65390498-e4193680-dd5f-11e9-9d3a-89b630d689e4.png)

* ConEmu's `-LoadCfgFile` argument :

![2019-09-22@17-06-41](https://user-images.githubusercontent.com/4513358/65390499-e4193680-dd5f-11e9-8d05-35cca15a3b83.png)

* `HKEY_CURRENT_USER\Software\ConEmu\.Vanilla\FontName` value :

![2019-09-22@17-08-18](https://user-images.githubusercontent.com/4513358/65390500-e4b1cd00-dd5f-11e9-8ade-e0f185291f7c.png)


## Issues

* This enhancement relies on `get_term()` which can't detect ConEmu if its [Cygwin/MSYS connector](https://conemu.github.io/en/CygwinMsysConnector.html) is not used.
* Very basic XML parsing is done on `ConEmu.xml` settings file. Font detection might silently fail if the `<value/>` node is `\n`-splitted. However, the default file structure is ok.