### PR TITLE
Avoid overwriting GIO_EXTRA_MODULES env var

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -46,7 +46,7 @@ LC_ALL=C
 LANG=C
 
 # Fix issues with gsettings.
-export GIO_EXTRA_MODULES=/usr/lib/x86_64-linux-gnu/gio/modules/
+[[ -z $GIO_EXTRA_MODULES ]] && export GIO_EXTRA_MODULES=/usr/lib/x86_64-linux-gnu/gio/modules/
 
 # Neofetch default config.
 read -rd '' config <<'EOF'


### PR DESCRIPTION
## Description

The fix for #949 introduced a regression in environments where `GIO_EXTRA_MODULES` is already set (and different from the provided value of `/usr/lib/x86_64-linux-gnu/gio/modules/`). This PR checks if the variable is already set before overwriting it.

I was personally experiencing an issue with incorrect themes being reported on NixOS that seemed to be directly caused by overwriting the existing `GIO_EXTRA_MODULES` environment variable. Using this patch fixed the issue.

I'm not sure if the issue @fearphage had in #949 was due to the variable being unset entirely or set to something incorrect, so this should probably be tested on other systems (especially Ubuntu, judging by #949) to ensure there is no regression. Alternatively, just appending `/usr/lib/x86_64-linux-gnu/gio/modules/` to the end of the variable if it already exists would possibly work, but I've not tested this.
