### PR TITLE
Add LangitKetujuh OS

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -806,8 +806,8 @@ image_source="auto"
 #       Solus, Source_Mage, Sparky, Star, SteamOS, SunOS, openSUSE_Leap, t2,
 #       openSUSE_Tumbleweed, openSUSE, SwagArch, Tails, Trisquel,
 #       Ubuntu-Cinnamon, Ubuntu-Budgie, Ubuntu-GNOME, Ubuntu-MATE,
-#       Ubuntu-Studio, Ubuntu, Univention, Venom, Void, semc, Obarun,
-#       windows10, Windows7, Xubuntu, Zorin, and IRIX have ascii logos.
+#       Ubuntu-Studio, Ubuntu, Univention, Venom, Void, LangitKetujuh, semc,
+#       Obarun, windows10, Windows7, Xubuntu, Zorin, and IRIX have ascii logos.
 # NOTE: Arch, Ubuntu, Redhat, Fedora and Dragonfly have 'old' logo variants.
 #       Use '{distro name}_old' to use the old logos.
 # NOTE: Ubuntu has flavor variants.
@@ -5154,8 +5154,8 @@ ASCII:
                                 Solus, Source_Mage, Sparky, Star, SteamOS, SunOS, openSUSE_Leap,
                                 t2, openSUSE_Tumbleweed, openSUSE, SwagArch, Tails, Trisquel,
                                 Ubuntu-Cinnamon, Ubuntu-Budgie, Ubuntu-GNOME, Ubuntu-MATE,
-                                Ubuntu-Studio, Ubuntu, Univention, Venom, Void, semc, Obarun,
-                                windows10, Windows7, Xubuntu, Zorin, and IRIX have ascii logos.
+                                Ubuntu-Studio, Ubuntu, Univention, Venom, Void, LangitKetujuh, semc,
+                                Obarun, windows10, Windows7, Xubuntu, Zorin, and IRIX have ascii logos.
 
                                 NOTE: Arch, Ubuntu, Redhat, Fedora and Dragonfly have 'old' logo variants.
 
@@ -11046,6 +11046,27 @@ ${c1}     -1vvnvv.     `~+++`        ++|+++
                -~|{*l}*|~
 EOF
 
+        ;;
+
+        "LangitKetujuh"*)
+            set_colors 7 4
+            read -rd '' ascii_data <<'EOF'
+${c1}
+   L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L
+      'L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L
+   L7L.   'L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L
+   L7L7L7L                             L7L7L7L
+   L7L7L7L                             L7L7L7L
+   L7L7L7L             L7L7L7L7L7L7L7L7L7L7L7L
+   L7L7L7L                'L7L7L7L7L7L7L7L7L7L
+   L7L7L7L                    'L7L7L7L7L7L7L7L
+   L7L7L7L                             L7L7L7L
+   L7L7L7L                             L7L7L7L
+   L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L.   'L7L
+   L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L.
+   L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L
+${c2}
+EOF
         ;;
 
        "semc"*)


### PR DESCRIPTION
## Description

LangitKetujuh GNU/Linux based on voidlinux.
homepage: https://langitketujuh.id

Terminal:
![Screenshot_20210714_125415](https://user-images.githubusercontent.com/45872139/125570630-34c9a487-e947-45ee-bed0-c2fa1befb294.png)

Splash screen logo:
![Screenshot_langitketujuh_2021-07-14_13:12:53](https://user-images.githubusercontent.com/45872139/125572155-b8e2f0e2-a5b8-46ad-b305-7bbdd23c91b2.png)

## Features

## Issues

## TODO
