### PR TITLE
Improve GPU Reading on Linux

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2491,7 +2491,7 @@ get_gpu() {
             gpu_cmd="$(lspci -mm |
                        awk -F '\"|\" \"|\\(' \
                               '/"Display|"3D|"VGA/ {
-                                  a[$0] = $1 " " $3 " " ($7 ~ /^$|^Device [[:xdigit:]]+$/ ? $4 : $7)
+                                  a[$0] = $1 " " $3 " " ($(NF-1) ~ /^$|^Device [[:xdigit:]]+$/ ? $4 : $(NF-1))
                               }
                               END { for (i in a) {
                                   if (!seen[a[i]]++) {


### PR DESCRIPTION
## Description

GPUs that have subsystem name but no revision number can be processed
correctly by using $(NF-1) instead of $7 in the awk
Since these don't have a revision number, their $(NF-1) becomes $6