### PR TITLE
Show GPU subsystem name if possible

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2412,9 +2412,17 @@ get_gpu() {
     case $os in
         "Linux")
             # Read GPUs into array.
-            gpu_cmd="$(lspci -mm | awk -F '\"|\" \"|\\(' \
-                                          '/"Display|"3D|"VGA/ {a[$0] = $1 " " $3 " " $4}
-                                           END {for(i in a) {if(!seen[a[i]]++) print a[i]}}')"
+            gpu_cmd="$(lspci -mm |
+                       awk -F '\"|\" \"|\\(' \
+                              '/"Display|"3D|"VGA/ {
+                                  a[$0] = $1 " " $3 " " ($7 ~ /^$|^Device [[:xdigit:]]+$/ ? $4 : $7)
+                              }
+                              END { for (i in a) {
+                                  if (!seen[a[i]]++) {
+                                      sub("^[^ ]+ ", "", a[i]);
+                                      print a[i]
+                                  }
+                              }}')"
             IFS=$'\n' read -d "" -ra gpus <<< "$gpu_cmd"
 
             # Remove duplicate Intel Graphics outputs.


### PR DESCRIPTION
## Description

After this change, if a subsystem name exists for a GPU, display that name instead of the device name. This should fix the issue mentioned in #1490. For example, a card that would be shown as `GPU: AMD ATI Radeon RX 470/480/570/570X/580/580X/590` before will now be shown as `GPU: AMD ATI Radeon RX 480 4GB`. This fallback logic is implemented in the `awk` command.

Additionally, the PCI address is now stripped from the awk output because it never is desirable to print it. It is, however, still kept internally in `awk` to distinguish multiple cards of the same model.

## Features

Implements #1490.