### PR TITLE
fix neofetch not recognizing brew package count on M1 macs

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1522,7 +1522,7 @@ get_packages() {
             has kiss       && tot kiss l
             has cpt-list   && tot cpt-list
             has pacman-key && tot pacman -Qq --color never
-            has apt        && tot apt list
+            has apt        && tot apt list --installed && ((packages-=1))
             has rpm        && tot rpm -qa
             has xbps-query && tot xbps-query -l
             has apk        && tot apk info

--- a/neofetch
+++ b/neofetch
@@ -1610,7 +1610,7 @@ get_packages() {
 
         "Mac OS X"|"macOS"|MINIX)
             has port  && pkgs_h=1 tot port installed && ((packages-=1))
-            has brew  && dir /usr/local/Cellar/*
+            has brew  && dir "$(brew --cellar)"/*
             has pkgin && tot pkgin list
 
             has nix-store && {


### PR DESCRIPTION
## Description

changes /usr/local/Cellar to "$(brew --cellar)" as used on line 1550

## Features

## Issues
#1746 
## TODO
~~Someone with a non-M1 mac should verify this has no issues for them~~ (done)