### PR TITLE
Add detection for Termux terminal

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3292,6 +3292,7 @@ get_term() {
     [[ "$TERM" == "tw52" || "$TERM" == "tw100" ]] && term="TosWin2"
     [[ "$SSH_CONNECTION" ]] && term="$SSH_TTY"
     [[ "$WT_SESSION" ]]     && term="Windows Terminal"
+    [[ "$TERMUX_VERSION" ]] && term="Termux ${TERMUX_VERSION}"
 
     # Check $PPID for terminal emulator.
     while [[ -z "$term" ]]; do

--- a/neofetch
+++ b/neofetch
@@ -3292,7 +3292,6 @@ get_term() {
     [[ "$TERM" == "tw52" || "$TERM" == "tw100" ]] && term="TosWin2"
     [[ "$SSH_CONNECTION" ]] && term="$SSH_TTY"
     [[ "$WT_SESSION" ]]     && term="Windows Terminal"
-    [[ "$TERMUX_VERSION" ]] && term="Termux ${TERMUX_VERSION}"
 
     # Check $PPID for terminal emulator.
     while [[ -z "$term" ]]; do
@@ -3331,6 +3330,10 @@ get_term() {
             ;;
         esac
     done
+
+    # Termux sets TERMUX_VERSION. Put this after the PPID check because this is
+    # also set if using a terminal on an X server.
+    [[ -z "$term" && "$TERMUX_VERSION" ]] && term="Termux ${TERMUX_VERSION}"
 
     # Log that the function was run.
     term_run=1


### PR DESCRIPTION
## Description

Adds detection for Termux (Termux sets the `$TERMUX_VERSION` environment variable, but doesn't expose its PID).

![Screenshot_20210929-120452](https://user-images.githubusercontent.com/6258309/135306591-e9608eee-a62c-4c04-bc50-72021ade22da.png)
