### PR TITLE
Add Slax logo. Closes #1836

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -10461,6 +10461,27 @@ ${c2}
 EOF
             ;;
 
+        "Slax"*)
+            set_colors 2
+            read -rd '' ascii_data <<'EOF'
+${c1}            .cMMc.
+      .,,.cMMMMMMm.      ..
+    .cMMMMMMMMMMMMm  ,cmMMMMc.
+    vMMMMMMMMMMMMMM cMMMMMMMM.
+     \"MMMMMMMMMMMMMMMMMMMMMMm.
+       `";mMMMMMMMMMMMMMMMMMMMMM\
+ .cMMMMMMMMMMMMMMMMMMMMMMMMMMMMMy
+ MMMMMMMMMMMMMMMMMMMMMMMMMMMM:"
+ "MMMMMMMMMMMMMMMMMMMMMMc.
+   `MMMMMMMMM:'MMMMMMMMMMMMc.
+    MMMMMMMM" MMMMMMMMMMMMMM.
+    `"MMM"` .  MMMMMMMMMMMMMy'
+            | 'MMMMMMy
+            l   `"""'
+            "
+EOF
+            ;;
+
         "Solus"*)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'


### PR DESCRIPTION
## Description

Added ascii logo for Slax as proposed in #1836


## Features
![Screenshot_20210722_100201](https://user-images.githubusercontent.com/40315484/126607194-dc357635-e24f-4f43-917a-13f51c113742.png)

## Issues
The logo will only show up when using `--ascii_distro slax` since they do not have a custom `/etc/os-release` file.


## TODO
