### PR TITLE
Added PuffOS successfuly instead of #1659

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -799,7 +799,7 @@ image_source="auto"
 #       openEuler, OpenIndiana, openmamba, OpenMandriva, OpenStage, OpenWrt,
 #       osmc, Oracle, OS Elbrus, PacBSD, Parabola, Pardus, Parrot, Parsix,
 #       TrueOS, PCLinuxOS, Pengwin, Peppermint, popos, Porteus, PostMarketOS,
-#       Proxmox, Puppy, PureOS, Qubes, Quibian, Radix, Raspbian, Reborn_OS,
+#       Proxmox, PuffOS Puppy, PureOS, Qubes, Quibian, Radix, Raspbian, Reborn_OS,
 #       Redstar, Redcore, Redhat, Refracted_Devuan, Regata, Regolith, Rosa,
 #       sabotage, Sabayon, Sailfish, SalentOS, Scientific, Septor,
 #       SereneLinux, SharkLinux, Siduction, Slackware, SliTaz, SmartOS,
@@ -5061,7 +5061,7 @@ ASCII:
                                 openmamba, OpenMandriva, OpenStage, OpenWrt, osmc, Oracle,
                                 OS Elbrus, PacBSD, Parabola, Pardus, Parrot, Parsix, TrueOS,
                                 PCLinuxOS, Pengwin, Peppermint, popos, Porteus, PostMarketOS,
-                                Proxmox, Puppy, PureOS, Qubes, Quibian, Radix, Raspbian, Reborn_OS,
+                                Proxmox, PuffOS, Puppy, PureOS, Qubes, Quibian, Radix, Raspbian, Reborn_OS,
                                 Redstar, Redcore, Redhat, Refracted_Devuan, Regata, Regolith, Rosa,
                                 sabotage, Sabayon, Sailfish, SalentOS, Scientific, Septor,
                                 SereneLinux, SharkLinux, Siduction, Slackware, SliTaz, SmartOS,
@@ -9271,6 +9271,25 @@ ${c1}                 /\\
   /          \\ \\                 \\
  /           / /                  \\
 /___________/ /____________________\\
+EOF
+        ;;
+
+        "PuffOS"*)
+            set_colors 3 
+            read -rd '' ascii_data <<'EOF'
+${c1}
+              _,..._,m,   
+            ,/'      '"";     
+           /             ".
+         ,'mmmMMMMmm.      \  
+       _/-"^^^^^"""%#%mm,   ;  
+ ,m,_,'              "###)  ;,
+(###%                 \#/  ;##mm.
+ ^#/  __        ___    ;  (######)
+  ;  //.\\     //.\\   ;   \####/
+ _; (#\"//     \\"/#)  ;  ,/
+@##\ \##/   =   `"=" ,;mm/
+`\##>.____,...,____,<####@
 EOF
         ;;
 


### PR DESCRIPTION
## Description
This commit provides PuffOS distro into neofetch. Instead of #1659 it is well generated little patch. This patch provided from developers of PuffOS and adds PuffOS logo
https://puffos.github.io
https://puffos.github.io/puffmixsized.png


## Features
Added PuffOS into table

## Issues
No issue seen

## TODO
Not any actual TODO