### PR TITLE
network speed support for linux

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2659,6 +2659,8 @@ get_network() {
                         networks+="$(cat "$i/speed")"
                     else
                         networks+="Wifi"
+                        phy="$(cat "$i/phy80211/name")"
+                        (iw "$phy" info | grep -qF 'VHT Capabilities') && networks+='6'
                     fi
                     networks+=$'\n'
                 fi
@@ -2670,6 +2672,8 @@ get_network() {
             [ "$n" -gt 1 ] && network+="${n}x "
             if [ "$i" = "Wifi" ]; then
                 network+="Wifi; "
+            elif [ "$i" = "Wifi6" ]; then
+                network+="Wifi6; "
             elif [ "$i" = "-1" ]; then
                 network+="Unknown; "
             elif [ "${i%000}" = "$i" ]; then

--- a/neofetch
+++ b/neofetch
@@ -73,6 +73,7 @@ print_info() {
     info "CPU" cpu
     info "GPU" gpu
     info "Memory" memory
+    info "Network" network
 
     # info "GPU Driver" gpu_driver  # Linux/macOS only
     # info "CPU Usage" cpu_usage
@@ -2648,6 +2649,45 @@ get_memory() {
     esac
 }
 
+get_network() {
+    case $os in
+        "Linux")
+            while IFS= read -r i; do
+                # List all operational, physical devices
+                if [ "$(cat "$i/operstate")" = "up" ] && [ -e "$i/device" ]; then
+                    if [ ! -e "$i/phy80211" ]; then
+                        networks+="$(cat "$i/speed")"
+                    else
+                        networks+="Wifi"
+                    fi
+                    networks+=$'\n'
+                fi
+            done < <(find /sys/class/net/ -type l)
+        ;;
+    esac
+    while IFS=' ' read -r n i; do
+        if [ -n "$i" ]; then
+            [ "$n" -gt 1 ] && network+="${n}x "
+            if [ "$i" = "Wifi" ]; then
+                network+="Wifi; "
+            elif [ "$i" = "-1" ]; then
+                network+="Unknown; "
+            elif [ "${i%000}" = "$i" ]; then
+                network+="$i Mbps; "
+            elif [ "$i" = "2500" ]; then
+                network+="2.5 Gbps; "
+            else
+                network+="${i%000} Gbps; "
+            fi
+        fi
+    done < <(sort -rn <<<"$networks" | uniq -c)
+    if [ -z "$network" ]; then
+        network="None"
+    else
+        network="${network%; }"
+    fi
+}
+
 get_song() {
     players=(
         "amarok"
@@ -5192,6 +5232,7 @@ get_args() {
                     info "GPU" gpu
                     info "GPU Driver" gpu_driver
                     info "Memory" memory
+                    info "Network" network
 
                     info "CPU Usage" cpu_usage
                     info "Disk" disk


### PR DESCRIPTION
## Description

Add the `Network` part to neofetch.

![shot-2020-07-23_23-09-31](https://user-images.githubusercontent.com/9152961/88357556-b31be080-cd39-11ea-8d94-56c290534507.png)

## Features

It lists all your operational physical network devices' speeds.

## TODO

Currently there's only Linux supported. Support for any other operating systems are TODOs.
