### PR TITLE
Better handling of Wayland compositors

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1788,40 +1788,41 @@ get_wm() {
     # If function was run, stop here.
     ((wm_run == 1)) && return
 
-    case $kernel_name in
-        *OpenBSD*) ps_flags=(x -c) ;;
-        *)         ps_flags=(-e) ;;
-    esac
-
-    if [[ $WAYLAND_DISPLAY ]]; then
-        wm=$(ps "${ps_flags[@]}" | grep -m 1 -o -F \
-                           -e arcan \
-                           -e asc \
-                           -e clayland \
-                           -e dwc \
-                           -e fireplace \
-                           -e gnome-shell \
-                           -e greenfield \
-                           -e grefsen \
-                           -e kwin \
-                           -e lipstick \
-                           -e maynard \
-                           -e mazecompositor \
-                           -e motorcar \
-                           -e orbital \
-                           -e orbment \
-                           -e perceptia \
-                           -e rustland \
-                           -e sway \
-                           -e ulubis \
-                           -e velox \
-                           -e wavy \
-                           -e way-cooler \
-                           -e wayfire \
-                           -e wayhouse \
-                           -e westeros \
-                           -e westford \
-                           -e weston)
+    if [[ -O "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}" ]]; then
+        case $kernel_name in
+            *OpenBSD*)
+                ps_flags=(x -c)
+                wm=$(ps "${ps_flags[@]}" | grep -m 1 -o -F \
+                                   -e arcan \
+                                   -e asc \
+                                   -e clayland \
+                                   -e dwc \
+                                   -e fireplace \
+                                   -e gnome-shell \
+                                   -e greenfield \
+                                   -e grefsen \
+                                   -e kwin \
+                                   -e lipstick \
+                                   -e maynard \
+                                   -e mazecompositor \
+                                   -e motorcar \
+                                   -e orbital \
+                                   -e orbment \
+                                   -e perceptia \
+                                   -e rustland \
+                                   -e sway \
+                                   -e ulubis \
+                                   -e velox \
+                                   -e wavy \
+                                   -e way-cooler \
+                                   -e wayfire \
+                                   -e wayhouse \
+                                   -e westeros \
+                                   -e westford \
+                                   -e weston)
+            ;;
+            *)  wm=$(fuser -v "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}" 2>&1 | sed -rne "s/^\s+$USER.* ([^ ]*$)/\1/p") ;;
+        esac
 
     elif [[ $DISPLAY && $os != "Mac OS X" && $os != "macOS" && $os != FreeMiNT ]]; then
         type -p xprop &>/dev/null && {

--- a/neofetch
+++ b/neofetch
@@ -1825,7 +1825,7 @@ get_wm() {
                                    -e westford \
                                    -e weston)
             ;;
-            *)  wm=$(ps -p $(lsof -t $XDG_RUNTIME_DIR/${WAYLAND_DISPLAY:-wayland-0}) --no-headers --format comm) ;;
+            *)  wm=$(ps -p $(lsof -t "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}") --no-headers --format comm) ;;
         esac
 
     elif [[ $DISPLAY && $os != "Mac OS X" && $os != "macOS" && $os != FreeMiNT ]]; then

--- a/neofetch
+++ b/neofetch
@@ -1794,40 +1794,42 @@ get_wm() {
     esac
 
     if [[ -O "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}" ]]; then
-        case $kernel_name in
-            *OpenBSD*)
-                wm=$(ps "${ps_flags[@]}" | grep -m 1 -o -F \
-                                   -e arcan \
-                                   -e asc \
-                                   -e clayland \
-                                   -e dwc \
-                                   -e fireplace \
-                                   -e gnome-shell \
-                                   -e greenfield \
-                                   -e grefsen \
-                                   -e kwin \
-                                   -e lipstick \
-                                   -e maynard \
-                                   -e mazecompositor \
-                                   -e motorcar \
-                                   -e orbital \
-                                   -e orbment \
-                                   -e perceptia \
-                                   -e rustland \
-                                   -e sway \
-                                   -e ulubis \
-                                   -e velox \
-                                   -e wavy \
-                                   -e way-cooler \
-                                   -e wayfire \
-                                   -e wayhouse \
-                                   -e westeros \
-                                   -e westford \
-                                   -e weston)
-            ;;
-            *)  wm=$(ps -p "$(lsof -t "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}")" -ho comm)
-            ;;
-        esac
+        if tmp_pid="$(lsof -t "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}" 2>&1)" ||
+           tmp_pid="$(fuser   "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}" 2>&1)"; then
+            wm="$(ps -p "${tmp_pid}" -ho comm=)"
+        else
+            # lsof may not exist, or may need root on some systems. Similarly fuser.
+            # On those systems we search for a list of known window managers, this can mistakenly
+            # match processes for another user or session and will miss unlisted window managers.
+            wm=$(ps "${ps_flags[@]}" | grep -m 1 -o -F \
+                               -e arcan \
+                               -e asc \
+                               -e clayland \
+                               -e dwc \
+                               -e fireplace \
+                               -e gnome-shell \
+                               -e greenfield \
+                               -e grefsen \
+                               -e kwin \
+                               -e lipstick \
+                               -e maynard \
+                               -e mazecompositor \
+                               -e motorcar \
+                               -e orbital \
+                               -e orbment \
+                               -e perceptia \
+                               -e rustland \
+                               -e sway \
+                               -e ulubis \
+                               -e velox \
+                               -e wavy \
+                               -e way-cooler \
+                               -e wayfire \
+                               -e wayhouse \
+                               -e westeros \
+                               -e westford \
+                               -e weston)
+        fi
 
     elif [[ $DISPLAY && $os != "Mac OS X" && $os != "macOS" && $os != FreeMiNT ]]; then
         type -p xprop &>/dev/null && {

--- a/neofetch
+++ b/neofetch
@@ -1825,7 +1825,7 @@ get_wm() {
                                    -e westford \
                                    -e weston)
             ;;
-            *)  wm=$(ps -p $(lsof -t "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}") --no-headers --format comm) ;;
+            *)  wm=$(ps -p "$(lsof -t "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}")" --no-headers --format comm) ;;
         esac
 
     elif [[ $DISPLAY && $os != "Mac OS X" && $os != "macOS" && $os != FreeMiNT ]]; then

--- a/neofetch
+++ b/neofetch
@@ -1788,10 +1788,14 @@ get_wm() {
     # If function was run, stop here.
     ((wm_run == 1)) && return
 
+    case $kernel_name in
+        *OpenBSD*) ps_flags=(x -c) ;;
+        *)         ps_flags=(-e) ;;
+    esac
+
     if [[ -O "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}" ]]; then
         case $kernel_name in
             *OpenBSD*)
-                ps_flags=(x -c)
                 wm=$(ps "${ps_flags[@]}" | grep -m 1 -o -F \
                                    -e arcan \
                                    -e asc \

--- a/neofetch
+++ b/neofetch
@@ -1825,7 +1825,8 @@ get_wm() {
                                    -e westford \
                                    -e weston)
             ;;
-            *)  wm=$(ps -p "$(lsof -t "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}")" --no-headers --format comm) ;;
+            *)  wm=$(ps -p "$(lsof -t "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}")" -ho comm)
+            ;;
         esac
 
     elif [[ $DISPLAY && $os != "Mac OS X" && $os != "macOS" && $os != FreeMiNT ]]; then

--- a/neofetch
+++ b/neofetch
@@ -1825,7 +1825,7 @@ get_wm() {
                                    -e westford \
                                    -e weston)
             ;;
-            *)  wm=$(fuser -v "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}" 2>&1 | sed -rne "s/^\s+$USER.* ([^ ]*$)/\1/p") ;;
+            *)  wm=$(ps -p $(lsof -t $XDG_RUNTIME_DIR/${WAYLAND_DISPLAY:-wayland-0}) --no-headers --format comm) ;;
         esac
 
     elif [[ $DISPLAY && $os != "Mac OS X" && $os != "macOS" && $os != FreeMiNT ]]; then


### PR DESCRIPTION
## Description

Better handling of Wayland desktops

## Features

Corrects detection of Wayland compositors when `WAYLAND_DISPLAY` is unset
Doesn't identify window managers belonging to other user session

## Issues

The logic for BSD is unchanged (I'm too lazy to set up a test system)

Fixes: #1500
