### PR TITLE
Detect Mutter on GNOME Wayland and Openbox theme on LXQt

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1809,19 +1809,17 @@ get_wm_theme() {
         ;;
 
         "Openbox")
-            if [[ "$de" == "LXDE" && -f "${HOME}/.config/openbox/lxde-rc.xml" ]]; then
-                ob_file="lxde-rc"
+            case $de in
+                "LXDE"*) ob_file="lxde-rc" ;;
+                "LXQt"*) ob_file="lxqt-rc" ;;
+                      *) ob_file="rc" ;;
+            esac
 
-            elif [[ "$de" == "LXQt" && -f "${HOME}/.config/openbox/lxqt-rc.xml" ]]; then
-                ob_file="lxqt-rc"
+            ob_file="${XDG_CONFIG_HOME}/openbox/${ob_file}.xml"
 
-            elif [[ -f "${HOME}/.config/openbox/rc.xml" ]]; then
-                ob_file="rc"
-            fi
-
-            wm_theme="$(awk '/<theme>/ {while (getline n) {if (match(n, /<name>/)) {l=n; exit}}}
-                        END {split(l, a, "[<>]"); print a[3]}' \
-                        "${XDG_CONFIG_HOME}/openbox/${ob_file}.xml")";
+            [[ -f "$ob_file" ]] && \
+                wm_theme="$(awk '/<theme>/ {while (getline n) {if (match(n, /<name>/))
+                            {l=n; exit}}} END {split(l, a, "[<>]"); print a[3]}' "$ob_file")"
         ;;
 
         "PekWM")

--- a/neofetch
+++ b/neofetch
@@ -1646,6 +1646,7 @@ get_wm() {
                            -e clayland \
                            -e dwc \
                            -e fireplace \
+                           -e gnome-shell \
                            -e greenfield \
                            -e grefsen \
                            -e kwin \
@@ -1677,10 +1678,6 @@ get_wm() {
             wm=${wm/\"}
             wm=${wm/\"*}
         }
-
-        # Rename window managers to their proper values.
-        [[ $wm == *WINDOWMAKER* ]]   && wm=wmaker
-        [[ $wm == *"GNOME Shell"* ]] && wm=Mutter
 
         # Fallback for non-EWMH WMs.
         [[ $wm ]] ||
@@ -1740,6 +1737,10 @@ get_wm() {
             ;;
         esac
     fi
+
+    # Rename window managers to their proper values.
+    [[ $wm == *WINDOWMAKER* ]] && wm=wmaker
+    [[ $wm == *GNOME*Shell* ]] && wm=Mutter
 
     wm_run=1
 }

--- a/neofetch
+++ b/neofetch
@@ -1765,7 +1765,7 @@ get_wm_theme() {
             wm_theme="$detheme (${wm_theme})"
         ;;
 
-        "Compiz" | "Mutter" | "GNOME Shell" | "Gala")
+        "Compiz" | "Mutter" | "Gala")
             if type -p gsettings >/dev/null; then
                 wm_theme="$(gsettings get org.gnome.shell.extensions.user-theme name)"
 

--- a/neofetch
+++ b/neofetch
@@ -1816,7 +1816,8 @@ get_wm_theme() {
                 ob_file="rc"
             fi
 
-            wm_theme="$(awk -F "[<,>]" '/<theme/ {getline; print $3}' \
+            wm_theme="$(awk '/<theme>/ {while (getline n) {if (match(n, /<name>/)) {l=n; exit}}}
+                        END {split(l, a, "[<>]"); print a[3]}' \
                         "${XDG_CONFIG_HOME}/openbox/${ob_file}.xml")";
         ;;
 

--- a/neofetch
+++ b/neofetch
@@ -1812,6 +1812,9 @@ get_wm_theme() {
             if [[ "$de" == "LXDE" && -f "${HOME}/.config/openbox/lxde-rc.xml" ]]; then
                 ob_file="lxde-rc"
 
+            elif [[ "$de" == "LXQt" && -f "${HOME}/.config/openbox/lxqt-rc.xml" ]]; then
+                ob_file="lxqt-rc"
+
             elif [[ -f "${HOME}/.config/openbox/rc.xml" ]]; then
                 ob_file="rc"
             fi


### PR DESCRIPTION
## Description
* Added WM detection (Mutter) on GNOME Wayland
* Added Openbox theme detection on LXQt

Also:
* Removed `GNOME Shell` from a WM case as it's renamed to `Mutter` anyway.
* Changed the `awk` command in Openbox theme detection to be more robust.
  It failed when there were other lines (e.g. comments) between the `<theme>` and `<name>` lines in the config file. That was the case in Lubuntu default config for example.
* And finally refactored the Openbox theme detection to look nicer with the LXQt addition.

