### PR TITLE
Fix CPU Temp. not showing up on Raspberry Pi

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2103,7 +2103,7 @@ get_cpu() {
 
             # Select the right temperature file.
             for temp_dir in /sys/class/hwmon/*; do
-                [[ "$(< "${temp_dir}/name")" =~ (coretemp|fam15h_power|k10temp) ]] && {
+                [[ "$(< "${temp_dir}/name")" =~ (cpu_thermal|coretemp|fam15h_power|k10temp) ]] && {
                     temp_dirs=("$temp_dir"/temp*_input)
                     temp_dir=${temp_dirs[0]}
                     break


### PR DESCRIPTION
## Description
Added another possible name to the regex for finding cpu temperature.

This was tested on a Raspberry Pi 4 running Arch Linux ARM.

## Features

## Issues
Should fix #1463 

## TODO
