### PR TITLE
packages: Improve detection for guix.

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1600,8 +1600,9 @@ get_packages() {
             has kpm-pkg && ((packages+=$(kpm  --get-selections | grep -cv deinstall$)))
 
             has guix && {
-                manager=guix-system && tot guix package -p "/run/current-system/profile" -I
+                manager=guix-system && tot guix package -p /run/current-system/profile -I
                 manager=guix-user   && tot guix package -I
+                manager=guix-home   && tot guix package -p ~/.guix-home/profile -I
             }
 
             has nix-store && {


### PR DESCRIPTION
## Description

If a separate `guix-home` manager is not desirable, it could probably be joined with `guix-user` instead, similar to how other user packages are handled for nix.

## Features

- detect packages managed by [`guix home`](https://guix.gnu.org/en/manual/devel/en/html_node/Home-Configuration.html)
