### PR TITLE
Count all AppImage files

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1643,7 +1643,7 @@ get_packages() {
 
             # This is the only standard location for appimages.
             # See: https://github.com/AppImage/AppImageKit/wiki
-            manager=appimage && has appimaged && dir ~/.local/bin/*.appimage
+            manager=appimage && has appimaged && dir ~/.local/bin/*.[Aa]pp[Ii]mage
         ;;
 
         "Mac OS X"|"macOS"|MINIX)


### PR DESCRIPTION
For AppImages count files ending in .AppImage as well as .appimage (and anything in between).

## Description

Only fill in the fields below if relevant.


## Features

## Issues

## TODO
