### PR TITLE
Show memory in GiB and KiB

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -4684,7 +4684,7 @@ TEXT FORMATTING:
 
 COLOR BLOCKS:
     --color_blocks on/off       Enable/Disable the color blocks
-    --col_offset auto/num      Left-padding of color blocks
+    --col_offset auto/num       Left-padding of color blocks
     --block_width num           Width of color blocks in spaces
     --block_height num          Height of color blocks in lines
     --block_range num num       Range of colors to print as blocks

--- a/neofetch
+++ b/neofetch
@@ -171,23 +171,23 @@ memory_unit="mib"
 #
 # Default: '1'
 # Values:  'int'
-# Flag:    --memory_used_gb_prec
+# Flag:    --memory_used_gib_prec
 #
 # Example:
 # 1: '1.8GiB / 7.7GiB'
 # 2: '1.76GiB / 7.7GiB'
-memory_used_gb_prec="1"
+memory_used_gib_prec="1"
 
 # Number of digit places past the decimal for total GiB
 #
 # Default: '1'
 # Values:  'int'
-# Flag:    --memory_total_gb_prec
+# Flag:    --memory_total_gib_prec
 #
 # Example:
 # 0: '1.8GiB / 8GiB'
 # 1: '1.8GiB / 7.7GiB'
-memory_total_gb_prec="1"
+memory_total_gib_prec="1"
 
 
 # Packages
@@ -2563,8 +2563,8 @@ get_memory() {
 
     if [[ "$memory_unit" == "gib" ]]; then
         mem_label='GiB'
-        mem_used=$(awk "BEGIN {print sprintf(\"%.${memory_used_gb_prec}f\", ${mem_used}/1024)}")
-        mem_total=$(awk "BEGIN {print sprintf(\"%.${memory_total_gb_prec}f\", ${mem_total}/1024)}")
+        mem_used=$(awk "BEGIN {print sprintf(\"%.${memory_used_gib_prec}f\", ${mem_used}/1024)}")
+        mem_total=$(awk "BEGIN {print sprintf(\"%.${memory_total_gib_prec}f\", ${mem_total}/1024)}")
     elif [[ "$memory_unit" == "kib" ]]; then
         mem_label='KiB'
         mem_used=$(( mem_used * 1024 ))
@@ -4672,8 +4672,8 @@ INFO:
     --song_shorthand on/off     Print the Artist/Album/Title on separate lines.
     --memory_percent on/off     Display memory percentage.
     --memory_unit kib/mib/gib   Display memory in the selected unit.
-    --memory_used_gb_prec int   Digit places after the decimal for used memory in GiB.
-    --memory_total_gb_prec int  Digit places after the decimal for total memory in GiB.
+    --memory_used_gib_prec int  Digit places after the decimal for used memory in GiB.
+    --memory_total_gib_prec int Digit places after the decimal for total memory in GiB.
     --music_player player-name  Manually specify a player to use.
                                 Available values are listed in the config file
 
@@ -4867,8 +4867,8 @@ get_args() {
             "--music_player") music_player="$2" ;;
             "--memory_percent") memory_percent="$2" ;;
             "--memory_unit") memory_unit="$2" ;;
-            "--memory_used_gb_prec") memory_used_gb_prec="$2" ;;
-            "--memory_total_gb_prec") memory_total_gb_prec="$2" ;;
+            "--memory_used_gib_prec") memory_used_gib_prec="$2" ;;
+            "--memory_total_gib_prec") memory_total_gib_prec="$2" ;;
             "--cpu_temp")
                 cpu_temp="$2"
                 [[ "$cpu_temp" == "on" ]] && cpu_temp="C"

--- a/neofetch
+++ b/neofetch
@@ -156,6 +156,39 @@ uptime_shorthand="on"
 # off:  '1801MiB / 7881MiB'
 memory_percent="off"
 
+# Show memory in GiB.
+#
+# Default: 'off'
+# Values:  'on', 'off'
+# Flag:    --memory_use_gb
+#
+# Example:
+# on:  '1801MiB / 7881MiB'
+# off: '1.8GiB / 7.7GiB'
+memory_use_gb="off"
+
+# Number of digit places past the decimal for used GiB
+#
+# Default: '1'
+# Values:  'int'
+# Flag:    --memory_used_gb_prec
+#
+# Example:
+# 1: '1.8GiB / 7.7GiB'
+# 2: '1.76GiB / 7.7GiB'
+memory_used_gb_prec="1"
+
+# Number of digit places past the decimal for total GiB
+#
+# Default: '1'
+# Values:  'int'
+# Flag:    --memory_total_gb_prec
+#
+# Example:
+# 0: '1.8GiB / 8GiB'
+# 1: '1.8GiB / 7.7GiB'
+memory_total_gb_prec="1"
+
 
 # Packages
 
@@ -2528,6 +2561,13 @@ get_memory() {
 
     [[ "$memory_percent" == "on" ]] && ((mem_perc=mem_used * 100 / mem_total))
 
+    if [[ "$memory_use_gb" == "on" ]]
+    then
+        mem_label='GiB'
+        mem_used=$(awk "BEGIN {print sprintf(\"%.${memory_used_gb_prec}f\", ${mem_used}/1024)}")
+        mem_total=$(awk "BEGIN {print sprintf(\"%.${memory_total_gb_prec}f\", ${mem_total}/1024)}")
+    fi
+
     memory="${mem_used}${mem_label:-MiB} / ${mem_total}${mem_label:-MiB} ${mem_perc:+(${mem_perc}%)}"
 
     # Bars.
@@ -4628,6 +4668,9 @@ INFO:
     --song_format format        Print the song data in a specific format (see config file).
     --song_shorthand on/off     Print the Artist/Album/Title on separate lines.
     --memory_percent on/off     Display memory percentage.
+    --memory_use_gb on/off      Display memory in GiB.
+    --memory_used_gb_prec int   Digit places after the decimal for used memory in GiB.
+    --memory_total_gb_prec int  Digit places after the decimal for total memory in GiB.
     --music_player player-name  Manually specify a player to use.
                                 Available values are listed in the config file
 
@@ -4820,6 +4863,9 @@ get_args() {
             "--song_shorthand") song_shorthand="$2" ;;
             "--music_player") music_player="$2" ;;
             "--memory_percent") memory_percent="$2" ;;
+            "--memory_use_gb") memory_use_gb="$2" ;;
+            "--memory_used_gb_prec") memory_used_gb_prec="$2" ;;
+            "--memory_total_gb_prec") memory_total_gb_prec="$2" ;;
             "--cpu_temp")
                 cpu_temp="$2"
                 [[ "$cpu_temp" == "on" ]] && cpu_temp="C"

--- a/neofetch
+++ b/neofetch
@@ -156,16 +156,16 @@ uptime_shorthand="on"
 # off:  '1801MiB / 7881MiB'
 memory_percent="off"
 
-# Show memory in GiB.
+# Set unit to display memory in
 #
-# Default: 'off'
-# Values:  'on', 'off'
-# Flag:    --memory_use_gb
+# Default: 'mib'
+# Values:  'kib', 'mib', gib'
+# Flag:    --memory_unit
 #
 # Example:
-# on:  '1801MiB / 7881MiB'
-# off: '1.8GiB / 7.7GiB'
-memory_use_gb="off"
+# mib:  '1801MiB / 7881MiB'
+# gib: '1.8GiB / 7.7GiB'
+memory_unit="mib"
 
 # Number of digit places past the decimal for used GiB
 #
@@ -2561,11 +2561,14 @@ get_memory() {
 
     [[ "$memory_percent" == "on" ]] && ((mem_perc=mem_used * 100 / mem_total))
 
-    if [[ "$memory_use_gb" == "on" ]]
-    then
+    if [[ "$memory_unit" == "gib" ]]; then
         mem_label='GiB'
         mem_used=$(awk "BEGIN {print sprintf(\"%.${memory_used_gb_prec}f\", ${mem_used}/1024)}")
         mem_total=$(awk "BEGIN {print sprintf(\"%.${memory_total_gb_prec}f\", ${mem_total}/1024)}")
+    elif [[ "$memory_unit" == "kib" ]]; then
+        mem_label='KiB'
+        mem_used=$(( mem_used * 1024 ))
+        mem_total=$(( mem_total * 1024 ))
     fi
 
     memory="${mem_used}${mem_label:-MiB} / ${mem_total}${mem_label:-MiB} ${mem_perc:+(${mem_perc}%)}"
@@ -4668,7 +4671,7 @@ INFO:
     --song_format format        Print the song data in a specific format (see config file).
     --song_shorthand on/off     Print the Artist/Album/Title on separate lines.
     --memory_percent on/off     Display memory percentage.
-    --memory_use_gb on/off      Display memory in GiB.
+    --memory_unit kib/mib/gib   Display memory in the selected unit.
     --memory_used_gb_prec int   Digit places after the decimal for used memory in GiB.
     --memory_total_gb_prec int  Digit places after the decimal for total memory in GiB.
     --music_player player-name  Manually specify a player to use.
@@ -4863,7 +4866,7 @@ get_args() {
             "--song_shorthand") song_shorthand="$2" ;;
             "--music_player") music_player="$2" ;;
             "--memory_percent") memory_percent="$2" ;;
-            "--memory_use_gb") memory_use_gb="$2" ;;
+            "--memory_unit") memory_unit="$2" ;;
             "--memory_used_gb_prec") memory_used_gb_prec="$2" ;;
             "--memory_total_gb_prec") memory_total_gb_prec="$2" ;;
             "--cpu_temp")


### PR DESCRIPTION
## Description

This PR implements the ability to display memory in GiB or KiB instead of MiB. The default is to use MiB, to preserve current behaviour. The precision for both used and total RAM can be set. These precisions both default to 1.

~I chose to use "gb" instead of "gib" in the option names because GiB just looks weird in snake case, and adding a single character will also require a whole bunch of whitespace realignment in the code around line 4673.~

I also noticed a single character whitespace misalignment and took the liberty of cleaning that up in this PR too.

## Features

Memory can be shown in GiB or KiB using ~`memory_use_gb="on"`~ `memory_unit=<kib|mib|gib>`
Precision for both used and total GiB can be set separately using `memory_used_gib_prec=<int>` and `memory_used_gib_prec=<int>`.

## Issues

Closes https://github.com/dylanaraps/neofetch/issues/1170

## TODO

N/A