### PR TITLE
Fix Homebrew's Cellar path for brew package counts

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1610,7 +1610,7 @@ get_packages() {
 
         "Mac OS X"|"macOS"|MINIX)
             has port  && pkgs_h=1 tot port installed && ((packages-=1))
-            has brew  && dir /usr/local/Cellar/*
+            has brew  && dir "$(brew --cellar)"/*
             has pkgin && tot pkgin list
 
             has nix-store && {


### PR DESCRIPTION
## Description

Since [Homebrew 2.6.0](https://brew.sh/2020/12/01/homebrew-2.6.0/), Homebrew supports Apple Silicon. Now Homebrew installs on different locations depending on CPU architecture.

From brew man page [--cellar](https://github.com/Homebrew/brew/blob/master/docs/Manpage.md#--cellar-formula) and [--prefix](https://github.com/Homebrew/brew/blob/master/docs/Manpage.md#--prefix-formula):

> ### `--cellar` [*`formula`*]
> 
> Display Homebrew's Cellar path. *Default:* `$(brew --prefix)/Cellar`, or if that directory doesn't exist, `$(brew --repository)/Cellar`.

> ### `--prefix` [*`formula`*]
> 
> Display Homebrew's install path. *Default:*
>
>  - macOS Intel: `/usr/local`
>  - macOS ARM: `/opt/homebrew`
>  - Linux: `/home/linuxbrew/.linuxbrew`

The current code doesn't count brew packages on ARM Mac, since it assumes Homebrew is always installed on `/usr/local`, which only works for **macOS Intel** only.

This fix correctly counts package numbers for Homebrew installed on ARM Mac (built for myself and tested).

### Screenshot (Neofetch 7.1.0 vs PR)

![Screen Shot 2021-01-16 at 2 43 37 AM](https://user-images.githubusercontent.com/31951923/104760390-a3d79600-57a4-11eb-9236-a8b9fe820c7d.png)
