### PR TITLE
Unbreak the runtime, fix a wrong multiple line spanning

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3307,7 +3307,7 @@ get_term() {
                 term="$(tty)"
             ;;
 
-            "ruby"|"1"|"tmux"*|"systemd"|"sshd"*|"python"*|
+            "ruby"|"1"|"tmux"*|"systemd"|"sshd"*|"python"*|\
             "USER"*"PID"*|"kdeinit"*|"launchd"*|"bwrap")
                 break
             ;;


### PR DESCRIPTION
Hi!

## Description

This bug has been introduced by 370a50c3e36b091dc2dc2f6cd9161477f3638b31

When running neofetch HEAD, i meet this:

```
./neofetch: line 3310: syntax error near unexpected token `newline'
./neofetch: line 3310: `"ruby"|"1"|"tmux"*|"systemd"|"sshd"*|"python"*|'
```

The spanning seems to miss a '\\'

