### PR TITLE
packages: fix dpkg

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1541,7 +1541,7 @@ get_packages() {
             has kiss       && tot kiss l
             has cpt-list   && tot cpt-list
             has pacman-key && tot pacman -Qq --color never
-            has dpkg       && pac "$(dpkg --list | grep -c ^ii)"
+            has dpkg       && tot dpkg-query -f '.\n' -W
             has xbps-query && tot xbps-query -l
             has apk        && tot apk info
             has opkg       && tot opkg list-installed


### PR DESCRIPTION
Fixes #1835

`pac` does not increment `$packages`, so the current command is broken.
This `dpkg-query` command is actually already in-use for macOS, and pfetch also uses it for both Linux and macOS.

https://github.com/dylanaraps/neofetch/blob/5dc9a2fa61719efc3e9614e44d9d8df5d9043c8d/neofetch#L1643