### PR TITLE
updated --help

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -4618,8 +4618,8 @@ ASCII:
 
                                 NOTE: Ubuntu has flavor variants.
 
-                                NOTE: Change this to 'Lubuntu', 'Kubuntu', 'Xubuntu', 'Ubuntu-GNOME',
-                               'Ubuntu-Studio', 'Ubuntu-Mate'  or 'Ubuntu-Budgie' to use the flavors.
+                                NOTE: Change this to Lubuntu, Kubuntu, Xubuntu, Ubuntu-GNOME,
+                                Ubuntu-Studio, Ubuntu-Mate  or Ubuntu-Budgie to use the flavors.
 
                                 NOTE: Arcolinux, Dragonfly, Fedora, Alpine, Arch, Ubuntu, 
                                 CRUX, Debian, Gentoo, FreeBSD, Mac, NixOS, OpenBSD, android, 

--- a/neofetch
+++ b/neofetch
@@ -4612,17 +4612,18 @@ ASCII:
     --ascii_colors x x x x x x  Colors to print the ascii art
     --ascii_distro distro       Which Distro's ascii art to print
 
-                                NOTE: Arch and Ubuntu have 'old' logo variants.
+                                NOTE: Arch, Ubuntu, Redhat, and Dragonfly have 'old' logo variants.
 
-                                NOTE: Use 'arch_old' or 'ubuntu_old' to use the old logos.
+                                NOTE: Use '{distro name}_old' to use the old logos.
 
                                 NOTE: Ubuntu has flavor variants.
 
-                                NOTE: Change this to 'Lubuntu', 'Xubuntu', 'Ubuntu-GNOME',
-                                'Ubuntu-Studio' or 'Ubuntu-Budgie' to use the flavors.
+                                NOTE: Change this to 'Lubuntu', 'Kubuntu', 'Xubuntu', 'Ubuntu-GNOME',
+                                'Ubuntu-Studio', 'Ubuntu-Mate'  or 'Ubuntu-Budgie' to use the flavors.
 
-                                NOTE: Alpine, Arch, CRUX, Debian, Gentoo, FreeBSD, Mac, NixOS,
-                                OpenBSD, postmarketOS, and Void have a smaller logo variant.
+                                NOTE: Arcolinux, Dragonfly, Fedora, Alpine, Arch,
+                                CRUX, Debian, Gentoo, FreeBSD, Mac, NixOS, OpenBSD,
+                                postmarketOS, and Void have a smaller logo variant.
 
                                 NOTE: Use '{distro name}_small' to use the small variants.
 
@@ -6215,8 +6216,7 @@ EOF
         "dragonfly_old"*)
             set_colors 1 7 3
             read -rd '' ascii_data <<'EOF'
-                   ${c1} |
-                   .-.
+     ${c1}              .-.
                  ${c3} ()${c1}I${c3}()
             ${c1} "==.__:-:__.=="
             "==.__/~|~\__.=="
@@ -8154,7 +8154,7 @@ ${c1}               PPPPPPPPPPPPPP
 EOF
         ;;
 
-        "popos_small"*)
+        "popos_small"* | "pop_os_small"*)
             set_colors 6 7
             read -rd '' ascii_data <<'EOF'
 ${c1}______
@@ -8168,7 +8168,7 @@ ${c1}______
 EOF
         ;;
 
-        "Pop!_OS"*)
+        "Pop!_OS"* | "popos"* | "pop_os"*)
             set_colors 6 7
             read -rd '' ascii_data <<'EOF'
 ${c1}             /////////////
@@ -8508,7 +8508,7 @@ RRRR     RRRRRRRRRRRRRRRRRRR  R   RRRR
 EOF
         ;;
 
-        "redhat_old")
+        "redhat_old" | "rhel_old"*)
             set_colors 1 7 3
             read -rd '' ascii_data <<'EOF'
 ${c1}             `.-..........`

--- a/neofetch
+++ b/neofetch
@@ -4619,7 +4619,7 @@ ASCII:
                                 NOTE: Ubuntu has flavor variants.
 
                                 NOTE: Change this to 'Lubuntu', 'Kubuntu', 'Xubuntu', 'Ubuntu-GNOME',
-                                'Ubuntu-Studio', 'Ubuntu-Mate'  or 'Ubuntu-Budgie' to use the flavors.
+                               'Ubuntu-Studio', 'Ubuntu-Mate'  or 'Ubuntu-Budgie' to use the flavors.
 
                                 NOTE: Arcolinux, Dragonfly, Fedora, Alpine, Arch, Ubuntu, 
                                 CRUX, Debian, Gentoo, FreeBSD, Mac, NixOS, OpenBSD, android, 

--- a/neofetch
+++ b/neofetch
@@ -6216,7 +6216,7 @@ EOF
         "dragonfly_old"*)
             set_colors 1 7 3
             read -rd '' ascii_data <<'EOF'
-     ${c1}                 .-.
+     ${c1}                   .-.
                  ${c3} ()${c1}I${c3}()
             ${c1} "==.__:-:__.=="
             "==.__/~|~\__.=="

--- a/neofetch
+++ b/neofetch
@@ -6216,7 +6216,7 @@ EOF
         "dragonfly_old"*)
             set_colors 1 7 3
             read -rd '' ascii_data <<'EOF'
-     ${c1}              .-.
+     ${c1}                 .-.
                  ${c3} ()${c1}I${c3}()
             ${c1} "==.__:-:__.=="
             "==.__/~|~\__.=="

--- a/neofetch
+++ b/neofetch
@@ -4621,8 +4621,11 @@ ASCII:
                                 NOTE: Change this to 'Lubuntu', 'Kubuntu', 'Xubuntu', 'Ubuntu-GNOME',
                                 'Ubuntu-Studio', 'Ubuntu-Mate'  or 'Ubuntu-Budgie' to use the flavors.
 
-                                NOTE: Arcolinux, Dragonfly, Fedora, Alpine, Arch,
-                                CRUX, Debian, Gentoo, FreeBSD, Mac, NixOS, OpenBSD,
+                                NOTE: Arcolinux, Dragonfly, Fedora, Alpine, Arch, Ubuntu, 
+                                CRUX, Debian, Gentoo, FreeBSD, Mac, NixOS, OpenBSD, android, 
+                                Antrix, CentOS, Cleanjaro, ElementaryOS, GUIX, Hyperbola,
+                                Manjaro, MXLinux, NetBSD, Parabola, POP_OS, PureOS,  
+                                Slackware, SunOS, LinuxLite, OpenSUSE, Raspbian,
                                 postmarketOS, and Void have a smaller logo variant.
 
                                 NOTE: Use '{distro name}_small' to use the small variants.


### PR DESCRIPTION
i got annoyed how bad --help was for --ascii_distro so 
i got all names in there for old varients, ubuntu flavors, and small varients 
i got a error when doing neofetch --ascii_distro "POP!_OS" so i made another one saying pop_os without exclamation mark cuz thats what made the error
no rhel_old annoyed me
fixed dragonfly_old cuz it had a weird line which i disliked 