### PR TITLE
Change order GTK3 settings.ini files are read

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2984,11 +2984,11 @@ get_style() {
             elif type -p gsettings >/dev/null; then
                 gtk3_theme="$(gsettings get org.gnome.desktop.interface "$gsettings")"
 
-            elif [[ -f "/usr/share/gtk-3.0/settings.ini" ]]; then
-                gtk3_theme="$(grep "^[^#]*$name" /usr/share/gtk-3.0/settings.ini)"
-
             elif [[ -f "/etc/gtk-3.0/settings.ini" ]]; then
                 gtk3_theme="$(grep "^[^#]*$name" /etc/gtk-3.0/settings.ini)"
+
+            elif [[ -f "/usr/share/gtk-3.0/settings.ini" ]]; then
+                gtk3_theme="$(grep "^[^#]*$name" /usr/share/gtk-3.0/settings.ini)"
             fi
 
             gtk3_theme="${gtk3_theme/${name}*=}"


### PR DESCRIPTION
## Description

Prefer `/etc/gtk-3.0/settings.ini` to `/usr/share/gtk-3.0/settings.ini`.

Currently, it checks `/usr/share/gtk-3.0/settings.ini` first; this causes it to misreport my GTK 3 theme, which I customized in `/etc/gtk-3.0/settings.ini`.

Curiously enough, for GTK 2, it already checks `/etc/gtk-2.0/gtkrc` first, so it already gets my GTK 2 theme right.