### PR TITLE
Use XSETTINGS to get theme without a DE

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3189,6 +3189,9 @@ get_style() {
         fi
 
         # Check for general GTK3 Theme.
+        if [[ -z "$gtk3_theme" ]] && type -p dump_xsettings >/dev/null; then
+            gtk3_theme="$(dump_xsettings | sed -n "s,^${xfconf#/} ,,p")"
+        fi
         if [[ -z "$gtk3_theme" ]]; then
             if [[ -f "${XDG_CONFIG_HOME}/gtk-3.0/settings.ini" ]]; then
                 gtk3_theme="$(grep "^[^#]*$name" "${XDG_CONFIG_HOME}/gtk-3.0/settings.ini")"


### PR DESCRIPTION
## Description

GTK is using XSETTINGS as the primary information for theme, icons and
font. It surpasses what's inside the configuration files. DE will
advertise the values they have in their own registries to XSETTINGS.
Without a DE, users can get XSETTINGS with xsettingsd. It is shipped
with `dump_xsettings` to get the current values.

Unrelated, but without a DE, I doubt the content of gsettings matter
much. GTK will not read it by itself (this is not related to `GtkSettings`).
I would remove it. People running a part of a DE (gnome-control-center
maybe?) will get XSETTINGS.