### PR TITLE
Fix Exaile song query and remove redundant trim

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2672,9 +2672,12 @@ get_song() {
 
         "exaile"*)
             # NOTE: Exaile >= 4.0.0 will support mpris2.
-            song="$(dbus-send --print-reply --dest=org.exaile.Exaile  /org/exaile/Exaile \
-                    org.exaile.Exaile.Query |
-                    awk -F':|,' '{if ($6 && $8 && $4) printf $6 "\n" $8 "\n" $4}')"
+            song="$(dbus-send --print-reply --dest=org.exaile.Exaile \
+                    /org/exaile/Exaile org.exaile.Exaile.Query |
+                    awk -F ':' '{sub(",[^,]*$", "", $3); t=$3;
+                                 sub(",[^,]*$", "", $4); a=$4;
+                                 sub(",[^,]*$", "", $5); b=$5}
+                                 END {print a "\n" b "\n" t}')"
         ;;
 
         "muine"*)

--- a/neofetch
+++ b/neofetch
@@ -3782,7 +3782,6 @@ END
                 "Plasma"*)
                     image=$XDG_CONFIG_HOME/plasma-org.kde.plasma.desktop-appletsrc
                     image=$(awk -F '=' '$1 == "Image" { print $2 }' "$image")
-                    image=${image##file://}
                 ;;
 
                 *)


### PR DESCRIPTION
## Description

* Fixed a bug with Exaile song query when artist, album or title contains a `,`. 

broken
![broken](https://user-images.githubusercontent.com/40315484/71448809-91299380-2741-11ea-90ad-a52c88a0f9c7.png)

fixed
![fixed](https://user-images.githubusercontent.com/40315484/71448814-a6062700-2741-11ea-9c65-4b79806101ed.png)


* Also removed stripping of `file://` from Plasma wallpaper path. It's done at the end of the function anyway.
