### PR TITLE
Add support for nushell

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1740,8 +1740,8 @@ get_shell() {
         ;;
 	
         nu)
-            shell="${shell:0:2}shell "
-            shell+=$("$SHELL" --version | grep -o '\d\.\d\d\.\d[^-]' | head -n 1 )
+            shell+=$("$SHELL" -c "version | get version")
+            shell=${shell/ $shell_name}
         ;;
 
 

--- a/neofetch
+++ b/neofetch
@@ -1738,6 +1738,12 @@ get_shell() {
             shell=${shell/ Yet another shell}
             shell=${shell/Copyright*}
         ;;
+	
+        nu)
+            shell="${shell:0:2}shell "
+            shell+=$("$SHELL" --version | grep -o '\d\.\d\d\.\d[^-]' | head -n 1 )
+        ;;
+
 
         *)
             shell+=$("$SHELL" --version 2>&1)


### PR DESCRIPTION
## Description

Currently, neofetch looks like this for nushell users

<img width="729" alt="image" src="https://user-images.githubusercontent.com/74019033/129765720-ca25551c-f604-4ef1-b3d7-e90e4fcf8951.png">

This fixes the issue so that it now looks like this

<img width="243" alt="image" src="https://user-images.githubusercontent.com/74019033/129765801-614ee57f-059a-4580-8758-7ebad68e6ebd.png">