### PR TITLE
neofetch: Don't hang on FreeBSD if pkg is not yet bootstrapped

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1620,7 +1620,7 @@ get_packages() {
 
             case $os-$kernel_name in
                 BSD-FreeBSD|BSD-DragonFly)
-                    has pkg && tot pkg info
+                    has pkg && tot pkg info </dev/null
                 ;;
 
                 BSD-*)


### PR DESCRIPTION
If not yet bootstrapped, pkg will print out:

    The package management tool is not yet installed on your system.
    Do you want to fetch and install it now? [y/N]: 

and wait for input if stdin is a tty. Use </dev/null to squash this.