### PR TITLE
Fix LEDE & LMDE logo 1st line indentation

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -8338,7 +8338,7 @@ EOF
         "LMDE"*)
             set_colors 2 7
             read -rd '' ascii_data <<'EOF'
-         ${c2}`.-::---..
+${c2}         `.-::---..
 ${c1}      .:++++ooooosssoo:.
     .+o++::.      `.:oos+.
 ${c1}   :oo:.`             -+oo${c2}:

--- a/neofetch
+++ b/neofetch
@@ -8212,7 +8212,7 @@ EOF
         "LEDE"*)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
-    ${c1} _________
+${c1}     _________
     /        /\
    /  LE    /  \
   /    DE  /    \


### PR DESCRIPTION
- fix indent of 1st line of LEDE logo
- fix indent of 1st line of LMDE logo

## Description

The first lines of the LEDE and LMDE logos were previously not indented;
it was as if the ${cX} codes after the initial spaces caused those
spaces not to be respected. These commits fix those (naively) by simply moving the spaces to after the ${cX} codes.