### PR TITLE
Improving MacOS M1 CPU/GPU prints

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2471,8 +2471,14 @@ get_cpu() {
     # Add CPU cores to the output.
     [[ "$cpu_cores" != "off" && "$cores" ]] && \
         case $os in
-            "Mac OS X"|"macOS") cpu="${cpu/@/(${cores}) @}" ;;
-            *)                  cpu="$cpu ($cores)" ;;
+            "Mac OS X"|"macOS")
+                if [[ $(uname -m) == 'arm64' ]]; then
+                    cpu="$cpu ($cores)"
+                else
+                    cpu="${cpu/@/(${cores}) @}"
+                fi
+            ;;
+            *) cpu="$cpu ($cores)" ;;
         esac
 
     # Add CPU speed to the output.
@@ -2591,10 +2597,16 @@ get_gpu() {
                 source "${cache_dir}/neofetch/gpu"
 
             else
-                gpu="$(system_profiler SPDisplaysDataType |\
-                       awk -F': ' '/^\ *Chipset Model:/ {printf $2 ", "}')"
-                gpu="${gpu//\/ \$}"
-                gpu="${gpu%,*}"
+                if [[ $(uname -m) == 'arm64' ]]; then
+                    chipset=$(system_profiler SPDisplaysDataType | awk '/Chipset Model/ { printf "%s %s %s", $3, $4, $5 }')
+                    cores=$(system_profiler SPDisplaysDataType | awk '/Total Number of Cores/ { printf "%d", $5 }')
+                    gpu="${chipset} (${cores})"
+                else
+                    gpu="$(system_profiler SPDisplaysDataType |\
+                        awk -F': ' '/^\ *Chipset Model:/ {printf $2 ", "}')"
+                    gpu="${gpu//\/ \$}"
+                    gpu="${gpu%,*}"
+                fi
 
                 cache "gpu" "$gpu"
             fi


### PR DESCRIPTION
## Description

Adding better support for Apple Silicon (M1) CPU and GPU prints
OLD:
```
CPU: Apple M1 Max
GPU: Apple M1 Max
```
NEW:
```
CPU: Apple M1 Max (10)
GPU: Apple M1 Max (24)
```
This is accurate for me as I have the 10c CPU and 24c GPU model

## Features
- Fix core-count not displaying on Apple Silicon (M1) devices (arm64)
- Add GPU core count for Apple Silicon (M1) devices

## Issues

## TODO
