### PR TITLE
Added APT/Debian Packager to package managers for MacOS and combined PR #1702

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1619,6 +1619,7 @@ get_packages() {
             has port  && pkgs_h=1 tot port installed && ((packages-=1))
             has brew  && dir /usr/local/Cellar/*
             has pkgin && tot pkgin list
+	    has dpkg  && tot dpkg-query -f '.\n' -W
 
             has nix-store && {
                 nix-user-pkgs() {

--- a/neofetch
+++ b/neofetch
@@ -1263,11 +1263,11 @@ get_model() {
                 iPad6,1[12]):        "iPad 5" ;;
                 iPad7,[5-6]):        "iPad 6" ;;
                 iPad7,1[12]):        "iPad 7" ;;
-		iPad11,[67]):        "iPad 8" ;;
+		        iPad11,[67]):        "iPad 8" ;;
                 iPad4,[1-3]):        "iPad Air" ;;
                 iPad5,[3-4]):        "iPad Air 2" ;;
                 iPad11,[3-4]):       "iPad Air 3" ;;
-		iPad13,[1-2]):       "iPad Air 4";;
+		        iPad13,[1-2]):       "iPad Air 4";;
                 iPad6,[7-8]):        "iPad Pro (12.9 Inch)" ;;
                 iPad6,[3-4]):        "iPad Pro (9.7 Inch)" ;;
                 iPad7,[1-2]):        "iPad Pro 2 (12.9 Inch)" ;;
@@ -1307,10 +1307,10 @@ get_model() {
                 iPhone12,3):    "iPhone 11 Pro" ;;
                 iPhone12,5):    "iPhone 11 Pro Max" ;;
                 iPhone12,8):    "iPhone SE 2020" ;;
-		iPhone13,1):    "iPhone 12 Mini" ;;
-		iPhone13,2):    "iPhone 12" ;;
-		iPhone13,3):    "iPhone 12 Pro" ;;
-		iPhone13,4):    "iPhone 12 Pro Max" ;;
+		        iPhone13,1):    "iPhone 12 Mini" ;;
+		        iPhone13,2):    "iPhone 12" ;;
+		        iPhone13,3):    "iPhone 12 Pro" ;;
+		        iPhone13,4):    "iPhone 12 Pro Max" ;;
 
                 iPod1,1): "iPod touch" ;;
                 ipod2,1): "iPod touch 2G" ;;
@@ -1318,7 +1318,7 @@ get_model() {
                 ipod4,1): "iPod touch 4G" ;;
                 ipod5,1): "iPod touch 5G" ;;
                 ipod7,1): "iPod touch 6G" ;;
-		iPod9,1): "iPod touch 7G" ;;
+		        iPod9,1): "iPod touch 7G" ;;
             esac
 
             model=$_
@@ -1619,7 +1619,7 @@ get_packages() {
             has port  && pkgs_h=1 tot port installed && ((packages-=1))
             has brew  && dir /usr/local/Cellar/*
             has pkgin && tot pkgin list
-	    has dpkg  && tot dpkg-query -f '.\n' -W
+	        has dpkg  && tot dpkg-query -f '.\n' -W
 
             has nix-store && {
                 nix-user-pkgs() {
@@ -2235,7 +2235,7 @@ get_cpu() {
                 "iPhone10,"[1-6]): "Apple A11 Bionic (6) @ 2.39GHz" ;;
                 "iPhone11,"[2468] | "iPad11,"[1-4] | "iPad11,"[6-7]): "Apple A12 Bionic (6) @ 2.49GHz" ;;
                 "iPhone12,"[1358]): "Apple A13 Bionic (6) @ 2.65GHz" ;;
-		"iPhone13,"[1-4] | "iPad13,"[1-2]): "Apple A14 Bionic (6) @ 3.00Ghz" ;;
+		        "iPhone13,"[1-4] | "iPad13,"[1-2]): "Apple A14 Bionic (6) @ 3.00Ghz" ;;
 
                 "iPod2,1"): "Samsung S5L8720 (1) @ 533MHz" ;;
                 "iPod3,1"): "Samsung S5L8922 (1) @ 600MHz" ;;
@@ -2525,7 +2525,7 @@ get_gpu() {
                 "iPhone10,"[1-6]):                            "Apple Designed GPU (A11)" ;;
                 "iPhone11,"[2468] | "iPad11,"[67]):           "Apple Designed GPU (A12)" ;;
                 "iPhone12,"[1358]):                           "Apple Designed GPU (A13)" ;;
-		"iPhone13,"[1234] | "iPad13,"[12]):           "Apple Designed GPU (A14)" ;;
+		        "iPhone13,"[1234] | "iPad13,"[12]):           "Apple Designed GPU (A14)" ;;
 
                 "iPad3,"[1-3]):     "PowerVR SGX534MP4" ;;
                 "iPad3,"[4-6]):     "PowerVR SGX554MP4" ;;

--- a/neofetch
+++ b/neofetch
@@ -1263,9 +1263,11 @@ get_model() {
                 iPad6,1[12]):        "iPad 5" ;;
                 iPad7,[5-6]):        "iPad 6" ;;
                 iPad7,1[12]):        "iPad 7" ;;
+		iPad11,[67]):        "iPad 8" ;;
                 iPad4,[1-3]):        "iPad Air" ;;
                 iPad5,[3-4]):        "iPad Air 2" ;;
                 iPad11,[3-4]):       "iPad Air 3" ;;
+		iPad13,[1-2]):       "iPad Air 4";;
                 iPad6,[7-8]):        "iPad Pro (12.9 Inch)" ;;
                 iPad6,[3-4]):        "iPad Pro (9.7 Inch)" ;;
                 iPad7,[1-2]):        "iPad Pro 2 (12.9 Inch)" ;;
@@ -1305,6 +1307,10 @@ get_model() {
                 iPhone12,3):    "iPhone 11 Pro" ;;
                 iPhone12,5):    "iPhone 11 Pro Max" ;;
                 iPhone12,8):    "iPhone SE 2020" ;;
+		iPhone13,1):    "iPhone 12 Mini" ;;
+		iPhone13,2):    "iPhone 12" ;;
+		iPhone13,3):    "iPhone 12 Pro" ;;
+		iPhone13,4):    "iPhone 12 Pro Max" ;;
 
                 iPod1,1): "iPod touch" ;;
                 ipod2,1): "iPod touch 2G" ;;
@@ -1312,6 +1318,7 @@ get_model() {
                 ipod4,1): "iPod touch 4G" ;;
                 ipod5,1): "iPod touch 5G" ;;
                 ipod7,1): "iPod touch 6G" ;;
+		iPod9,1): "iPod touch 7G" ;;
             esac
 
             model=$_
@@ -2225,8 +2232,9 @@ get_cpu() {
                     "Apple A10 Fusion (4) @ 2.34GHz"
                 ;;
                 "iPhone10,"[1-6]): "Apple A11 Bionic (6) @ 2.39GHz" ;;
-                "iPhone11,"[2468] | "iPad11,"[1-4]): "Apple A12 Bionic (6) @ 2.49GHz" ;;
+                "iPhone11,"[2468] | "iPad11,"[1-4] | "iPad11,"[6-7]): "Apple A12 Bionic (6) @ 2.49GHz" ;;
                 "iPhone12,"[1358]): "Apple A13 Bionic (6) @ 2.65GHz" ;;
+		"iPhone13,"[1-4] | "iPad13,"[1-2]): "Apple A14 Bionic (6) @ 3.00Ghz" ;;
 
                 "iPod2,1"): "Samsung S5L8720 (1) @ 533MHz" ;;
                 "iPod3,1"): "Samsung S5L8922 (1) @ 600MHz" ;;
@@ -2514,8 +2522,9 @@ get_gpu() {
                 "iPhone8,"[1-4] | "iPad6,1"[12]):             "PowerVR GT7600" ;;
                 "iPhone9,"[1-4] | "iPad7,"[5-6]):             "PowerVR GT7600 Plus" ;;
                 "iPhone10,"[1-6]):                            "Apple Designed GPU (A11)" ;;
-                "iPhone11,"[2468]):                           "Apple Designed GPU (A12)" ;;
+                "iPhone11,"[2468] | "iPad11,"[67]):           "Apple Designed GPU (A12)" ;;
                 "iPhone12,"[1358]):                           "Apple Designed GPU (A13)" ;;
+		"iPhone13,"[1234] | "iPad13,"[12]):           "Apple Designed GPU (A14)" ;;
 
                 "iPad3,"[1-3]):     "PowerVR SGX534MP4" ;;
                 "iPad3,"[4-6]):     "PowerVR SGX554MP4" ;;


### PR DESCRIPTION
## Description

This adds support for APT/dpkg package manager for macOS when being used.

Added support by providing information for new iOS and iPadOS devices. [This was initially apart of PR# 1702](https://github.com/dylanaraps/neofetch/pull/1702)


## Features
This add the number of APT/dpkg packages installed on macOS.

This will allow for Host, CPU, and GPU tags to display correct and accurate information for newer iOS and iPadOS devices. Huge thanks to @NotZoeyDev for providing this information about the new devices.