### PR TITLE
Add support for globally installed npm packages

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1565,6 +1565,10 @@ get_packages() {
             # This is the only standard location for appimages.
             # See: https://github.com/AppImage/AppImageKit/wiki
             manager=appimage && has appimaged && dir ~/.local/bin/*.appimage
+
+			# npm can be used to install JavaScript CLI tools like tsc and webpack-cli.
+			# -1 packages because npm itself is a package.
+			has npm && tot ls $(npm root -g) --color=none && ((packages-=1))
         ;;
 
         "Mac OS X"|"macOS"|MINIX)


### PR DESCRIPTION
## Description

I often use npm to install cli tools, such as `tsc`, `sass`, `yo` and others. I thought some people might find it useful to display the number of globally installed npm packages, so I made this PR. (This is only my second PR on GitHub, so if I'm missing something, let me know!)

## Features

- Displays the number of globally installed npm packages alongside other package managers.
