### PR TITLE
Edit PCLinuxOS logo for proper alignment.

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -9096,7 +9096,7 @@ EOF
         "PCLinuxOS"*)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
-            ${c1}mhhhyyyyhhhdN
+${c1}            mhhhyyyyhhhdN
         dyssyhhhhhhhhhhhssyhN
      Nysyhhyo/:-.....-/oyhhhssd
    Nsshhy+.              `/shhysm


### PR DESCRIPTION
## Description

Only fill in the fields below if relevant.


## Features
Fix PCLinuxOS logo alignment

## Issues
PCLinuxOS logo was misaligned. (this is on my openSUSE laptop with `--ascii_distro pclinuxos` passed as argument)
![example](https://i.imgur.com/sPWG3SC.png)

So I fixed it
![fixed](https://i.imgur.com/QDfadkl.png)

## TODO
