### PR TITLE
Add recognition for Hackintosh VMs

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1257,7 +1257,7 @@ get_model() {
         ;;
 
         "Mac OS X"|"macOS")
-            if [[ $(kextstat | grep -F -e "FakeSMC" -e "VirtualSMC") != "" ]]; then
+            if [[ $(kextstat | grep -F -e "FakeSMC" -e "VirtualSMC" -e "Lilu") != "" ]]; then
                 model="Hackintosh (SMBIOS: $(sysctl -n hw.model))"
             else
                 model=$(sysctl -n hw.model)


### PR DESCRIPTION
## Description
Makes the `kextstat` command also check for the Lilu kernel extension. This ensures that Hackintosh VMs will also be recognized as Hackintoshes. The previous implementation checked for either FakeSMC or VirtualSMC, but a properly configured VM does not need an SMC emulator. It should, however, nearly always have Lilu.

## Features
Hackintosh VMs will now be recognized as such.