### PR TITLE
Fix font support for yakuake

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3335,7 +3335,7 @@ END
             QT_BINDIR="$(qtpaths --binaries-dir)" && PATH+=":$QT_BINDIR"
 
             IFS=$'\n' read -d "" -ra konsole_instances \
-                <<< "$(qdbus | awk '/org.kde.konsole/ {print $1}')"
+                <<< "$(qdbus | awk '/org.kde.'"$term"'/ {print $1}')"
 
             for i in "${konsole_instances[@]}"; do
                 IFS=$'\n' read -d "" -ra konsole_sessions <<< "$(qdbus "$i" | grep -F '/Sessions/')"


### PR DESCRIPTION
Originally added in #1063, but did not actually work because it only
looked for konsole processes (rather than yakuake's) when querying its
session profile.
