### PR TITLE
added compatibility with LeftWM temes

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2177,6 +2177,13 @@ get_wm_theme() {
             wm_theme=${wm_theme##*\\}
             wm_theme=${wm_theme%.*}
         ;;
+
+        LeftWM*)
+			if command -v leftwm-theme &> /dev/null
+			then
+				wm_theme=$(leftwm-theme status | grep "Your current theme" | sed -e 's/Your current theme is //g' -e 's/\,.*$//g')
+			fi
+        ;;
     esac
 
     wm_theme=$(trim_quotes "$wm_theme")


### PR DESCRIPTION
Adding compatibility to the wm_theme feature for the LeftWM window manager. The current implementation depends on the leftwm-theme tool for querying the theme since LeftWM doesn't have a build in theme querying feature.