### PR TITLE
Change Windows' DE name to "Windows Explorer"

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1730,9 +1730,7 @@ get_de() {
     case $os in
         "Mac OS X"|"macOS") de=Aqua ;;
 
-        Windows)
-            de="Windows Explorer"
-        ;;
+        Windows) de="Windows Explorer" ;;
 
         FreeMiNT)
             freemint_wm=(/proc/*)

--- a/neofetch
+++ b/neofetch
@@ -1731,19 +1731,7 @@ get_de() {
         "Mac OS X"|"macOS") de=Aqua ;;
 
         Windows)
-            case $distro in
-                *"Windows 10"*)
-                    de=Fluent
-                ;;
-
-                *"Windows 8"*)
-                    de=Metro
-                ;;
-
-                *)
-                    de=Aero
-                ;;
-            esac
+            de="Windows Explorer"
         ;;
 
         FreeMiNT)


### PR DESCRIPTION
## Description
The Windows Desktop Environment is part of Windows Explorer which would make it the DE on Windows
