### PR TITLE
detect whether using -current on OpenBSD

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1032,6 +1032,11 @@ get_distro() {
                     *) distro="Guix System $(guix system -V | awk 'NR==1{printf $5}')"
                 esac
 
+            # Display whether using '-current' or '-release' on OpenBSD.
+            elif [[ $kernel_name = OpenBSD ]] ; then
+                read -ra kernel_info <<< "$(sysctl -n kern.version)"
+                distro=${kernel_info[*]:0:2}
+
             else
                 for release_file in /etc/*-release; do
                     distro+=$(< "$release_file")


### PR DESCRIPTION
Previous output: `OS: OpenBSD 6.6 amd64`  
Changed output: `OS: OpenBSD 6.6-current amd64`

If not running current, simply `OpenBSD 6.6` is printed.

full text output of the command used:

```sh
% sysctl -n kern.version
OpenBSD 6.6-current (GENERIC.MP) #40: Sun Mar  8 20:17:34 MDT 2020
    deraadt@amd64.openbsd.org:/usr/src/sys/arch/amd64/compile/GENERIC.MP

%
```