### PR TITLE
OpenBSD: change cpu count (#1574)

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2245,7 +2245,17 @@ get_cpu() {
             [[ -z "$speed" ]] && speed="$(sysctl -n  hw.clockrate)"
 
             # Get CPU cores.
-            cores="$(sysctl -n hw.ncpu)"
+            case $kernel_name in
+                "OpenBSD"*)
+                    [[ "$(sysctl -n hw.smt)" == "1" ]] && smt="on" || smt="off"
+                    ncpufound="$(sysctl -n hw.ncpufound)"
+                    ncpuonline="$(sysctl -n hw.ncpuonline)"
+                    cores="${ncpuonline}/${ncpufound},\\xc2\\xa0SMT\\xc2\\xa0${smt}"
+                ;;
+                *)
+                    cores="$(sysctl -n hw.ncpu)"
+                ;;
+            esac
 
             # Get CPU temp.
             case $kernel_name in


### PR DESCRIPTION
## Description

This change is limited to OpenBSD only, and related to cpu reporting improvements as seen in https://github.com/dylanaraps/neofetch/issues/1574

Instead of using [hw.ncpu](https://man.openbsd.org/sysctl.2#HW_NCPU~2), use [hw.ncpuonline](https://man.openbsd.org/sysctl.2#HW_NCPUONLINE~2) and [hw.ncpufound](https://man.openbsd.org/sysctl.2#HW_NCPUFOUND~2), and check [SMT](https://man.openbsd.org/sysctl.2#HW_SMT~2) status.

I confirm that "physical" is not available on OpenBSD.

## Features

```bash
$ sysctl hw.smt
1
$ neofetch
[...]
CPU: AMD Ryzen 5 2600 (12/12, SMT on) @ 3.400GHz
[...]

$ doas sysctl hw.smt=0
$ neofetch
[...]
CPU: AMD Ryzen 5 2600 (6/12, SMT off) @ 3.400GHz
[...]
```

## Issues

There is not enough context ootb in the GH diff view, i had to inject non breaking spaces because regular spaces are filtered below.

By the way, shellcheck reported no issue related to that change.


