### PR TITLE
local_ip: add interface selection for macOS

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -382,6 +382,13 @@ public_ip_host="http://ident.me"
 # Flag:    --ip_timeout
 public_ip_timeout=2
 
+# Local IP interface (macOS)
+#
+# Default: 'en0'
+# Values:  'en0', 'en1'
+# Flag:    --ip_interface
+local_ip_interface=('en0')
+
 
 # Disk
 
@@ -3374,8 +3381,18 @@ get_local_ip() {
         ;;
 
         "Mac OS X" | "iPhone OS")
-            local_ip="$(ipconfig getifaddr en0)"
-            [[ -z "$local_ip" ]] && local_ip="$(ipconfig getifaddr en1)"
+            if [[ "${#local_ip_interface[@]}" == "1" ]]; then
+                local_ip="$(ipconfig getifaddr "$local_ip_interface")"
+            else
+                for interface in "${local_ip_interface[@]}"; do
+                    local_ip="$(ipconfig getifaddr "$interface")"
+                    if [[ -n "$local_ip" ]]; then
+                        prin "$interface" "$local_ip"
+                    else
+                        err "Local IP: Could not detect local ip for $interface"
+                    fi
+                done
+            fi
         ;;
 
         "Windows")
@@ -4487,6 +4504,7 @@ INFO:
 
     --ip_host url               URL to query for public IP
     --ip_timeout int            Public IP timeout (in seconds).
+    --ip_interface value        Interface(s) to use for local IP
     --song_format format        Print the song data in a specific format (see config file).
     --song_shorthand on/off     Print the Artist/Album/Title on separate lines.
     --memory_percent on/off     Display memory percentage.
@@ -4643,6 +4661,17 @@ get_args() {
             "--shell_version") shell_version="$2" ;;
             "--ip_host") public_ip_host="$2" ;;
             "--ip_timeout") public_ip_timeout="$2" ;;
+            "--ip_interface")
+                unset local_ip_interface
+                for arg in "$@"; do
+                    case "$arg" in
+                        "--ip_interface") ;;
+                        "-"*) break ;;
+                        *) local_ip_interface+=("$arg") ;;
+                    esac
+                done
+            ;;
+
             "--song_format") song_format="$2" ;;
             "--song_shorthand") song_shorthand="$2" ;;
             "--music_player") music_player="$2" ;;


### PR DESCRIPTION
## Description

Adds option `--ip_interface` and array `local_ip_interface` to allow multiple local IPs to be shown

Resolves #1264 

## Features

Select as many interfaces as you want
Interfaces with no IP get ignored and error shown when run with `-v`

## Issues

Only supports macOS for now

## TODO

Add support for other OSes