### PR TITLE
Add long distro name for Manjaro Linux

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -987,6 +987,12 @@ get_distro() {
                 . /etc/armbian-release
                 distro="Armbian $DISTRIBUTION_CODENAME (${VERSION:-})"
 
+            elif [[ -f /etc/manjaro-release ]]; then
+                case $distro_shorthand in
+                    on|tiny) distro="Manjaro Linux" ;;
+                    *) distro="Manjaro Linux $(lsb_release -src)"
+                esac
+
             elif [[ -f /etc/siduction-version ]]; then
                 case $distro_shorthand in
                     on|tiny) distro=Siduction ;;


### PR DESCRIPTION
Before:

- `distro_shorthand="off"` : "Manjaro Linux"
- `distro_shorthand="tiny"` : "ManjaroLinux"
- `distro_shorthand="on"` : "ManjaroLinux"

After:

- `distro_shorthand="off"` : "Manjaro Linux 21.1.0 Pahvo"
- `distro_shorthand="tiny"` : "Manjaro Linux"
- `distro_shorthand="on"` : "Manjaro Linux"