### PR TITLE
feat(backend): add viu image backend

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -749,7 +749,8 @@ disk_display="off"
 #
 # Default:  'ascii'
 # Values:   'ascii', 'caca', 'catimg', 'chafa', 'jp2a', 'iterm2', 'off',
-#           'pot', 'termpix', 'pixterm', 'tycat', 'w3m', 'kitty', 'ueberzug'
+#           'pot', 'termpix', 'pixterm', 'tycat', 'w3m', 'kitty', 'ueberzug',
+#           'viu'
 
 # Flag:     --backend
 image_backend="ascii"
@@ -3892,7 +3893,8 @@ image_backend() {
         "off") image_backend="off" ;;
 
         "caca" | "catimg" | "chafa" | "jp2a" | "iterm2" | "termpix" |\
-        "tycat" | "w3m" | "sixel" | "pixterm" | "kitty" | "pot", | "ueberzug")
+        "tycat" | "w3m" | "sixel" | "pixterm" | "kitty" | "pot", | "ueberzug" |\
+         "viu")
             get_image_source
 
             [[ ! -f "$image" ]] && {
@@ -3919,7 +3921,7 @@ image_backend() {
             err "Image: Unknown image backend specified '$image_backend'."
             err "Image: Valid backends are: 'ascii', 'caca', 'catimg', 'chafa', 'jp2a', 'iterm2',
                                             'kitty', 'off', 'sixel', 'pot', 'pixterm', 'termpix',
-                                            'tycat', 'w3m')"
+                                            'tycat', 'w3m', 'viu')"
             err "Image: Falling back to ascii mode."
             print_ascii
         ;;
@@ -4395,6 +4397,12 @@ display_image() {
         "tycat")
             tycat \
                 -g "${width}x${height}" \
+            "$image"
+        ;;
+
+        "viu")
+            viu \
+                -t -w ""$((width / font_width))"" -h "$((height / font_height))" \
             "$image"
         ;;
 
@@ -4973,7 +4981,7 @@ BARS:
 IMAGE BACKEND:
     --backend backend           Which image backend to use.
                                 Possible values: 'ascii', 'caca', 'catimg', 'chafa', 'jp2a',
-                                'iterm2', 'off', 'sixel', 'tycat', 'w3m', 'kitty'
+                                'iterm2', 'off', 'sixel', 'tycat', 'w3m', 'kitty', 'viu'
     --source source             Which image or ascii file to use.
                                 Possible values: 'auto', 'ascii', 'wallpaper', '/path/to/img',
                                 '/path/to/ascii', '/path/to/dir/', 'command output' [ascii]
@@ -4995,6 +5003,7 @@ IMAGE BACKEND:
     --tycat source              Shortcut to use 'tycat' backend.
     --w3m source                Shortcut to use 'w3m' backend.
     --ueberzug source           Shortcut to use 'ueberzug' backend
+    --viu source                Shortcut to use 'viu' backend
     --off                       Shortcut to use 'off' backend (Disable ascii art).
 
     NOTE: 'source; can be any of the following: 'auto', 'ascii', 'wallpaper', '/path/to/img',
@@ -5224,7 +5233,7 @@ get_args() {
             "--source") image_source="$2" ;;
             "--ascii" | "--caca" | "--catimg" | "--chafa" | "--jp2a" | "--iterm2" | "--off" |\
             "--pot" | "--pixterm" | "--sixel" | "--termpix" | "--tycat" | "--w3m" | "--kitty" |\
-            "--ueberzug")
+            "--ueberzug" | "--viu")
                 image_backend="${1/--}"
                 case $2 in
                     "-"* | "") ;;

--- a/neofetch
+++ b/neofetch
@@ -4402,7 +4402,7 @@ display_image() {
 
         "viu")
             viu \
-                -t -w ""$((width / font_width))"" -h "$((height / font_height))" \
+                -t -w "$((width / font_width))" -h "$((height / font_height))" \
             "$image"
         ;;
 


### PR DESCRIPTION
## Description

This add [viu](https://github.com/atanunq/viu) image backend. 
I added this because Überzug was not working for me (alacritty + sway/wayland). 

## Feature 

Image can now be rendered under wayland (low definition but still). 

## TODO

Still need to document this in the wiki (how to I do it ?) 
