### PR TITLE
FreeMiNT-specific fixes and updates

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2828,6 +2828,10 @@ get_resolution() {
             [[ "$refresh_rate" == "off" ]] && resolution="${resolution/ @*}"
         ;;
 
+        "FreeMiNT")
+            # Need to block X11 queries
+        ;;
+
         *)
             if type -p xrandr >/dev/null && [[ $DISPLAY && -z $WAYLAND_DISPLAY ]]; then
                 case $refresh_rate in
@@ -3711,10 +3715,6 @@ get_cols() {
     fi
 
     unset -v blocks blocks2 cols
-
-    # TosWin2 on FreeMiNT is terrible at this,
-    # so we'll reset colors arbitrarily.
-    [[ "$term" == "TosWin2" ]] && printf '\e[30;47m'
 
     # Tell info() that we printed manually.
     prin=1
@@ -6766,8 +6766,7 @@ EOF
         ;;
 
         "FreeMiNT"*)
-            # Don't explicitly set colors since
-            # TosWin2 doesn't reset well.
+            set_colors 7
             read -rd '' ascii_data <<'EOF'
 ${c1}          ##
           ##         #########

--- a/neofetch
+++ b/neofetch
@@ -1261,6 +1261,7 @@ get_model() {
 
         FreeMiNT)
             model=$(sysctl -n hw.model)
+            model=${model/ (_MCH *)}
         ;;
     esac
 
@@ -1799,11 +1800,11 @@ get_wm() {
                 freemint_wm=(/proc/*)
 
                 case ${freemint_wm[*]} in
-                    *xaaes*) wm=XaAES ;;
-                    *myaes*) wm=MyAES ;;
-                    *naes*)  wm=N.AES ;;
-                    geneva)  wm=Geneva ;;
-                    *)       wm="Atari AES" ;;
+                    *xaaes* | *xaloader*) wm=XaAES ;;
+                    *myaes*)              wm=MyAES ;;
+                    *naes*)               wm=N.AES ;;
+                    geneva)               wm=Geneva ;;
+                    *)                    wm="Atari AES" ;;
                 esac
             ;;
         esac
@@ -2560,7 +2561,7 @@ get_memory() {
         "FreeMiNT")
             mem="$(awk -F ':|kB' '/MemTotal:|MemFree:/ {printf $2, " "}' /kern/meminfo)"
             mem_free="${mem/*  }"
-            mem_total="${mem/  *}"
+            mem_total="${mem/$mem_free}"
             mem_used="$((mem_total - mem_free))"
             mem_total="$((mem_total / 1024))"
             mem_used="$((mem_used / 1024))"


### PR DESCRIPTION
## Description

This pair of commits fixes some FreeMiNT-specific issues:

1. Removes a number of FreeMiNT-specific color fixes that aren't strictly necessary

2. Checks for the presence of _xaloader_ in processes to detect XaAES when loaded via kernel module (as it is in current versions)

3. Blocks using X11 resolution checks since these checks will lock up with the default X11 tools on FreeMiNT if the X server isn't running and will be incorrect if X/GEM is running

4. Fixes the memory info on current kernels and Bash versions

5. Strips machine cookiejar identifier from the model info

## Features

## Issues

## TODO
