### PR TITLE
BUGFIX: fix offset bug w/ col_offset and many color blocks #2037

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3985,18 +3985,21 @@ get_cols() {
         [[ "$blocks"  ]] && cols+="${block_spaces// /${blocks}[mnl}"
         [[ "$blocks2" ]] && cols+="${block_spaces// /${blocks2}[mnl}"
 
+        # Determine the horizontal offset of the blocks.
+        case $col_offset in
+            "auto")  block_offset="$text_padding" ;;
+            *)       block_offset="$col_offset" ;;
+        esac
+
         # Add newlines to the string.
         cols=${cols%%nl}
         cols=${cols//nl/
-[${text_padding}C${zws}}
+[${block_offset}C${zws}}
 
         # Add block height to info height.
         ((info_height+=block_range[1]>7?block_height+2:block_height+1))
 
-        case $col_offset in
-            "auto") printf '\n\e[%bC%b\n' "$text_padding" "${zws}${cols}" ;;
-            *) printf '\n\e[%bC%b\n' "$col_offset" "${zws}${cols}" ;;
-        esac
+        printf '\n\e[%bC%b\n' "$block_offset" "${zws}${cols}"
     fi
 
     unset -v blocks blocks2 cols


### PR DESCRIPTION
## Description

Fixes #2037 

Fix a bug where `neofetch` was passed a numeric `col_offset` value and the program only set the offset of the first color block, but not the others.

The first block either used the `text_padding` offset or the number set in `col_offset`. However, the other blocks still used `text_padding` even if `col_offset` was specified a number.

### Original (`--col_offset 60`):

![image](https://user-images.githubusercontent.com/39676098/152324162-1f3b78e1-f98f-415c-8b7a-20aea38c9c91.png)

### Fixed (`--col_offset 60`):

![image](https://user-images.githubusercontent.com/39676098/152324196-d8458653-f388-46e2-870f-e5c81ad51e5c.png)

## Features

## Issues

## TODO
