### PR TITLE
Add es shell support

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1594,7 +1594,7 @@ get_shell() {
             shell+=${BASH_VERSION/-*}
         ;;
 
-        sh|ash|dash) ;;
+        sh|ash|dash|es) ;;
 
         *ksh)
             shell+=$("$SHELL" -c "printf %s \"\$KSH_VERSION\"")


### PR DESCRIPTION
es shell doesn't have any way to check the version, so I added it to the shells that ignore `--shell_version on` in this simple commit.