### PR TITLE
Better kitty terminal font detection

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3428,11 +3428,9 @@ END
         ;;
 
         "kitty"*)
-            kitty_config="$(kitty --debug-config)"
-            [[ "$kitty_config" != *font_family* ]] && return
-
-            term_font="$(awk '/^font_family|^font_size/ {$1="";gsub("^ *","",$0);print $0}' \
-                         <<< "$kitty_config")"
+            term_font="from kitty.cli import *; o = create_default_opts(); \
+                print(f'{o.font_family} {o.font_size}')"
+            term_font="$(kitty +runpy ''"$term_font"'')"
         ;;
 
         "konsole" | "yakuake")

--- a/neofetch
+++ b/neofetch
@@ -3429,7 +3429,7 @@ END
 
         "kitty"*)
             term_font="from kitty.cli import *; o = create_default_opts(); \
-                print(f'{o.font_family} {o.font_size}')"
+                       print(f'{o.font_family} {o.font_size}')"
             term_font="$(kitty +runpy ''"$term_font"'')"
         ;;
 


### PR DESCRIPTION
## Description

The current way of getting kitty's terminal font won't work on v0.21.0 and later due to the removal of `--debug-config`. However, the author provided a more precise way to query the current config. More info can be read at kovidgoyal/kitty#3756.

This change is backwards compatible (and tested) with older versions of kitty.

## Features

## Issues

## TODO
