### PR TITLE
image: Fix terminal size detection in slow/remote sessions

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -4233,14 +4233,12 @@ get_window_size() {
     # The escape codes above print the desired output as
     # user input so we have to use read to store the out
     # -put as a variable.
-    # The 1 second timeout is required for older bash
+    # The 3 second timeout is required for slow/remote
+    # sessions.
     #
     # False positive.
     # shellcheck disable=2141
-    case $bash_version in
-        4|5) IFS=';t' read -d t -t 0.05 -sra term_size ;;
-        *)   IFS=';t' read -d t -t 1 -sra term_size ;;
-    esac
+    IFS=';t' read -d t -t 3 -sra term_size
     unset IFS
 
     # Split the string into height/width.


### PR DESCRIPTION
Remote or just generally slow sessions could have too high latency for the terminal response to get through before the timeout, rendering in-terminal image backends unusable. Increase the timeout to accommodate these.

See #1339.
