### PR TITLE
Respect `$TMPDIR` if it exists

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -4807,10 +4807,11 @@ cache() {
 }
 
 get_cache_dir() {
-    case $os in
-        "Mac OS X"|"macOS") cache_dir="/Library/Caches" ;;
-        *)          cache_dir="/tmp" ;;
-    esac
+    if [[ "$TMPDIR" ]]; then
+        cache_dir="$TMPDIR"
+    else
+        cache_dir="/tmp"
+    fi
 }
 
 kde_config_dir() {
@@ -5363,8 +5364,7 @@ get_args() {
             "--gap") gap="$2" ;;
             "--clean")
                 [[ -d "$thumbnail_dir" ]] && rm -rf "$thumbnail_dir"
-                rm -rf "/Library/Caches/neofetch/"
-                rm -rf "/tmp/neofetch/"
+                rm -rf "$cache_dir/neofetch/"
                 exit
             ;;
 
@@ -11477,6 +11477,7 @@ EOF
 main() {
     cache_uname
     get_os
+    get_cache_dir
 
     # Load default config.
     eval "$config"
@@ -11499,7 +11500,6 @@ main() {
     }
 
     image_backend
-    get_cache_dir
     old_functions
     print_info
     dynamic_prompt


### PR DESCRIPTION
## Description

Set `cache_dir` to [`$TMPDIR`](https://en.wikipedia.org/wiki/TMPDIR) if it exists, this helps non-standard environment like Android (Termux and such). Also `/Library/Caches` on macOS is intended for system/privileged programs, `/tmp` on macOS is not standard etc.


## Features

## Issues

## TODO
