### PR TITLE
Add CPU temp file for Raspberry Pi/linux and fix CPU detection for Raspberry Pi devices

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2219,6 +2219,10 @@ get_cpu() {
                     break
                 }
             done
+	    # If on a Raspberry Pi...
+            if grep -q "Raspberry Pi" /proc/device-tree/model; then
+                temp_dir=/sys/class/thermal/thermal_zone0/temp
+            fi
 
             # Get CPU speed.
             if [[ -d "$speed_dir" ]]; then

--- a/neofetch
+++ b/neofetch
@@ -2202,8 +2202,32 @@ get_cpu() {
                     [[ -z "$cpu" ]] && cpu="$(awk -F':' '/family/ {printf $2; exit}' "$cpu_file")"
                 ;;
 
+                "aarch64" | "armv7l")
+                    if grep -q "Raspberry Pi" /proc/device-tree/model; then
+                        cpu_revision="$(awk -F':' '/Revision/ {print substr($2,4,1); exit}' "$cpu_file")"
+                        case $cpu_revision in
+                            "0")
+                                cpu="BCM2835"
+                            ;;
+    
+                            "1")
+                                cpu="BCM2835"
+                            ;;
+    
+                            "2")
+                                cpu="BCM2837"
+                            ;;
+    
+                            "3")
+                                cpu="BCM2711"
+                            ;;
+                        esac
+
+                    fi
+                ;;&
+
                 *)
-                    cpu="$(awk -F '\\s*: | @' \
+                    [[ -z "$cpu" ]] && cpu="$(awk -F '\\s*: | @' \
                             '/model name|Hardware|Processor|^cpu model|chip type|^cpu type/ {
                             cpu=$2; if ($1 == "Hardware") exit } END { print cpu }' "$cpu_file")"
                 ;;


### PR DESCRIPTION
Fixes #1960 

## Description

Add the location for `/sys` tree CPU temperature file for Raspberry Pi devices.

Tested on a Raspberry Pi 4B (works), and also on a x86_64 machine (no errors), with `neofetch --cpu_temp C` .

![image](https://user-images.githubusercontent.com/1096701/142560954-3c252709-f9d8-4793-bab3-115b42f4609d.png)

Also fixed CPU detection, since `/proc/cpuinfo` reports BCM2835 for all Raspberry Pi devices when booted into 64-bit mode as per https://github.com/raspberrypi/linux/issues/3022#issuecomment-580758031 and https://github.com/raspberrypi/linux/issues/3022#issuecomment-505172683 .