### PR TITLE
Fix Guix ascii not shown

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -6679,7 +6679,7 @@ ${c1}|.__          __.|
 EOF
         ;;
 
-        "GuixSD"*)
+        "Guix"*)
             set_colors 3 7 6 1 8
             read -rd '' ascii_data <<'EOF'
 ${c1} ..                             `.

--- a/neofetch
+++ b/neofetch
@@ -6666,7 +6666,7 @@ eee        ${c2}//  \\ooo/  \\\        ${c1}eee
 EOF
         ;;
 
-        "guixsd_small"*)
+        "guix_small"*)
             set_colors 3 7 6 1 8
             read -rd '' ascii_data <<'EOF'
 ${c1}|.__          __.|


### PR DESCRIPTION
## Description
According to #1342 Guix was renamed from GuixSD to Guix System and the ascii logo is not shown.

Reduced the matching to "Guix"* instead of "GuixSD"* to fix this. For consistency also renamed the small logo.

