### PR TITLE
Use DNF package cache if available

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1537,7 +1537,7 @@ get_packages() {
             has swupd      && tot swupd bundle-list --quiet
 
             # Using DNF package cache is much faster than rpm.
-            if has dnf; then
+            if has dnf && type -p sqlite3 >/dev/null && [[ -f /var/cache/dnf/packages.db ]]; then
                 pac "$(sqlite3 /var/cache/dnf/packages.db "SELECT count(pkg) FROM installed")"
             else
                 has rpm && tot rpm -qa

--- a/neofetch
+++ b/neofetch
@@ -1523,7 +1523,6 @@ get_packages() {
             has cpt-list   && tot cpt-list
             has pacman-key && tot pacman -Qq --color never
             has apt        && tot apt list
-            has rpm        && tot rpm -qa
             has xbps-query && tot xbps-query -l
             has apk        && tot apk info
             has opkg       && tot opkg list-installed
@@ -1536,6 +1535,13 @@ get_packages() {
             has alps       && tot alps showinstalled
             has butch      && tot butch list
             has swupd      && tot swupd bundle-list --quiet
+
+            # Using DNF package cache is much faster than rpm.
+            if has dnf; then
+                pac "$(sqlite3 /var/cache/dnf/packages.db "SELECT count(pkg) FROM installed")"
+            else
+                has rpm && tot rpm -qa
+            fi
 
             # 'mine' conflicts with minesweeper games.
             [[ -f /etc/SDE-VERSION ]] &&


### PR DESCRIPTION
## Description

Currently, neofetch counts packages on RPM based systems by running `tot rpm -qa`, which is rather slow on account of how long it takes `rpm -qa` to run.

DNF has an SQLite 3 database at `/var/cache/dnf/packages.db`, which can be queried much faster than running `rpm -qa`.

For a benchmark:

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `rpm -qa` | 543.7 ± 3.1 | 537.2 | 547.6 | 536.56 ± 86.54 |
| `dnf -C list installed` | 755.8 ± 12.7 | 738.9 | 779.4 | 745.80 ± 120.86 |
| `sqlite3 /var/cache/dnf/packages.db "SELECT count(pkg) FROM installed"` | 1.0 ± 0.2 | 0.8 | 2.9 | 1.00 |

## Features

Use DNF package cache in favor of `rpm -qa`

## Issues

#1584

## TODO

Formatting?