### PR TITLE
Add patterns for AMD CPUs with numeric core counts

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2191,6 +2191,8 @@ get_cpu() {
     cpu="${cpu//Quad-Core}"
     cpu="${cpu//Six-Core}"
     cpu="${cpu//Eight-Core}"
+    cpu="${cpu//[1-9][0-9]-Core}"
+    cpu="${cpu//[0-9]-Core}"
     cpu="${cpu//, * Compute Cores}"
     cpu="${cpu//Core / }"
     cpu="${cpu//(\"AuthenticAMD\"*)}"


### PR DESCRIPTION
## Description
Previously, AMD CPUs with numeric core values (for example 3rd-gen Ryzen CPUs) had their CPU name cut off incorrectly:
![image](https://user-images.githubusercontent.com/12816807/73610544-378a7380-45e1-11ea-8af7-ca4070ad5912.png)
This patch fixes the problem:
![image](https://user-images.githubusercontent.com/12816807/73610538-23467680-45e1-11ea-8718-8dac97f99460.png)