### PR TITLE
Add info longtitle (FQDN)

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -70,6 +70,7 @@ print_info() {
     info "GPU" gpu
     info "Memory" memory
 
+    # info longtitle
     # info "GPU Driver" gpu_driver  # Linux/macOS only
     # info "CPU Usage" cpu_usage
     # info "Disk" disk
@@ -1279,6 +1280,13 @@ get_title() {
     user=${USER:-$(id -un || printf %s "${HOME/*\/}")}
     hostname=${HOSTNAME:-$(hostname)}
     title=${title_color}${bold}${user}${at_color}@${title_color}${bold}${hostname}
+    length=$((${#user} + ${#hostname} + 1))
+}
+
+get_longtitle() {
+    user=${USER:-$(id -un || printf %s "${HOME/*\/}")}
+    hostname=$(hostname -f)
+    longtitle=${title_color}${bold}${user}${at_color}@${title_color}${bold}${hostname}
     length=$((${#user} + ${#hostname} + 1))
 }
 


### PR DESCRIPTION
Add function get_longtitle() for info longtitle to display FQDN instead of short hostname.

## TODO
Maybe add config option for get_title() instead?
