### PR TITLE
fix macos big sur and monterey not showing codenames

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1150,8 +1150,8 @@ get_distro() {
                 10.14*) codename="macOS Mojave" ;;
                 10.15*) codename="macOS Catalina" ;;
                 10.16*) codename="macOS Big Sur" ;;
-                11.0*)  codename="macOS Big Sur" ;;
-                12.0*)  codename="macOS Monterey" ;;
+                11.*)  codename="macOS Big Sur" ;;
+                12.*)  codename="macOS Monterey" ;;
                 *)      codename=macOS ;;
             esac
 


### PR DESCRIPTION
## Description
## Features
## Issues
fixes #1813 
## TODO
