### PR TITLE
os: Add OpenStage Linux

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -769,7 +769,7 @@ image_source="auto"
 #       LMDE, Lubuntu, Lunar, macos, Mageia, MagpieOS, Mandriva,
 #       Manjaro, Maui, Mer, Minix, LinuxMint, MX_Linux, Namib,
 #       Neptune, NetBSD, Netrunner, Nitrux, NixOS, Nurunner,
-#       NuTyX, OBRevenge, OpenBSD, OpenIndiana, OpenMandriva,
+#       NuTyX, OBRevenge, OpenBSD, OpenIndiana, OpenMandriva, OpenStage,
 #       OpenWrt, osmc, Oracle, PacBSD, Parabola, Pardus, Parrot,
 #       Parsix, TrueOS, PCLinuxOS, Peppermint, popos, Porteus,
 #       PostMarketOS, Proxmox, Puppy, PureOS, Qubes, Radix, Raspbian,
@@ -4833,7 +4833,7 @@ ASCII:
                                 LMDE, Lubuntu, Lunar, macos, Mageia, MagpieOS, Mandriva,
                                 Manjaro, Maui, Mer, Minix, LinuxMint, MX_Linux, Namib,
                                 Neptune, NetBSD, Netrunner, Nitrux, NixOS, Nurunner,
-                                NuTyX, OBRevenge, OpenBSD, OpenIndiana, OpenMandriva,
+                                NuTyX, OBRevenge, OpenBSD, OpenIndiana, OpenMandriva, OpenStage,
                                 OpenWrt, osmc, Oracle, PacBSD, Parabola, Pardus, Parrot,
                                 Parsix, TrueOS, PCLinuxOS, Peppermint, popos, Porteus,
                                 PostMarketOS, Proxmox, Puppy, PureOS, Qubes, Radix, Raspbian,
@@ -8171,6 +8171,29 @@ ${c1}                  ``````
         `:oyhhhhhhhhhhhhhhhhhhyo:`
             .:+syhhhhhhhhys+:-`
                  ``....``
+EOF
+        ;;
+
+        "OpenStage"*)
+            set_colors 2
+            read -rd '' ascii_data <<'EOF'
+${c1}                 /(/
+              .(((((((,
+             /(((((((((/
+           .(((((/,/(((((,
+          *(((((*   ,(((((/
+          (((((*      .*/((
+         *((((/  (//(/*
+         /((((*  ((((((((((,
+      .  /((((*  (((((((((((((.
+     ((. *((((/        ,((((((((
+   ,(((/  (((((/     **   ,((((((*
+  /(((((. .(((((/   //(((*  *(((((/
+ .(((((,    ((/   .(((((/.   .(((((,
+ /((((*        ,(((((((/      ,(((((
+ /(((((((((((((((((((/.  /(((((((((/
+ /(((((((((((((((((,   /(((((((((((/
+     */(((((//*.      */((/(/(/*
 EOF
         ;;
 


### PR DESCRIPTION
## Description

Add ascii logo for OpenStage Linux.
https://www.openstagelinux.org/
https://gitlab.com/openstage-packages/community/screenfetch-os/-/blob/master/ascii2


![openstage](https://user-images.githubusercontent.com/40315484/77848783-91657f00-71c7-11ea-875c-420790849918.png)

