### PR TITLE
add centerlinux

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -813,7 +813,7 @@ image_source="auto"
 # NOTE: Ubuntu has flavor variants.
 #       Change this to Lubuntu, Kubuntu, Xubuntu, Ubuntu-GNOME,
 #       Ubuntu-Studio, Ubuntu-Mate  or Ubuntu-Budgie to use the flavors.
-# NOTE: Arcolinux, Dragonfly, Fedora, Alpine, Arch, Ubuntu,
+# NOTE: Arcolinux, Dragonfly, Fedora, Alpine, Arch, CenterLinux, Ubuntu,
 #       CRUX, Debian, Gentoo, FreeBSD, Mac, NixOS, OpenBSD, android,
 #       Artix, CentOS, Cleanjaro, ElementaryOS, GUIX, Hyperbola,
 #       Manjaro, MXLinux, NetBSD, Parabola, POP_OS, PureOS,
@@ -5178,7 +5178,7 @@ ASCII:
                                 NOTE: Change this to Lubuntu, Kubuntu, Xubuntu, Ubuntu-GNOME,
                                 Ubuntu-Studio, Ubuntu-Mate  or Ubuntu-Budgie to use the flavors.
 
-                                NOTE: Arcolinux, Dragonfly, Fedora, Alpine, Arch, Ubuntu,
+                                NOTE: Arcolinux, Dragonfly, Fedora, Alpine, Arch, CenterLinux, Ubuntu,
                                 CRUX, Debian, Gentoo, FreeBSD, Mac, NixOS, OpenBSD, android,
                                 Artix, CentOS, Cleanjaro, ElementaryOS, GUIX, Hyperbola,
                                 Manjaro, MXLinux, NetBSD, Parabola, POP_OS, PureOS,
@@ -6631,6 +6631,24 @@ ${c2}              <><><><>
                  ''
 EOF
         ;;
+
+        "CenterLinux"*)
+            read -rd '' ascii_data <<'EOF'
+${c2}                           .
+                    o,
+            .       d,       .
+            ';'   ..d;..  .cl'
+              .:; 'oldO,.oo.
+              ..,:,xKXxoo;'.
+        ,;;;;;ldxkONMMMXxkxc;;;;;.
+        .....':oddXWMNOxlcl:......
+               .:dlxk0c;:. .
+              :d:.,xcld,.,:.
+            ;l,    .l;     ';'
+                   .o;
+                    l,
+EOF
+                ;;
 
         "Chakra"*)
             set_colors 4 5 7 6

--- a/neofetch
+++ b/neofetch
@@ -784,7 +784,7 @@ image_source="auto"
 #       Antergos, antiX, "AOSC OS", "AOSC OS/Retro", Apricity, ArchCraft,
 #       ArcoLinux, ArchBox, ARCHlabs, ArchStrike, XFerience, ArchMerge, Arch,
 #       Artix, Arya, Bedrock, Bitrig, BlackArch, BLAG, BlankOn, BlueLight,
-#       Bodhi, bonsai, BSD, BunsenLabs, Calculate, Carbs, CentOS, Chakra, ChaletOS,
+#       Bodhi, bonsai, BSD, BunsenLabs, Calculate, Carbs, CentOS, CenterOS, Chakra, ChaletOS,
 #       Chapeau, Chrom*, Cleanjaro, ClearOS, Clear_Linux, Clover, Condres,
 #       Container_Linux, Crystal Linux, CRUX, Cucumber, dahlia, Debian, Deepin,
 #       DesaOS, Devuan, DracOS, DarkOs, Itc, DragonFly, Drauger, Elementary,
@@ -813,7 +813,7 @@ image_source="auto"
 # NOTE: Ubuntu has flavor variants.
 #       Change this to Lubuntu, Kubuntu, Xubuntu, Ubuntu-GNOME,
 #       Ubuntu-Studio, Ubuntu-Mate  or Ubuntu-Budgie to use the flavors.
-# NOTE: Arcolinux, Dragonfly, Fedora, Alpine, Arch, CenterLinux, Ubuntu,
+# NOTE: Arcolinux, Dragonfly, Fedora, Alpine, Arch, Ubuntu,
 #       CRUX, Debian, Gentoo, FreeBSD, Mac, NixOS, OpenBSD, android,
 #       Artix, CentOS, Cleanjaro, ElementaryOS, GUIX, Hyperbola,
 #       Manjaro, MXLinux, NetBSD, Parabola, POP_OS, PureOS,
@@ -5178,7 +5178,7 @@ ASCII:
                                 NOTE: Change this to Lubuntu, Kubuntu, Xubuntu, Ubuntu-GNOME,
                                 Ubuntu-Studio, Ubuntu-Mate  or Ubuntu-Budgie to use the flavors.
 
-                                NOTE: Arcolinux, Dragonfly, Fedora, Alpine, Arch, CenterLinux, Ubuntu,
+                                NOTE: Arcolinux, Dragonfly, Fedora, Alpine, Arch, Ubuntu,
                                 CRUX, Debian, Gentoo, FreeBSD, Mac, NixOS, OpenBSD, android,
                                 Artix, CentOS, Cleanjaro, ElementaryOS, GUIX, Hyperbola,
                                 Manjaro, MXLinux, NetBSD, Parabola, POP_OS, PureOS,
@@ -6632,7 +6632,7 @@ ${c2}              <><><><>
 EOF
         ;;
 
-        "CenterLinux"*)
+        "Center"*)
             read -rd '' ascii_data <<'EOF'
 ${c2}                           .
                     o,


### PR DESCRIPTION
## Description
Add ascii art for centerLinux by teahouselab


## Features

MetaLinux,flashable linux with lots of tools and a package manager called ctpkg, come from taipei, have a clean theme for kde plasma

![dark](https://user-images.githubusercontent.com/38799701/163665065-58c8da41-ceb7-40f7-af81-dd38a47d8a76.png)
![light](https://user-images.githubusercontent.com/38799701/163665069-6b745b08-c4d0-4ab7-837c-35e3d607086b.png)