### PR TITLE
Add support for Ubuntu Kylin

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -805,13 +805,13 @@ image_source="auto"
 #       SereneLinux, SharkLinux, Siduction, SkiffOS, Slackware, SliTaz, SmartOS,
 #       Solus, Source_Mage, Sparky, Star, SteamOS, SunOS, openSUSE_Leap, t2,
 #       openSUSE_Tumbleweed, openSUSE, SwagArch, Tails, Trisquel,
-#       Ubuntu-Cinnamon, Ubuntu-Budgie, Ubuntu-GNOME, Ubuntu-MATE,
+#       Ubuntu-Cinnamon, Ubuntu-Budgie, Ubuntu-GNOME, Ubuntu-Kylin, Ubuntu-MATE,
 #       Ubuntu-Studio, Ubuntu, Univention, Venom, Void, VNux, LangitKetujuh, semc,
 #       Obarun, windows10, Windows7, Xubuntu, Zorin, and IRIX have ascii logos.
 # NOTE: Arch, Ubuntu, Redhat, Fedora and Dragonfly have 'old' logo variants.
 #       Use '{distro name}_old' to use the old logos.
 # NOTE: Ubuntu has flavor variants.
-#       Change this to Lubuntu, Kubuntu, Xubuntu, Ubuntu-GNOME,
+#       Change this to Lubuntu, Kubuntu, Xubuntu, Ubuntu-GNOME, Ubuntu-Kylin
 #       Ubuntu-Studio, Ubuntu-Mate  or Ubuntu-Budgie to use the flavors.
 # NOTE: Arcolinux, Dragonfly, Fedora, Alpine, Arch, Ubuntu,
 #       CRUX, Debian, Gentoo, FreeBSD, Mac, NixOS, OpenBSD, android,
@@ -1131,6 +1131,7 @@ get_distro() {
                     *"Lubuntu"*)  distro=${distro/Ubuntu/Lubuntu} ;;
                     *"budgie"*)   distro=${distro/Ubuntu/Ubuntu Budgie} ;;
                     *"cinnamon"*) distro=${distro/Ubuntu/Ubuntu Cinnamon} ;;
+                    *"ukui"*)     distro=${distro/Ubuntu/Ubuntu Kylin} ;;
                 esac
             fi
         ;;
@@ -5161,7 +5162,7 @@ ASCII:
                                 SereneLinux, SharkLinux, Siduction, Slackware, SliTaz, SmartOS,
                                 Solus, Source_Mage, Sparky, Star, SteamOS, SunOS, openSUSE_Leap,
                                 t2, openSUSE_Tumbleweed, openSUSE, SwagArch, Tails, Trisquel,
-                                Ubuntu-Cinnamon, Ubuntu-Budgie, Ubuntu-GNOME, Ubuntu-MATE,
+                                Ubuntu-Cinnamon, Ubuntu-Budgie, Ubuntu-GNOME, Ubuntu-Kylin, Ubuntu-MATE,
                                 Ubuntu-Studio, Ubuntu, Univention, Venom, Void, VNux, LangitKetujuh, semc,
                                 Obarun, windows10, Windows7, Xubuntu, Zorin, and IRIX have ascii logos.
 
@@ -5171,7 +5172,7 @@ ASCII:
 
                                 NOTE: Ubuntu has flavor variants.
 
-                                NOTE: Change this to Lubuntu, Kubuntu, Xubuntu, Ubuntu-GNOME,
+                                NOTE: Change this to Lubuntu, Kubuntu, Xubuntu, Ubuntu-GNOME, Ubuntu-Kylin,
                                 Ubuntu-Studio, Ubuntu-Mate  or Ubuntu-Budgie to use the flavors.
 
                                 NOTE: Arcolinux, Dragonfly, Fedora, Alpine, Arch, Ubuntu,
@@ -10932,6 +10933,32 @@ ${c4}     `ooooo    ${c3}``    ${c4}.oooo
 ${c4}       `soooo.     .oooo`
          `\/oooooooooo`
             ``\/oo``
+EOF
+        ;;
+
+        "Ubuntu Kylin"* | "Ubuntu-Kylin"*)
+            set_colors 1 7 3
+            read -rd '' ascii_data <<'EOF'
+${c1}            .__=liiiiiii=__,
+        ._=liiliii|i|i|iiilii=_.
+      _=iiiii|ii|i|ii|i|inwwwzii=,
+    .=liiii|ii|ii|wwww|i${c2}3QWWWW${c1}ziii=,
+   =lii|i|ii|i|${c2}QQQWWWWWm]QWWQD${c1}||iiii=
+  =lii|iiivw${c2}Qm${c1}>3${c2}WWWWWQWQQwwQw${c1}cii|i|ii=
+ =lii|ii|n${c2}QWWWQ${c1}|)i${c2}|i${c1}%i|]${c2}TQWWWWm${c1}|ii|i|i=
+.li|i|i|m${c2}WWWQV${c1}|ii${c2}wmD${c1}|iiii|${c2}TWWWWm${c1}|i|iiii,
+=iii${c2}www|$WQWk${c1}|i${c2}aWWWD${c1}|i|i|ii]${c2}QQWQk${c1}|ii|i|=
+iii${c2}QWWWQz$WW${c1}|i${c2}jQQWQm${c1}w|ii${c2}wW${c1}k|${c2}TTTTY${c1}i|i|iii
+iiI${c2}QWQWWtyQQ${c1}|i|${c2}$WWWWWQWk${c1}||i|i|ii||i|ii|i
+<|i|${c2}TTT|mQQWz${c1}|i${c2}3D${c1}]C|${c2}nD$W${c1}|ii${c2}vWWWWk${c1}||ii|i>
+-|ii|i|i${c2}WWWQw${c1}|${c2}Tt${c1}|i3${c2}T${c1}|${c2}T${c1}|i|${c2}nQWQWDk${c1}|ii|ii`
+ <|i|iii|${c2}VWQWWQ${c1}|i|i|||ii${c2}wmWWQWD${c1}||ii|ii+
+  <|ii|i|i]${c2}$W@${c1}tv${c2}QQQWQQQWWTTHT${c1}1|iii|i|>
+   <|i|ii|ii||v${c2}QWWWQWWW@vmWWWm${c1}|i|i|i>
+    -<|i|ii|ii|i|${c2}TTTTTT${c1}|]${c2}QQWWWC${c1}|ii>`
+      -<|i|ii|i|ii|i|i|ii3${c2}TTT${c1}t|i>`
+         ~<|ii|ii|iiiii|i|||i>~
+            -~~<|ii|i||i>~~`
 EOF
         ;;
 


### PR DESCRIPTION
## Description

Add support for Ubuntu Kylin, the long time absent official flavor of Ubuntu.

1. Support ubuntu flavor detecting with `XDG_CONFIG_DIRS`.
2. Add the ubuntu kylin ascii art logo. (shown as below)
3. Add the distribution name (ID) into the comments / help information.

If there are something I can improve, please tell me.

## Features
![image](https://user-images.githubusercontent.com/32282736/144107772-4d5553b5-a7a8-4012-9fb4-b97975cfa5a2.png)


## Issues

## TODO
