### PR TITLE
neofetch: Fix Terminal Font for mintty

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3423,7 +3423,7 @@ END
         ;;
 
         "mintty")
-            term_font="$(awk -F '=' '!/^($|#)/ && /^\s*Font\s*=/ {printf $2; exit}' "${HOME}/.minttyrc")"
+            term_font="$(awk -F '=' '!/^($|#)/ && /^\\s*Font\\s*=/ {printf $2; exit}' "${HOME}/.minttyrc")"
         ;;
 
         "pantheon"*)

--- a/neofetch
+++ b/neofetch
@@ -3423,7 +3423,7 @@ END
         ;;
 
         "mintty")
-            term_font="$(awk -F '=' '!/^($|#)/ && /Font/ {printf $2; exit}' "${HOME}/.minttyrc")"
+            term_font="$(awk -F '=' '!/^($|#)/ && /^\s*Font\s*=/ {printf $2; exit}' "${HOME}/.minttyrc")"
         ;;
 
         "pantheon"*)


### PR DESCRIPTION
## Description

My ~/.minttyrc has:
```
BoldAsFont=-1
Font=Lucida Console
FontHeight=10
```
so neofetch reported:
```
  Terminal Font: -1
```
This patch fixes it:
```
  Terminal Font: Lucida Console
```
This patch does not address that ~/.minttyrc can be moved to ~/.config/mintty/config per https://mintty.github.io/mintty.1.html#CONFIGURATION, or default to the Font specified in /etc/minttyrc, if it exists.