### PR TITLE
Turn memory percent on

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -168,7 +168,7 @@ uptime_shorthand="on"
 # Example:
 # on:   '1801MiB / 7881MiB (22%)'
 # off:  '1801MiB / 7881MiB'
-memory_percent="off"
+memory_percent="on"
 
 
 # Packages


### PR DESCRIPTION
## Description

Turns the memory display percent on by default.


## Features

May help people understand better.

## Issues

Hasn't been tested yet.

## TODO

(MAYBE) Better support for percent?