### PR TITLE
Fix GPU listing for Windows

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2501,7 +2501,7 @@ get_gpu() {
         "Windows")
             while mapfile line; do
                 prin "${subtitle:+${subtitle}${gpu_name}}" "$(trim "{$line[@]}")"
-            done <<<" $(wmic PATH Win32_videocontroller GET description | awk 'NF' | tail +2)"
+            done <<< "$(wmic PATH Win32_videocontroller GET description | awk 'NF' | tail +2)"
 
             gpu=${gpu//Caption}
         ;;

--- a/neofetch
+++ b/neofetch
@@ -2500,7 +2500,7 @@ get_gpu() {
 
         "Windows")
             while mapfile line; do
-                prin "${subtitle:+${subtitle}${gpu_name}}" "$(trim "$line")"
+                prin "${subtitle:+${subtitle}${gpu_name}}" "$(trim "{$line[@]}")"
             done <<<" $(wmic PATH Win32_videocontroller GET description | awk 'NF' | tail +2)"
 
             gpu=${gpu//Caption}

--- a/neofetch
+++ b/neofetch
@@ -2499,7 +2499,7 @@ get_gpu() {
         ;;
 
         "Windows")
-            while mapfile line; do
+            while read -r line; do
                 prin "${subtitle:+${subtitle}${gpu_name}}" "$(trim "${line[@]}")"
             done <<< "$(wmic PATH Win32_videocontroller GET description | awk 'NF' | tail +2)"
 

--- a/neofetch
+++ b/neofetch
@@ -2499,9 +2499,9 @@ get_gpu() {
         ;;
 
         "Windows")
-            while read -r line; do
+            while mapfile line; do
                 prin "${subtitle:+${subtitle}${gpu_name}}" "$(trim "$line")"
-            done <<< $(wmic PATH Win32_videocontroller GET description | awk 'NF' | tail +2)
+            done <<<" $(wmic PATH Win32_videocontroller GET description | awk 'NF' | tail +2)"
 
             gpu=${gpu//Caption}
         ;;

--- a/neofetch
+++ b/neofetch
@@ -2501,7 +2501,7 @@ get_gpu() {
         "Windows")
             while read -r line; do
                 prin "${subtitle:+${subtitle}${gpu_name}}" "$(trim "$line")"
-            done <<< $(wmic PATH Win32_videocontroller GET description | awk 'NF' | sed '2,$ !d')
+            done <<< $(wmic PATH Win32_videocontroller GET description | awk 'NF' | tail +2)
 
             gpu=${gpu//Caption}
         ;;

--- a/neofetch
+++ b/neofetch
@@ -2500,7 +2500,7 @@ get_gpu() {
 
         "Windows")
             while mapfile line; do
-                prin "${subtitle:+${subtitle}${gpu_name}}" "$(trim "{$line[@]}")"
+                prin "${subtitle:+${subtitle}${gpu_name}}" "$(trim "${line[@]}")"
             done <<< "$(wmic PATH Win32_videocontroller GET description | awk 'NF' | tail +2)"
 
             gpu=${gpu//Caption}

--- a/neofetch
+++ b/neofetch
@@ -2501,7 +2501,7 @@ get_gpu() {
         "Windows")
             while read -r line; do
                 prin "${subtitle:+${subtitle}${gpu_name}}" "$(trim "$line")"
-            done < <(wmic path Win32_VideoController get caption)
+            done <<< $(wmic PATH Win32_videocontroller GET description | awk 'NF' | sed '2,$ !d')
 
             gpu=${gpu//Caption}
         ;;


### PR DESCRIPTION
## Description

Fix for GPU listing on Windows having extraneous values like blank lines or "Description" from Win32_videocontroller.

