### PR TITLE
Add pkg_info listing for macOS

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1609,9 +1609,10 @@ get_packages() {
         ;;
 
         "Mac OS X"|"macOS"|MINIX)
-            has port  && pkgs_h=1 tot port installed && ((packages-=1))
-            has brew  && dir /usr/local/Cellar/*
-            has pkgin && tot pkgin list
+            has port     && pkgs_h=1 tot port installed && ((packages-=1))
+            has brew     && dir /usr/local/Cellar/*
+            has pkgin    && tot pkgin list
+            has pkg_info && tot pkg_info
 
             has nix-store && {
                 nix-user-pkgs() {


### PR DESCRIPTION
## Add pkg_info listing for MacOS
I have been using pkgsrc and I saw there are no packages printed on mac.
![image](https://user-images.githubusercontent.com/46130107/113018086-733ab200-9180-11eb-8456-cf65e92f02a1.png)
