### PR TITLE
Add Virtuozzo Linux Logo

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1068,6 +1068,9 @@ get_distro() {
             # by the shell since the values aren't quoted.
             elif [[ -f /etc/lsb-release && $(< /etc/lsb-release) == *CHROMEOS* ]]; then
                 distro='Chrome OS'
+		
+	    elif [[ -f /etc/vzlinux-release ]]; then
+                distro='VzLinux'
 
             elif type -p guix >/dev/null; then
                 case $distro_shorthand in
@@ -11435,6 +11438,33 @@ ${c3}#######${c2}#${c1}#####${c2}#${c3}#######
 ${c3}  #####${c2}#######${c3}#####
 EOF
                 ;;
+
+"VzLinux"*)
+set_colors 1 7 3
+read -rd '' ascii_data <<'EOF'                                            
+${c2}                 ${c1}.::::::::.${c2}                  
+    `/////`      ${c1}:zzzzzzzz${c2}        ://///-     
+     VVVVVu`         ${c1}-zzz`${c2}       /VVVVV.     
+     `dVVVVV        ${c1}.zzz`${c2}       :VVVVV:      
+      `VVVVVo       ${c1}zzz${c2}        -VVVVV/       
+       .VVVVV\     ${c1}zzz/${c2}       .VVVVV+        
+        -VVVVV:   ${c1}zzzzzzzzz${c2}  .dVVVVs         
+         \VVVVV-  ${c1}`````````${c2}  VVVVVV          
+          +VVVVV.           sVVVVu`          
+           oVVVVd`         +VVVVd`           
+            VVVVVV        /VVVVV.            
+            `uVVVVs      -VVVVV-             
+             `dVVVV+    .VVVVV/              
+              .VVVVV\  `dVVVV+               
+               -VVVVV-`uVVVVo                
+                :VVVVVVVVVVV                 
+                 \VVVVVVVVu                  
+                  oVVVVVVd`                  
+                   sVVVVV.                   
+                    ----.                    
+EOF
+;;         
+
         "Profelis SambaBOX"* | "SambaBOX"*)
             set_colors 3 6
             read -rd '' ascii_data <<'EOF'


### PR DESCRIPTION
## Description
For years, VzLinux has been a base operating system for OpenVz and commercial product Virtuozzo. Additionally, it was used as a guest operating system for containers and virtual machines.
Forever fully free and always open source 1:1 Red Hat Enterprise Linux clone developed for and with the Linux community.​ 
[https://vzlinux.org](https://vzlinux.org)

## /etc/os-release
> cat /etc/os-release
> NAME="Virtuozzo Linux"
> VERSION="8"
> ID="virtuozzo"
> ID_LIKE="rhel fedora"
> VERSION_ID="8"
> PLATFORM_ID="platform:el8"
> PRETTY_NAME="Virtuozzo Linux"
> ANSI_COLOR="0;31"
> CPE_NAME="cpe:/o:virtuozzoproject:vzlinux:8"
> HOME_URL="https://www.vzlinux.org"
> BUG_REPORT_URL="https://bugs.openvz.org"

## Logo File
![Logo](https://avatars.githubusercontent.com/u/11892069?s=280&v=4)
### [SVG Link](https://vzlinux.org/img/vzlinux-logo-black.svg)
