### PR TITLE
Add (rudimentary) Synology DSM support

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1080,6 +1080,11 @@ get_distro() {
                 read -ra kernel_info <<< "$(sysctl -n kern.version)"
                 distro=${kernel_info[*]:0:2}
 
+            elif [[ -f /etc/VERSION ]]; then
+                # Source the DSM VERSION file
+                source /etc/VERSION
+                distro="Synology DSM ${productversion}-${buildnumber} Update ${smallfixnumber}"
+
             else
                 for release_file in /etc/*-release; do
                     distro+=$(< "$release_file")
@@ -1536,6 +1541,7 @@ get_packages() {
             has alps       && tot alps showinstalled
             has butch      && tot butch list
             has swupd      && tot swupd bundle-list --quiet
+            has dpkg       && pkgs_h=5 tot dpkg --list
 
             # 'mine' conflicts with minesweeper games.
             [[ -f /etc/SDE-VERSION ]] &&


### PR DESCRIPTION
## Description

Added rudimentary Synology DSM support (see also #1275), via the DSM specific release metadata in `/etc/VERSION` as well as detecting packages via `dpkg` in addition to the current `opkg` support (if you're using the shell on a DSM box, you'll probably end up installing packages from Optware or Entware via the _Easy Bootrap Installer_ comunity package. Well at least I did to get `acme.sh` running but that's another story).

## Features

* Detects and reports the major.minor.patch DSM release, plus build number, plus update number
* Detects and reports packages installed via `dpkg`

## Issues

Running `shellcheck` will fail with `SC2154: [productversion|buildnumber|smallfixnumber] is referenced but not assigned` if not run natively on DSM due to a dependency on sourcing the DSM `/etc/VERSION` file.

## TODO

* Try and find a decent ASCII art version of the Synology logo
