### PR TITLE
Get wallpaper for Plasma desktop

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3743,7 +3743,7 @@ END
 
                 "Plasma"*)
                     image="${XDG_CONFIG_HOME}/plasma-org.kde.plasma.desktop-appletsrc"
-                    image="$(awk -F '=' '$1 == "Image" { print $2 }' $image)"
+                    image="$(awk -F '=' '$1 == "Image" { print $2 }' "$image")"
                 ;;
 
                 *)

--- a/neofetch
+++ b/neofetch
@@ -5781,23 +5781,23 @@ EOF
     "Carbs"*)
         set_colors 4 5 4 4 4 4
         read -rd '' ascii_data <<'EOF'
-${c2}             ..........
-          ..,;:ccccccc:;'..
-       ..,clllc:;;;;;:cllc,.
-      .,cllc,...     ..';;'.
-     .;lol;..           ..
-    .,lol;.
-    .coo:.
-   .'lol,.
-   .,lol,.
-   .,lol,.
-    'col;.
-    .:ooc'.
-    .'col:.
-     .'cllc'..          .''.
-      ..:lolc,'.......',cll,.
-        ..;cllllccccclllc;'.
-          ...',;;;;;;,,...
+${c2}             ..........               
+          ..,;:ccccccc:;'..           
+       ..,clllc:;;;;;:cllc,.          
+      .,cllc,...     ..';;'.          
+     .;lol;..           ..            
+    .,lol;.                           
+    .coo:.                            
+   .'lol,.                            
+   .,lol,.                            
+   .,lol,.                            
+    'col;.                            
+    .:ooc'.                           
+    .'col:.                           
+     .'cllc'..          .''.          
+      ..:lolc,'.......',cll,.         
+        ..;cllllccccclllc;'.          
+          ...',;;;;;;,,...            
                 .....
 EOF
         ;;

--- a/neofetch
+++ b/neofetch
@@ -3741,6 +3741,10 @@ END
                     image="$(decode_url "$image")"
                 ;;
 
+                "Plasma"*)
+                    image="$(cat ${HOME}/.config/plasma-org.kde.plasma.desktop-appletsrc | grep --fixed-strings --after-context 1  "[Wallpaper][org.kde.image][General]" | grep --extended-regexp --only-matching  "file.+")"
+                ;;
+
                 *)
                     if type -p feh >/dev/null && [[ -f "${HOME}/.fehbg" ]]; then
                         image="$(awk -F\' '/feh/ {printf $(NF-1)}' "${HOME}/.fehbg")"
@@ -5777,23 +5781,23 @@ EOF
     "Carbs"*)
         set_colors 4 5 4 4 4 4
         read -rd '' ascii_data <<'EOF'
-${c2}             ..........               
-          ..,;:ccccccc:;'..           
-       ..,clllc:;;;;;:cllc,.          
-      .,cllc,...     ..';;'.          
-     .;lol;..           ..            
-    .,lol;.                           
-    .coo:.                            
-   .'lol,.                            
-   .,lol,.                            
-   .,lol,.                            
-    'col;.                            
-    .:ooc'.                           
-    .'col:.                           
-     .'cllc'..          .''.          
-      ..:lolc,'.......',cll,.         
-        ..;cllllccccclllc;'.          
-          ...',;;;;;;,,...            
+${c2}             ..........
+          ..,;:ccccccc:;'..
+       ..,clllc:;;;;;:cllc,.
+      .,cllc,...     ..';;'.
+     .;lol;..           ..
+    .,lol;.
+    .coo:.
+   .'lol,.
+   .,lol,.
+   .,lol,.
+    'col;.
+    .:ooc'.
+    .'col:.
+     .'cllc'..          .''.
+      ..:lolc,'.......',cll,.
+        ..;cllllccccclllc;'.
+          ...',;;;;;;,,...
                 .....
 EOF
         ;;

--- a/neofetch
+++ b/neofetch
@@ -3742,8 +3742,8 @@ END
                 ;;
 
                 "Plasma"*)
-                    image="${XDG_CONFIG_HOME}/plasma-org.kde.plasma.desktop-appletsrc"
-                    image="$(awk -F '=' '$1 == "Image" { print $2 }' "$image")"
+                    image="${XDG_CONFIG_HOME}/plasmarc"
+                    image="$(awk -F '=' '$1 == "usersWallpapers" { print $2 }' "$image")"
                 ;;
 
                 *)

--- a/neofetch
+++ b/neofetch
@@ -3742,7 +3742,8 @@ END
                 ;;
 
                 "Plasma"*)
-                    image="$(cat ${HOME}/.config/plasma-org.kde.plasma.desktop-appletsrc | grep --fixed-strings --after-context 1  "[Wallpaper][org.kde.image][General]" | grep --extended-regexp --only-matching  "file.+")"
+                    image="${XDG_CONFIG_HOME}/plasma-org.kde.plasma.desktop-appletsrc"
+                    image="$(awk -F '=' '$1 == "Image" { print $2 }' $image)"
                 ;;
 
                 *)


### PR DESCRIPTION
## Description

Get wallpaper for Plasma desktop from ~~`${XDG_CONFIG_HOME}/plasma-org.kde.plasma.desktop-appletsrc`~~ `${XDG_CONFIG_HOME}/plasmarc`.

Tested with KDE Plasma 5.17.4 on Arch Linux.


