### PR TITLE
Add exclamation mark for uptime > 100 days

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1481,6 +1481,9 @@ get_uptime() {
     ((${h/ *} == 0)) && unset h
     ((${m/ *} == 0)) && unset m
 
+    # Add "(!)" if more than 100 days
+    ((${d/ *} > 100)) && d="${d}(!)"
+
     uptime=${d:+$d, }${h:+$h, }$m
     uptime=${uptime%', '}
     uptime=${uptime:-$s seconds}


### PR DESCRIPTION
## Description

htop has this for years, and I think it would be fun if neofetch also
matches it.

htop reference: https://github.com/htop-dev/htop/blob/1601931bbf7837a2a910b854d58716da344aeb22/UptimeMeter.c#L36

## Features

Add `(!)` after the day part of uptime.

htop example:

![image](https://user-images.githubusercontent.com/16748524/147772190-10404daa-5a68-4620-8200-82717e4529a9.png)
