### PR TITLE
song: Switch Quodlibet to get_song_dbus

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2768,6 +2768,7 @@ get_song() {
         "tauonmb"*)       get_song_dbus "tauon" ;;
         "olivia"*)        get_song_dbus "olivia" ;;
         "exaile"*)        get_song_dbus "exaile" ;;
+        "quodlibet"*)     get_song_dbus "quodlibet" ;;
         "netease-cloud-music"*)        get_song_dbus "netease-cloud-music" ;;
         "plasma-browser-integration"*) get_song_dbus "plasma-browser-integration" ;;
         "io.elementary.music"*)        get_song_dbus "Music" ;;
@@ -2817,13 +2818,6 @@ get_song() {
                     org.gnome.Muine.Player.GetCurrentSong |
                     awk -F':' '/^artist/ {a=$2} /^album/ {b=$2} /^title/ {t=$2}
                                END {print a " \n" b " \n" t}')"
-        ;;
-
-        "quodlibet"*)
-            song="$(dbus-send --print-reply --dest=net.sacredchao.QuodLibet \
-                    /net/sacredchao/QuodLibet net.sacredchao.QuodLibet.CurrentSong |\
-                    awk -F'"' 'BEGIN {RS=" entry"}; /"artist"/ {a=$4} /"album"/ {b=$4}
-                    /"title"/ {t=$4} END {print a " \n" b " \n" t}')"
         ;;
 
         "pogo"*)


### PR DESCRIPTION
## Description
Quodlibet comes with mpris2 support, so we could use get_song_dbus.

## Issues
The only drawback I see is that the mpris plugin is disabled by default (at least on Ubuntu 20.04).

If you think it's not a good idea to make the switch just close this. :)

