### PR TITLE
Debian: Update distro colors

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -6754,7 +6754,7 @@ EOF
         ;;
 
         "Debian"*)
-            set_colors 1 7 3
+            set_colors 1 197 3
             read -rd '' ascii_data <<'EOF'
 ${c2}       _,met$$$$$gg.
     ,g$$$$$$$$$$$$$$$P.


### PR DESCRIPTION
Change the c2 color for Debian distro for a 256-base magenta color. This
color for the distro logo resembles the original color of Debian
logotype.