### PR TITLE
Add font size for Apple Terminal

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3371,7 +3371,8 @@ get_term_font() {
 
         "Apple_Terminal")
             term_font="$(osascript <<END
-                         tell application "Terminal" to font name of window frontmost
+                         tell application "Terminal" to font name of window frontmost \
+			 & " " & font size of window frontmost
 END
 )"
         ;;

--- a/neofetch
+++ b/neofetch
@@ -3372,7 +3372,7 @@ get_term_font() {
         "Apple_Terminal")
             term_font="$(osascript <<END
                          tell application "Terminal" to font name of window frontmost \
-			 & " " & font size of window frontmost
+                         & " " & font size of window frontmost
 END
 )"
         ;;


### PR DESCRIPTION
This PR extends the Apple Terminal AppleScript call that fetches the font. It now fetches the font size and appends it to the font name to make the output match other terminals.