### PR TITLE
Improve ASCII art for LangitKetujuh GNU/Linux

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -792,7 +792,7 @@ image_source="auto"
 #       FreeMiNT, Frugalware, Funtoo, GalliumOS, Garuda, Gentoo, Pentoo,
 #       gNewSense, GNOME, GNU, GoboLinux, Grombyang, Guix, Haiku, Huayra, HydroOS
 #       Hyperbola, iglunix, janus, Kali, KaOS, KDE_neon, Kibojoe, Kogaion, Korora,
-#       KSLinux, Kubuntu, LEDE, LaxerOS, LibreELEC, LFS, Linux_Lite, LMDE,
+#       KSLinux, Kubuntu, LEDE, LangitKetujuh, LaxerOS, LibreELEC, LFS, Linux_Lite, LMDE,
 #       Lubuntu, Lunar, macos, Mageia, MagpieOS, Mandriva, Manjaro, TeArch, Maui,
 #       Mer, Minix, LinuxMint, Live_Raizo, MX_Linux, Namib, Neptune, NetBSD,
 #       Netrunner, Nitrux, NixOS, Nurunner, NuTyX, OBRevenge, OpenBSD,
@@ -806,7 +806,7 @@ image_source="auto"
 #       Solus, Source_Mage, Sparky, Star, SteamOS, SunOS, openSUSE_Leap, t2,
 #       openSUSE_Tumbleweed, openSUSE, SwagArch, Tails, Trisquel,
 #       Ubuntu-Cinnamon, Ubuntu-Budgie, Ubuntu-GNOME, Ubuntu-MATE,
-#       Ubuntu-Studio, Ubuntu, Univention, Venom, Void, VNux, LangitKetujuh, semc,
+#       Ubuntu-Studio, Ubuntu, Univention, Venom, Void, VNux, semc,
 #       Obarun, windows10, Windows7, Xubuntu, Zorin, and IRIX have ascii logos.
 # NOTE: Arch, Ubuntu, Redhat, Fedora and Dragonfly have 'old' logo variants.
 #       Use '{distro name}_old' to use the old logos.
@@ -5141,7 +5141,7 @@ ASCII:
                                 EuroLinux, Exherbo, Fedora, Feren, FreeBSD, FreeMiNT, Frugalware,
                                 Funtoo, GalliumOS, Garuda, Gentoo, Pentoo, gNewSense, GNOME, GNU,
                                 GoboLinux, Grombyang, Guix, Haiku, Huayra, Hyperbola, iglunix, janus, Kali,
-                                KaOS, KDE_neon, Kibojoe, Kogaion, Korora, KSLinux, Kubuntu, LEDE,
+                                KaOS, KDE_neon, Kibojoe, Kogaion, Korora, KSLinux, Kubuntu, LEDE, LangitKetujuh,
                                 LaxerOS, LibreELEC, LFS, Linux_Lite, LMDE, Lubuntu, Lunar, macos,
                                 Mageia, MagpieOS, Mandriva, Manjaro, TeArch, Maui, Mer, Minix, LinuxMint,
                                 Live_Raizo, MX_Linux, Namib, Neptune, NetBSD, Netrunner, Nitrux,
@@ -5156,7 +5156,7 @@ ASCII:
                                 Solus, Source_Mage, Sparky, Star, SteamOS, SunOS, openSUSE_Leap,
                                 t2, openSUSE_Tumbleweed, openSUSE, SwagArch, Tails, Trisquel,
                                 Ubuntu-Cinnamon, Ubuntu-Budgie, Ubuntu-GNOME, Ubuntu-MATE,
-                                Ubuntu-Studio, Ubuntu, Univention, Venom, Void, VNux, LangitKetujuh, semc,
+                                Ubuntu-Studio, Ubuntu, Univention, Venom, Void, VNux, semc,
                                 Obarun, windows10, Windows7, Xubuntu, Zorin, and IRIX have ascii logos.
 
                                 NOTE: Arch, Ubuntu, Redhat, Fedora and Dragonfly have 'old' logo variants.
@@ -8202,6 +8202,26 @@ EOF
 EOF
         ;;
 
+        "LangitKetujuh"*)
+            set_colors 4 2
+            read -rd '' ascii_data <<'EOF'
+${c1}
+. 'MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMML7
+MM.   'MMMMMMMMMMMMMMMMMMMMMMMMMMML7L7
+MMMMMM     MMMMMMML7L7L7L7L7L7L7L7L7L7
+L7MMMM                          L7L7L7
+L7L7MM           'L7L7L7L7L7L7L7L7L7L:
+L7L7L7               'L7L7L7L7L7L7L:::
+L7L7L7                   'L7L7L7::::::
+:7L7L7                          ::::::
+::L7L7L7L7L7L7L7L7L7L::::::.    ::::::
+:::::7L7L7L7L7L7:::::::::::::::.   '::
+:::::::::::::::::::::::::::::::::::. '
+${c2}
+
+EOF
+        ;;
+
         "LaxerOS"*)
             set_colors 7 4
             read -rd '' ascii_data <<'EOF'
@@ -11104,27 +11124,6 @@ ${c1} 'ljmwn${c2}~tk8${c5}MWWWWM8O${c2}X${c1}r${c2}+]nC${c1}[
                    ^"                                
 EOF
 
-        ;;
-
-        "LangitKetujuh"*)
-            set_colors 7 4
-            read -rd '' ascii_data <<'EOF'
-${c1}
-   L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L
-      'L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L
-   L7L.   'L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L
-   L7L7L7L                             L7L7L7L
-   L7L7L7L                             L7L7L7L
-   L7L7L7L             L7L7L7L7L7L7L7L7L7L7L7L
-   L7L7L7L                'L7L7L7L7L7L7L7L7L7L
-   L7L7L7L                    'L7L7L7L7L7L7L7L
-   L7L7L7L                             L7L7L7L
-   L7L7L7L                             L7L7L7L
-   L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L.   'L7L
-   L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L.
-   L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L
-${c2}
-EOF
         ;;
 
        "semc"*)


### PR DESCRIPTION
## Description

- The logo uses blue as the main color.
- The size of the ascii logo is slightly narrowed.
- Ascii logo moved in alphabetical order

## Features

#### Logo

![Screenshot_20211108_124531](https://user-images.githubusercontent.com/45872139/140693593-ddab4cd1-f4a5-4de0-94ee-ce66516f1173.png)

#### Old ASCII

![Screenshot_20211108_124729](https://user-images.githubusercontent.com/45872139/140693647-152130e7-4001-474f-a4ef-7bcdc8044bc7.png)

#### New ASCII

![Screenshot_20211108_124835](https://user-images.githubusercontent.com/45872139/140693701-90ba176d-ae6e-41d8-9f90-864ccfe0bf2a.png)

## 