### PR TITLE
Use /sys/devices/virtual/dmi/id/board_*  for motherboard identification

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1235,6 +1235,11 @@ get_model() {
             if [[ -d /system/app/ && -d /system/priv-app ]]; then
                 model="$(getprop ro.product.brand) $(getprop ro.product.model)"
 
+            elif [[ -f /sys/devices/virtual/dmi/id/board_vendor ||
+                    -f /sys/devices/virtual/dmi/id/board_name ]]; then
+                model=$(< /sys/devices/virtual/dmi/id/board_vendor)
+                model+=" $(< /sys/devices/virtual/dmi/id/board_name)"
+
             elif [[ -f /sys/devices/virtual/dmi/id/product_name ||
                     -f /sys/devices/virtual/dmi/id/product_version ]]; then
                 model=$(< /sys/devices/virtual/dmi/id/product_name)


### PR DESCRIPTION
## Description
Use /sys/devices/virtual/dmi/id/board_vendor / board_name for motherboard identification if available. Fixes issues when product_name/product_version are not available.
