### PR TITLE
Added support for Alter Linux and Serene Linux

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -757,7 +757,7 @@ image_source="auto"
 # Default: 'auto'
 # Values:  'auto', 'distro_name'
 # Flag:    --ascii_distro
-# NOTE: AIX, Alpine, Anarchy, Android, Antergos, antiX, "AOSC OS",
+# NOTE: AIX, Alpine, AlterLinux, Anarchy, Android, Antergos, antiX, "AOSC OS",
 #       "AOSC OS/Retro", Apricity, ArcoLinux, ArchBox, ARCHlabs, ArchStrike,
 #       XFerience, ArchMerge, Arch, Artix, Arya, Bedrock, Bitrig,
 #       BlackArch, BLAG, BlankOn, BlueLight, bonsai, BSD,
@@ -778,9 +778,9 @@ image_source="auto"
 #       Parsix, TrueOS, PCLinuxOS, Peppermint, popos, Porteus,
 #       PostMarketOS, Proxmox, Puppy, PureOS, Qubes, Radix, Raspbian,
 #       Reborn_OS, Redstar, Redcore, Redhat, Refracted_Devuan, Regata,
-#       Rosa, sabotage, Sabayon, Sailfish, SalentOS, Scientific, Septor,
-#       SharkLinux, Siduction, Slackware, SliTaz, SmartOS, Solus,
-#       Source_Mage, Sparky, Star, SteamOS, SunOS, openSUSE_Leap,
+#       Rosa, sabotage, Sabayon, Sailfish, SalentOS, Scientific, Septor, 
+#       SereneLinux, SharkLinux, Siduction, Slackware, SliTaz, SmartOS,
+#       Solus, Source_Mage, Sparky, Star, SteamOS, SunOS, openSUSE_Leap,
 #       openSUSE_Tumbleweed, openSUSE, SwagArch, Tails, Trisquel,
 #       Ubuntu-Budgie, Ubuntu-GNOME, Ubuntu-MATE, Ubuntu-Studio, Ubuntu,
 #       Void, Obarun, windows10, Windows7, Xubuntu, Zorin, and IRIX

--- a/neofetch
+++ b/neofetch
@@ -9247,6 +9247,32 @@ yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
 EOF
         ;;
 
+        "Serene"*)
+            set_colors 6 6
+            read -rd '' ascii_data <<'EOF'
+${c1}              __---''''''---__
+          .                      .
+        :                          :
+      -                       _______----_-
+     s               __----'''     __----
+ __h_            _-'           _-'     h
+ '-._''--.._    ;           _-'         y
+  :  ''-._  '-._/        _-'             :
+  y       ':_       _--''                y
+  m    .--'' '-._.;'                     m
+  m   :        :                         m
+  y    '.._     '-__                     y
+  :        '--._    '''----___           :
+   y            '--._         ''-- _    y
+    h                '--._          :  h
+     s                  __';         vs
+      -         __..--''             -
+        :_..--''                   :
+          .                     _ .
+            `''---______---''-``
+EOF
+        ;;
+
         "SharkLinux"*)
             set_colors 4 7
             read -rd '' ascii_data <<'EOF'

--- a/neofetch
+++ b/neofetch
@@ -4836,9 +4836,9 @@ ASCII:
     --ascii_colors x x x x x x  Colors to print the ascii art
     --ascii_distro distro       Which Distro's ascii art to print
 
-                                NOTE: AIX, Alpine, Anarchy, Android, Antergos, antiX, "AOSC OS",
-                                "AOSC OS/Retro", Apricity, ArcoLinux, ArchBox, ARCHlabs, ArchStrike,
-                                XFerience, ArchMerge, Arch, Artix, Arya, Bedrock, Bitrig,
+                                NOTE: AIX, Alpine, AlterLinux, Anarchy, Android, Antergos, antiX,
+                                "AOSC OS", "AOSC OS/Retro", Apricity, ArcoLinux, ArchBox, ARCHlabs,
+                                ArchStrike, XFerience, ArchMerge, Arch, Artix, Arya, Bedrock, Bitrig,
                                 BlackArch, BLAG, BlankOn, BlueLight, bonsai, BSD,
                                 BunsenLabs, Calculate, Carbs, CentOS, Chakra, ChaletOS,
                                 Chapeau, Chrom, Cleanjaro, ClearOS, Clear_Linux, Clover,
@@ -4858,8 +4858,8 @@ ASCII:
                                 PostMarketOS, Proxmox, Puppy, PureOS, Qubes, Radix, Raspbian,
                                 Reborn_OS, Redstar, Redcore, Redhat, Refracted_Devuan, Regata,
                                 Rosa, sabotage, Sabayon, Sailfish, SalentOS, Scientific, Septor,
-                                SharkLinux, Siduction, Slackware, SliTaz, SmartOS, Solus,
-                                Source_Mage, Sparky, Star, SteamOS, SunOS, openSUSE_Leap,
+                                SereneLinux, SharkLinux, Siduction, Slackware, SliTaz, SmartOS,
+                                Solus, Source_Mage, Sparky, Star, SteamOS, SunOS, openSUSE_Leap,
                                 openSUSE_Tumbleweed, openSUSE, SwagArch, Tails, Trisquel,
                                 Ubuntu-Budgie, Ubuntu-GNOME, Ubuntu-MATE, Ubuntu-Studio, Ubuntu,
                                 Void, Obarun, windows10, Windows7, Xubuntu, Zorin, and IRIX

--- a/neofetch
+++ b/neofetch
@@ -5273,6 +5273,32 @@ hdddyo+ohddyosdddddddddho+oydddy++ohdddh
 EOF
         ;;
 
+        "Alter"*)
+            set_colors 6 6
+            read -rd '' ascii_data <<'EOF'
+${c1}                      %,
+                    ^WWWw
+                   'wwwwww
+                  !wwwwwwww
+                 #`wwwwwwwww
+                @wwwwwwwwwwww
+               wwwwwwwwwwwwwww
+              wwwwwwwwwwwwwwwww
+             wwwwwwwwwwwwwwwwwww
+            wwwwwwwwwwwwwwwwwwww,
+           w~1i.wwwwwwwwwwwwwwwww,
+         3~:~1lli.wwwwwwwwwwwwwwww.
+        :~~:~?ttttzwwwwwwwwwwwwwwww
+       #<~:~~~~?llllltO-.wwwwwwwwwww
+      #~:~~:~:~~?ltlltlttO-.wwwwwwwww
+     @~:~~:~:~:~~(zttlltltlOda.wwwwwww
+    @~:~~: ~:~~:~:(zltlltlO    a,wwwwww
+   8~~:~~:~~~~:~~~~_1ltltu          ,www
+  5~~:~~:~~:~~:~~:~~~_1ltq             N,,
+ g~:~~:~~~:~~:~~:~:~~~~1q                N,
+EOF
+        ;;
+
         "Amazon"*)
             set_colors 3 7
             read -rd '' ascii_data <<'EOF'

--- a/neofetch.1
+++ b/neofetch.1
@@ -287,8 +287,8 @@ Colors to print the ascii art
 \fB\-\-ascii_distro\fR distro
 Which Distro's ascii art to print
 .TP
-NOTE: AIX, Alpine, Anarchy, Android, Antergos, antiX, AOSC,
-Apricity, ArcoLinux, ArchBox, ARCHlabs, ArchStrike,
+NOTE: AIX, Alpine, AlterLinux, Anarchy, Android, Antergos, antiX,
+AOSC, Apricity, ArcoLinux, ArchBox, ARCHlabs, ArchStrike,
 XFerience, ArchMerge, Arch, Artix, Arya, Bedrock, Bitrig,
 BlackArch, BLAG, BlankOn, BlueLight, bonsai, BSD,
 BunsenLabs, Calculate, Carbs, CentOS, Chakra, ChaletOS,
@@ -309,8 +309,8 @@ Parsix, TrueOS, PCLinuxOS, Peppermint, popos, Porteus,
 PostMarketOS, Proxmox, Puppy, PureOS, Qubes, Radix, Raspbian,
 Reborn_OS, Redstar, Redcore, Redhat, Refracted_Devuan, Regata,
 Rosa, sabotage, Sabayon, Sailfish, SalentOS, Scientific, Septor,
-SharkLinux, Siduction, Slackware, SliTaz, SmartOS, Solus,
-Source_Mage, Sparky, Star, SteamOS, SunOS, openSUSE_Leap,
+SereneLinux, SharkLinux, Siduction, Slackware, SliTaz, SmartOS,
+Solus, Source_Mage, Sparky, Star, SteamOS, SunOS, openSUSE_Leap,
 openSUSE_Tumbleweed, openSUSE, SwagArch, Tails, Trisquel,
 Ubuntu\-Budgie, Ubuntu\-GNOME, Ubuntu\-MATE, Ubuntu\-Studio, Ubuntu,
 Void, Obarun, windows10, Windows7, Xubuntu, Zorin, and IRIX


### PR DESCRIPTION
## Description
Added the [Alter Linux](https://fascode.net/en/projects/linux/alter/) and [Serene Linux](https://fascode.net/en/projects/linux/serene/) logos.

I didn't quite understand the format of the commit message.I apologize.
I am Japanese and I am not very good at English. I am using Google Translate for this sentence.

