### PR TITLE
Added Wii ASCII for wii-linux-ngx, whiite and gc-linux

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -807,7 +807,7 @@ image_source="auto"
 #       openSUSE_Tumbleweed, openSUSE, SwagArch, Tails, Trisquel,
 #       Ubuntu-Cinnamon, Ubuntu-Budgie, Ubuntu-GNOME, Ubuntu-MATE,
 #       Ubuntu-Studio, Ubuntu, Univention, Venom, Void, LangitKetujuh, semc,
-#       Obarun, windows10, Windows7, Xubuntu, Zorin, and IRIX have ascii logos.
+#       Obarun, wii-linux-ngx, whiite-linux, gc-linux, windows10, Windows7, Xubuntu, Zorin, and IRIX have ascii logos.
 # NOTE: Arch, Ubuntu, Redhat, Fedora and Dragonfly have 'old' logo variants.
 #       Use '{distro name}_old' to use the old logos.
 # NOTE: Ubuntu has flavor variants.
@@ -5152,7 +5152,7 @@ ASCII:
                                 t2, openSUSE_Tumbleweed, openSUSE, SwagArch, Tails, Trisquel,
                                 Ubuntu-Cinnamon, Ubuntu-Budgie, Ubuntu-GNOME, Ubuntu-MATE,
                                 Ubuntu-Studio, Ubuntu, Univention, Venom, Void, LangitKetujuh, semc,
-                                Obarun, windows10, Windows7, Xubuntu, Zorin, and IRIX have ascii logos.
+                                Obarun, wii-linux-ngx, whiite-linux, gc-linux, windows10, Windows7, Xubuntu, Zorin, and IRIX have ascii logos.
 
                                 NOTE: Arch, Ubuntu, Redhat, Fedora and Dragonfly have 'old' logo variants.
 
@@ -11133,6 +11133,29 @@ ${c1}                    ,;::::;
     cooooooooooooloooooc
      ;ooooooooooooool;
        ;looooooolc;
+EOF
+        ;;
+
+        *"wii-linux-ngx"*|*"whiite-linux"*|\
+        *"gc-linux"*)
+            set_colors 6 7
+            read -rd '' ascii_data <<'EOF'
+${c1}'''''''            `~;:`            -''''''   ~kQ@@g\      ,EQ@@g/
+h@@@@@@'          o@@@@@9`         `@@@@@@D  `@@@@@@@=     @@@@@@@?
+'@@@@@@X         o@@@@@@@D         v@@@@@@:   R@@@@@@,     D@@@@@@_
+ t@@@@@@'       _@@@@@@@@@;       `Q@@@@@U     ;fmo/-       ;fmo/-
+ `Q@@@@@m       d@@@@@@@@@N       7@@@@@@'
+  L@@@@@@'     :@@@@@&@@@@@|     `Q@@@@@Z     :]]]]]v      :]]]]]v
+   Q@@@@@X     R@@@@Q`g@@@@Q     f@@@@@Q-     z@@@@@Q      v@@@@@Q
+   r@@@@@@~   ;@@@@@/ ;@@@@@L   `@@@@@@/      z@@@@@Q      v@@@@@Q
+    d@@@@@q   M@@@@#   H@@@@Q   ]@@@@@Q       z@@@@@Q      v@@@@@Q
+    ,@@@@@@, >@@@@@;   _@@@@@c `@@@@@@>       z@@@@@Q      v@@@@@Q
+     X@@@@@U Q@@@@R     Z@@@@Q`{@@@@@N        z@@@@@Q      v@@@@@Q
+     .@@@@@@S@@@@@:     -@@@@@e@@@@@@:        z@@@@@Q      v@@@@@Q
+      {@@@@@@@@@@U       t@@@@@@@@@@e         z@@@@@Q      v@@@@@Q
+      `Q@@@@@@@@@'       `Q@@@@@@@@@-         z@@@@@Q      v@@@@@Q
+       :@@@@@@@@|         ;@@@@@@@@=          z@@@@@Q      v@@@@@Q
+        '2#@@Q6:           ,eQ@@QZ~           /QQQQQg      \QQQQQN
 EOF
         ;;
 


### PR DESCRIPTION
wii-linux-ngx, whiite-linux and gc-linux are linux distros for Nintendo Wii. All can use the same Wii logo.