### PR TITLE
set_text_color: fix color code for multi-digit ones

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -4718,6 +4718,7 @@ set_text_colors() {
     case ${bar_color_total}${1} in
         distro[736]) bar_color_total=$(color "$1") ;;
         distro[0-9]) bar_color_total=$(color "$2") ;;
+        distro*)     bar_color_total=$(color "$1") ;;
         *)           bar_color_total=$(color "$bar_color_total") ;;
     esac
 }


### PR DESCRIPTION
Distributions which call set_color with a multi-digit color code end up
in the default case of the switch case statement in set_text_colors for
bar_color_total. This results in setting the color code to 'distroXY'
within the color function.

E.g. Fedroa calls 'set_color 12 7', which results in printing the color
code '\e[38;5;distrom'.

Fix this by checking whether bar_color_total equals 'distro' and in case
default to the color code in $1.

Signed-off-by: Danilo Krummrich <danilokrummrich@dk-develop.de>

## Description

Only fill in the fields below if relevant.


## Features

## Issues

## TODO
