### PR TITLE
Only use DNS if public_ip_host option is empty

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3806,12 +3806,12 @@ get_local_ip() {
 }
 
 get_public_ip() {
-    if type -p dig >/dev/null; then
+    if [[ ! -n "$public_ip_host" ]] && type -p dig >/dev/null; then
         public_ip="$(dig +time=1 +tries=1 +short myip.opendns.com @resolver1.opendns.com)"
        [[ "$public_ip" =~ ^\; ]] && unset public_ip
     fi
 
-    if [[ -z "$public_ip" ]] && type -p drill >/dev/null; then
+    if [[ ! -n "$public_ip_host" ]] && [[ -z "$public_ip" ]] && type -p drill >/dev/null; then
         public_ip="$(drill myip.opendns.com @resolver1.opendns.com | \
                      awk '/^myip\./ && $3 == "IN" {print $5}')"
     fi


### PR DESCRIPTION
It seems like there is no option to use a custom address for getting the public IP address if _dig_ or _drill_ is installed.
This request changes this to always use the public_ip_host variable if it's set, and if it's empty then DNS will be used.

## Usage of public_ip_host in config

public_ip_host="" -> uses DNS for getting public IP
public_ip_host="http://example.com/ip" -> uses wget/curl for getting public IP
