### PR TITLE
Fixes and updates for Konsole font detection

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3112,6 +3112,7 @@ END
                     if ((child == "$(qdbus "$i" "$session" processId)")); then
                         profile="$(qdbus "$i" "$session" environment |\
                                    awk -F '=' '/KONSOLE_PROFILE_NAME/ {print $2}')"
+                        [[ ! $profile ]] && profile="$(qdbus "$i" "$session" profile)"
                         break
                     fi
                 done

--- a/neofetch
+++ b/neofetch
@@ -3116,7 +3116,7 @@ END
                         break
                     fi
                 done
-                [[ "$profile" ]] && break
+                [[ $profile ]] && break
             done
 
             [[ ! $profile ]] && return
@@ -3125,7 +3125,7 @@ END
             profile_filename="$(grep -l "Name=${profile}" "$HOME"/.local/share/konsole/*.profile)"
             profile_filename="${profile_filename/$'\n'*}"
 
-            [[ "$profile_filename" ]] && \
+            [[ $profile_filename ]] && \
                 term_font="$(awk -F '=|,' '/Font=/ {print $2,$3}' "$profile_filename")"
         ;;
 

--- a/neofetch
+++ b/neofetch
@@ -3119,6 +3119,8 @@ END
                 [[ "$profile" ]] && break
             done
 
+            [[ ! $profile ]] && return
+
             # We could have two profile files for the same profile name, take first match
             profile_filename="$(grep -l "Name=${profile}" "$HOME"/.local/share/konsole/*.profile)"
             profile_filename="${profile_filename/$'\n'*}"

--- a/neofetch
+++ b/neofetch
@@ -3102,6 +3102,8 @@ END
             # Get Process ID of current konsole window / tab
             child="$(get_ppid "$$")"
 
+            QT_BINDIR="$(qtpaths --binaries-dir)" && PATH+=":$QT_BINDIR"
+
             IFS=$'\n' read -d "" -ra konsole_instances \
                 <<< "$(qdbus | awk '/org.kde.konsole/ {print $1}')"
 

--- a/neofetch
+++ b/neofetch
@@ -3112,14 +3112,14 @@ END
                     if ((child == "$(qdbus "$i" "$session" processId)")); then
                         profile="$(qdbus "$i" "$session" environment |\
                                    awk -F '=' '/KONSOLE_PROFILE_NAME/ {print $2}')"
-                        [[ ! $profile ]] && profile="$(qdbus "$i" "$session" profile)"
+                        [[ $profile ]] || profile="$(qdbus "$i" "$session" profile)"
                         break
                     fi
                 done
                 [[ $profile ]] && break
             done
 
-            [[ ! $profile ]] && return
+            [[ $profile ]] || return
 
             # We could have two profile files for the same profile name, take first match
             profile_filename="$(grep -l "Name=${profile}" "$HOME"/.local/share/konsole/*.profile)"


### PR DESCRIPTION
## Description

In Konsole 19.12.0 `KONSOLE_PROFILE_NAME` was removed from `environment` and replaced with dbus method `profile()`.

* Added a line to use the new `profile()` method if `$profile` is empty after grepping for `KONSOLE_PROFILE_NAME`.

* To avoid printing wrong font info  return early if getting the profile name fails. 

* Removed some quotes for consistency.
