### PR TITLE
Fix Konsole font on Tumbleweed

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3125,7 +3125,7 @@ END
                         break
                     fi
                 done
-                [[ "$profile" ]] && break
+                [[ $profile ]] && break
             done
 
             [[ ! $profile ]] && return
@@ -3134,7 +3134,7 @@ END
             profile_filename="$(grep -l "Name=${profile}" "$HOME"/.local/share/konsole/*.profile)"
             profile_filename="${profile_filename/$'\n'*}"
 
-            [[ "$profile_filename" ]] && \
+            [[ $profile_filename ]] && \
                 term_font="$(awk -F '=|,' '/Font=/ {print $2,$3}' "$profile_filename")"
         ;;
 

--- a/neofetch
+++ b/neofetch
@@ -3102,21 +3102,33 @@ END
             # Get Process ID of current konsole window / tab
             child="$(get_ppid "$$")"
 
+            _qdbus() {
+                if type -p qdbus-qt5 >/dev/null; then
+                    qdbus-qt5 "$@"
+                else
+                    qdbus "$@"
+                fi
+            }
+
             IFS=$'\n' read -d "" -ra konsole_instances \
-                <<< "$(qdbus | awk '/org.kde.konsole/ {print $1}')"
+                <<< "$(_qdbus | awk '/org.kde.konsole/ {print $1}')"
 
             for i in "${konsole_instances[@]}"; do
-                IFS=$'\n' read -d "" -ra konsole_sessions <<< "$(qdbus "$i" | grep -F '/Sessions/')"
+                IFS=$'\n' read -d "" -ra konsole_sessions \
+                    <<< "$(_qdbus "$i" | grep -F '/Sessions/')"
 
                 for session in "${konsole_sessions[@]}"; do
-                    if ((child == "$(qdbus "$i" "$session" processId)")); then
-                        profile="$(qdbus "$i" "$session" environment |\
+                    if ((child == "$(_qdbus "$i" "$session" processId)")); then
+                        profile="$(_qdbus "$i" "$session" environment |\
                                    awk -F '=' '/KONSOLE_PROFILE_NAME/ {print $2}')"
+                        [[ ! $profile ]] && profile="$(_qdbus "$i" "$session" profile)"
                         break
                     fi
                 done
                 [[ "$profile" ]] && break
             done
+
+            [[ ! $profile ]] && return
 
             # We could have two profile files for the same profile name, take first match
             profile_filename="$(grep -l "Name=${profile}" "$HOME"/.local/share/konsole/*.profile)"


### PR DESCRIPTION
## Description

* On default Tumbleweed Plasma installation there is only qdbus-qt5. Add a wrapper `_qdbus`
to call `qdbus-qt5 `if available, otherwise `qdbus`.

* In Konsole 19.12.0 `KONSOLE_PROFILE_NAME` was replaced with dbus method `profile()`.  Use the `profile()` method if profile name is empty after grepping for `KONSOLE_PROFILE_NAME`.

* If there are more than one profile file in the config directory and getting the profile name fails for some reason it is possible that we print wrong font information. To avoid that return early if getting profile name fails.

* Remove some quotes for consistency.
