### PR TITLE
neofetch: Print MACHINE_ARCH not MACHINE for FreeBSD

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1217,8 +1217,8 @@ get_distro() {
     [[ $distro ]] || distro="$os (Unknown)"
 
     # Get OS architecture.
-    case $os in
-        Solaris|AIX|Haiku|IRIX|FreeMiNT)
+    case $os-$kernel_name in
+        Solaris-*|AIX-*|Haiku-*|IRIX-*|FreeMiNT-*|BSD-FreeBSD)
             machine_arch=$(uname -p)
         ;;
 


### PR DESCRIPTION
MACHINE refers to the architecture family, whereas MACHINE_ARCH refers
to the specific variant. For x86, MACHINE is already split up into i386
and amd64, so there is only one MACHINE_ARCH for each, that takes an
identical value, and thus this patch has no effect there. There is also
the oddity of arm64, which only has one MACHINE_ARCH, but the name of
that is aarch64. For other architectures, one MACHINE covers multiple
MACHINE_ARCH variants, like powerpc which has powerpc, powerpcspe,
powerpc64 and powerpc64le. It's therefore more helpful to print
MACHINE_ARCH here, not MACHINE.

Note that MACHINE_ARCH is what official release information, such as
download pages and the list of supported architectures, tends to use,
due to its increased specificity.

This may also apply to other BSDs, but I have no experience of them.