### PR TITLE
replaced "artix_small" ASCII

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -6186,13 +6186,19 @@ EOF
         "artix_small"*)
             set_colors 6 6 7 1
             read -rd '' ascii_data <<'EOF'
-${c1}      /\\
-     /  \\
-    /`'.,\\
-   /     ',
-  /      ,`\\
- /   ,.'`.  \\
-/.,'`     `'.\\
+${c1}            '
+           'A'
+          'ooo'
+         'ookxo'
+         `ookxxo'
+       '.   `ooko'
+      'ooo`.   `oo'
+     'ooxxxoo`.   `'
+    'ookxxxkooo.`   . 
+   'ookxxkoo'`   .'oo'
+  'ooxoo'`     .:ooxxo'
+ 'io'`             `'oo'
+'`                     `'
 EOF
         ;;
 


### PR DESCRIPTION
## Description
much better ASCII, looks more like "arcolinux_small"

before: (looks ridiculous, yes it's small but its nothing like the big one)
![Screenshot_2021-08-13_05-30-16](https://user-images.githubusercontent.com/58430679/129301099-83112d3a-f79b-4892-9be7-055bbffc65b9.png)

now: (so much better, more like the big one)
![Screenshot_2021-08-13_05-32-27](https://user-images.githubusercontent.com/58430679/129301245-caaf6a73-0ccf-41d9-9b61-8258974255bd.png)