### PR TITLE
ascii: revert colors

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -7745,7 +7745,7 @@ EOF
         ;;
 
         "Lubuntu"*)
-            set_colors 27 7 1
+            set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
 ${c1}           `.:/ossyyyysso/:.
         `.:yyyyyyyyyyyyyyyyyy:.`
@@ -10281,7 +10281,7 @@ EOF
         ;;
 
         "Xubuntu"*)
-            set_colors 20 7 1
+            set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
 ${c1}           `.:/ossyyyysso/:.
         `.yyyyyyyyyyyyyyyyyyyy.`


### PR DESCRIPTION
## Description

Didn't know that it's a requirement that we use only colors 0-16.
This reverts the colors for Xubuntu and Lubuntu back to 4.


