### PR TITLE
neofetch: remove duplicate distro ASCII logo

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -11365,31 +11365,6 @@ ${c1}                 `-     `
 EOF
                 ;;
 
-                "IRIX"*)
-                    set_colors 4 7
-                    read -rd '' ascii_data <<'EOF'
-${c1}           ./ohmNd/  +dNmho/-
-     `:+ydNMMMMMMMM.-MMMMMMMMMdyo:.
-   `hMMMMMMNhs/sMMM-:MMM+/shNMMMMMMh`
-   -NMMMMMmo-` /MMM-/MMM- `-omMMMMMN.
- `.`-+hNMMMMMNhyMMM-/MMMshmMMMMMmy+...`
-+mMNds:-:sdNMMMMMMMyyMMMMMMMNdo:.:sdMMm+
-dMMMMMMmy+.-/ymNMMMMMMMMNmy/-.+hmMMMMMMd
-oMMMMmMMMMNds:.+MMMmmMMN/.-odNMMMMmMMMM+
-.MMMM-/ymMMMMMmNMMy..hMMNmMMMMMmy/-MMMM.
- hMMM/ `/dMMMMMMMN////NMMMMMMMd/. /MMMh
- /MMMdhmMMMmyyMMMMMMMMMMMMhymMMMmhdMMM:
- `mMMMMNho//sdMMMMM//NMMMMms//ohNMMMMd
-  `/so/:+ymMMMNMMMM` mMMMMMMMmh+::+o/`
-     `yNMMNho-yMMMM` NMMMm.+hNMMNh`
-     -MMMMd:  oMMMM. NMMMh  :hMMMM-
-      -yNMMMmooMMMM- NMMMyomMMMNy-
-        .omMMMMMMMM-`NMMMMMMMmo.
-          `:hMMMMMM. NMMMMMh/`
-             .odNm+  /dNms.
-EOF
-                ;;
-
             esac
         ;;
     esac


### PR DESCRIPTION
## Description

Removed the duplicated `IRIX` distro ASCII logo which already exists [here](https://github.com/dylanaraps/neofetch/blob/master/neofetch#L11190-L11213).