### PR TITLE
count dpkgs with grep

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1516,13 +1516,19 @@ get_packages() {
         br_prefix="/bedrock/strata/*"
     }
 
+    dpkgs() {
+        for file in /var/lib/dpkg/status /data/data/com.termux/files/usr/var/lib/dpkg/status ; do
+            [[ -f "$file" ]] && grep -c "^Status:.*installed" "$file" && return
+        done
+    }
+
     case $os in
         Linux|BSD|"iPhone OS"|Solaris)
             # Package Manager Programs.
             has kiss       && tot kiss l
             has cpt-list   && tot cpt-list
             has pacman-key && tot pacman -Qq --color never
-            has apt        && tot apt list
+            has apt        && pac "$(dpkgs)"
             has rpm        && tot rpm -qa
             has xbps-query && tot xbps-query -l
             has apk        && tot apk info


### PR DESCRIPTION
## Description

Using `dpkg --list` with `grep -c` significantly reduces runtime of the get_packages function.

With only the packages output configured on my system, this seems to run over five times faster than #1620 (4ce30b59) when counting approximately 5500 apt packages.

Measured with https://github.com/sharkdp/hyperfine/commit/907d38aa18e773a0bd64c02643658b98f18ff74b
```bash
# pr/1620 (4ce30b59)
  Time (mean ± σ):      1.161 s ±  0.046 s    [User: 480.1 ms, System: 680.1 ms]

# HEAD (0854f61a)
  Time (mean ± σ):     222.6 ms ±   2.2 ms    [User: 142.9 ms, System: 76.7 ms]
```

## Issues

fixes #1619
