### PR TITLE
Fix gentoo's logo

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -6890,7 +6890,7 @@ EOF
         ;;
 
         "Gentoo"*)
-            set_colors 5 7
+            set_colors 4 7
             read -rd '' ascii_data <<'EOF'
 ${c1}         -/oyddmdhs+:.
      -o${c2}dNMMMMMMMMNNmhy+${c1}-`


### PR DESCRIPTION
The logo of gentoo is pink and white instead of purple and white,
here are the official logos given by the gentoo fondation : https://gentoo.org/inside-gentoo/artwork/gentoo-logo.html