### PR TITLE
song: add comment about cmus mpris support

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2521,6 +2521,7 @@ get_song() {
         "plasma-browser-integration"*) get_song_dbus "plasma-browser-integration" ;;
 
         "cmus"*)
+            # NOTE: cmus >= 2.8.0 supports mpris2
             song="$(cmus-remote -Q | awk 'BEGIN { ORS=" "};
                                           /tag artist/ {
                                               $1=$2=""; sub("  ", ""); a=$0


### PR DESCRIPTION
## Description

As of v2.8.0 cmus supports mpris2, so `get_song_dbus` could be used to query song info.
Until v2.8.0 has made it's way into the (major) distros add a comment as reminder. Perhaps debain stable is a good indicator for the switch?  :see_no_evil: