### PR TITLE
Improve glxinfo call, OpenBSD sensors fix

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2168,8 +2168,7 @@ get_cpu() {
                 ;;
                 "OpenBSD"* | "Bitrig"*)
                     deg="$(sysctl hw.sensors | \
-                           awk -F '=| degC' '/lm0.temp|cpu0.temp/ {print $2; exit}')"
-                    deg="${deg/00/0}"
+                        awk -F'=|degC' '/(ksmn|adt|lm|cpu)0.temp0/ {printf("%2.1f", $2); exit}')"
                 ;;
             esac
         ;;

--- a/neofetch
+++ b/neofetch
@@ -2492,7 +2492,7 @@ get_gpu() {
                 ;;
 
                 *)
-                    gpu="$(glxinfo | grep -F 'OpenGL renderer string')"
+                    gpu="$(glxinfo -B | grep -F 'OpenGL renderer string')"
                     gpu="${gpu/OpenGL renderer string: }"
                 ;;
             esac


### PR DESCRIPTION
Hi,

Here are small fixes: 

### Improve `glxinfo` call

`glxinfo` is taking a major part of the global neofetch' run time here, using the `-B` flag is enough to get the GPU. On 100 iterations, it's 2 times faster!

### OpenBSD: fix sensors output

Looks like other OSes use "%2.1f",  but OpenBSD uses "%2.2f". I had the cpu at 3725°C instead of 37.25°C.

While here, i've added [adt(4)](https://man.openbsd.org/amd64/adt.4) and the more recent [ksmn(4)](https://man.openbsd.org/amd64/ksmn.4).