### PR TITLE
Add support for `swupd` package manager

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1535,6 +1535,7 @@ get_packages() {
             has alps       && tot alps showinstalled
             has butch      && tot butch list
             has mine       && tot mine -q
+            has swupd      && tot swupd bundle-list --quiet
 
             # Counting files/dirs.
             # Variables need to be unquoted here. Only Bedrock Linux is affected.


### PR DESCRIPTION
## Description

`swupd` is the default package manager of Clear Linux OS (they actually call their packages bundles). This patch adds support for swupd.


## Features

## Issues

## TODO
