### PR TITLE
Replace non-posix use of 'hostname' command with 'uname -n'

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1376,10 +1376,10 @@ get_title() {
 
     case $title_fqdn in
         on) hostname="$(uname -n)" ;;
-        *)  hostname="${HOSTNAME:-$(
+        *)  hostname="${HOSTNAME:-"$(
                 hostname="$(uname -n)"
                 printf '%s\n' "${hostname%%.*}"
-            )}" ;;
+            )"}" ;;
     esac
 
     title=${title_color}${bold}${user}${at_color}@${title_color}${bold}${hostname}

--- a/neofetch
+++ b/neofetch
@@ -1375,8 +1375,11 @@ get_title() {
     user=${USER:-$(id -un || printf %s "${HOME/*\/}")}
 
     case $title_fqdn in
-        on) hostname=$(hostname -f) ;;
-        *)  hostname=${HOSTNAME:-$(hostname)} ;;
+        on) hostname=$(uname -n) ;;
+        *)  hostname=${HOSTNAME:-$(
+                hostname="$(uname -n)"
+                printf '%s\n' "${hostname%%.*}"
+            )} ;;
     esac
 
     title=${title_color}${bold}${user}${at_color}@${title_color}${bold}${hostname}

--- a/neofetch
+++ b/neofetch
@@ -1375,11 +1375,11 @@ get_title() {
     user=${USER:-$(id -un || printf %s "${HOME/*\/}")}
 
     case $title_fqdn in
-        on) hostname=$(uname -n) ;;
-        *)  hostname=${HOSTNAME:-$(
+        on) hostname="$(uname -n)" ;;
+        *)  hostname="${HOSTNAME:-$(
                 hostname="$(uname -n)"
                 printf '%s\n' "${hostname%%.*}"
-            )} ;;
+            )}" ;;
     esac
 
     title=${title_color}${bold}${user}${at_color}@${title_color}${bold}${hostname}


### PR DESCRIPTION
## Description

This PR replaces the use of the 'hostname' (not accepted by POSIX) command with 'uname -n' (accepted by POSIX).

## Features

## Issues

The 'hostname' command is not specified by the POSIX standard, thus limiting the portability of the program.

## TODO
