### PR TITLE
Change source_mage's colors.

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -10539,7 +10539,7 @@ EOF
         ;;
 
         "Source Mage"* | "Source_Mage"*)
-            set_colors 4 7 1
+            set_colors 2 7 1
             read -rd '' ascii_data <<'EOF'
 ${c2}       :ymNMNho.
 .+sdmNMMMMMMMMMMy`


### PR DESCRIPTION
If you look on the website for source mage or the logo the accent color is clearly red.
