### PR TITLE
Support multiple displays under wayland

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2991,9 +2991,9 @@ get_resolution() {
 
             elif [[ -d /sys/class/drm ]]; then
                 for dev in /sys/class/drm/*/modes; do
-                    read -r resolution _ < "$dev"
+                    read -r single_resolution _ < "$dev"
 
-                    [[ $resolution ]] && break
+                    [[ $single_resolution ]] && resolution="${single_resolution}, ${resolution}"
                 done
             fi
         ;;


### PR DESCRIPTION
## Description
Instead of breaking after the first-found non-empty `/sys/class/drm/*/modes` file, process all of them by pre-pending values to the `resolution` string. This is able to correctly show the four attached displays on my workstation running Sway, rather than only the display on the first DisplayPort output. I've also tested this on a laptop with only the built-in display, running Sway.