### PR TITLE
Add BigLinux

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,41 @@
+# Maintainer: Dylan Araps <dyl@tfwno.gf>
+
+pkgname=neofetch-big
+_pkgname=neofetch
+pkgver=7.1.0.r171.ge6407c77
+pkgrel=1
+pkgdesc="Uma ferramenta CLI de informações do sistema escrita em BASH que suporta a exibição de imagens."
+arch=('any')
+url="https://github.com/ezileicorreia/${_pkgname}"
+license=('MIT')
+provides=($_pkgname)
+conflicts=($_pkgname)
+depends=('bash')
+optdepends=(
+  'feh: Wallpaper Display'
+  'imagemagick: Image cropping / Thumbnail creation / Take a screenshot'
+  'nitrogen: Wallpaper Display'
+  'w3m: Display Images'
+  'catimg: Display Images'
+  'jp2a: Display Images'
+  'libcaca: Display Images'
+  'xdotool: See https://github.com/ezileicorreia/neofetch/wiki/Images-in-the-terminal'
+  'xorg-xdpyinfo: Resolution detection (Single Monitor)'
+  'xorg-xprop: Desktop Environment and Window Manager'
+  'xorg-xrandr: Resolution detection (Multi Monitor + Refresh rates)'
+  'xorg-xwininfo: See https://github.com/ezileicorreia/neofetch/wiki/Images-in-the-terminal'
+)
+makedepends=('git')
+source=("$pkgname::git+https://github.com/ezileicorreia/neofetch.git")
+md5sums=('SKIP')
+
+pkgver() {
+  cd $pkgname
+  git describe --tags --long | sed -r -e 's,^[^0-9]*,,;s,([^-]*-g),r\1,;s,[-_],.,g'
+}
+
+package() {
+  cd $pkgname
+  make DESTDIR="$pkgdir" install
+  install -D -m644 LICENSE.md "$pkgdir/usr/share/licenses/neofetch/LICENSE.md"
+}

--- a/neofetch
+++ b/neofetch
@@ -783,7 +783,7 @@ image_source="auto"
 # NOTE: AIX, Hash, Alpine, AlterLinux, Amazon, Anarchy, Android, instantOS,
 #       Antergos, antiX, "AOSC OS", "AOSC OS/Retro", Apricity, ArchCraft,
 #       ArcoLinux, ArchBox, ARCHlabs, ArchStrike, XFerience, ArchMerge, Arch,
-#       Artix, Arya, Bedrock, Bitrig, BigLinux, BlackArch, BLAG, BlankOn, BlueLight,
+#       Artix, Arya, Bedrock, BigLinux, Bitrig, BlackArch, BLAG, BlankOn, BlueLight,
 #       Bodhi, bonsai, BSD, BunsenLabs, Calculate, Carbs, CentOS, Chakra, ChaletOS,
 #       Chapeau, Chrom*, Cleanjaro, ClearOS, Clear_Linux, Clover, Condres,
 #       Container_Linux, Crystal Linux, CRUX, Cucumber, dahlia, Debian, Deepin,
@@ -6273,29 +6273,6 @@ ${c1}--------------------------------------
 EOF
         ;;
 
-        "Bitrig"*)
-            set_colors 2 7
-            read -rd '' ascii_data <<'EOF'
-${c1}   `hMMMMN+
-   -MMo-dMd`
-   oMN- oMN`
-   yMd  /NM:
-  .mMmyyhMMs
-  :NMMMhsmMh
-  +MNhNNoyMm-
-  hMd.-hMNMN:
-  mMmsssmMMMo
- .MMdyyhNMMMd
- oMN.`/dMddMN`
- yMm/hNm+./MM/
-.dMMMmo.``.NMo
-:NMMMNmmmmmMMh
-/MN/-------oNN:
-hMd.       .dMh
-sm/         /ms
-EOF
-        ;;
-
         "BigLinux"*)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
@@ -6318,6 +6295,29 @@ cMMN:;OMMMK  ;MMc KMMMM. .MMc  xMMMMc.0MMk
    kMMMMMMMMMM.                          
     :NMMMMMW,                            
        ..                                
+EOF
+        ;;
+
+        "Bitrig"*)
+            set_colors 2 7
+            read -rd '' ascii_data <<'EOF'
+${c1}   `hMMMMN+
+   -MMo-dMd`
+   oMN- oMN`
+   yMd  /NM:
+  .mMmyyhMMs
+  :NMMMhsmMh
+  +MNhNNoyMm-
+  hMd.-hMNMN:
+  mMmsssmMMMo
+ .MMdyyhNMMMd
+ oMN.`/dMddMN`
+ yMm/hNm+./MM/
+.dMMMmo.``.NMo
+:NMMMNmmmmmMMh
+/MN/-------oNN:
+hMd.       .dMh
+sm/         /ms
 EOF
         ;;
 

--- a/neofetch
+++ b/neofetch
@@ -6276,25 +6276,25 @@ EOF
         "BigLinux"*)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
-${c2}                                ...      
-                             .xXMMMWk.   
-                           .0MMMMMMMMMo  
-                 :xkx:    'WMMMMW.   ;Md 
-  .             XMMMMM:  .MMMMW        k.
- c;             :MMMMO   XMMMK          ,
- Nc               ...   .MMMM       lkk; 
-.MX      ,cc,     cKX0c .MMMd     dWMMMMd
-:MM.   ;NMMMWWk.  MMMMM  MMM,   ,NMMMMMMM,
-cMMN:;OMMMK  ;MMc KMMMM. .MMc  xMMMMc.0MMk
-'MMMMMMMM.   .MMM. KMMMX   xNxWMMMx    WMO
- kMMMMMO     ;MMM:  :MMMX.   .;l;      :Ml
-  lNM,       KMMM,    .oWMd            .M.
- '          dMMMM                      .K
- .X.      .OMMMM,                      . 
-  xMk:'':kMMMMMc                   
-   kMMMMMMMMMM.                          
-    :NMMMMMW,                            
-       ..                                
+${c2}                                 ...
+                              :OWMMMNd.
+                            :NMMMMMMMMWc
+                  okkl.    kMMMMMW0xdOWMl
+  :             xMMMMMW.  kMMMMNc      lW.
+ :x             NMMMMMO  ,MMMM0.        'l
+ Xx              .lkkd   kMMMX      .okx,
+.MX      .cc;.    .kXKx. KMMM:    .OMMMMMl
+:MM'   'KMMMMWK:  0MMMMk xMMM.   lWMMMMMMM'
+cMMN:;xMMMMk::MMO oMMMMX .XMM. .KMMMWOOMMMd
+'MMMMMMMMN,   NMMx OMMMMl .kM0OMMMMk.  ;MMd
+ xMMMMMMd    .MMMW  cNMMMd  .ckKKx'     KMc
+  dWMNd.     oMMMN    :kNMX,            oM.
+ ;.         ;MMMMx       cc,.           cO
+ .X.       oMMMMW.                      l.
+  dMk:..;xWMMMMW,
+   kMMMMMMMMMMX.
+    :XMMMMMMK:
+      ':cc,.	    
 EOF
         ;;
 

--- a/neofetch
+++ b/neofetch
@@ -783,7 +783,7 @@ image_source="auto"
 # NOTE: AIX, Hash, Alpine, AlterLinux, Amazon, Anarchy, Android, instantOS,
 #       Antergos, antiX, "AOSC OS", "AOSC OS/Retro", Apricity, ArchCraft,
 #       ArcoLinux, ArchBox, ARCHlabs, ArchStrike, XFerience, ArchMerge, Arch,
-#       Artix, Arya, Bedrock, Bitrig, BlackArch, BLAG, BlankOn, BlueLight,
+#       Artix, Arya, Bedrock, Bitrig, BigLinux, BlackArch, BLAG, BlankOn, BlueLight,
 #       Bodhi, bonsai, BSD, BunsenLabs, Calculate, Carbs, CentOS, Chakra, ChaletOS,
 #       Chapeau, Chrom*, Cleanjaro, ClearOS, Clear_Linux, Clover, Condres,
 #       Container_Linux, Crystal Linux, CRUX, Cucumber, dahlia, Debian, Deepin,
@@ -6293,6 +6293,31 @@ ${c1}   `hMMMMN+
 /MN/-------oNN:
 hMd.       .dMh
 sm/         /ms
+EOF
+        ;;
+
+        "BigLinux"*)
+            set_colors 4 7 1
+            read -rd '' ascii_data <<'EOF'
+${c2}                                ...      
+                             .xXMMMWk.   
+                           .0MMMMMMMMMo  
+                 :xkx:    'WMMMMW.   ;Md 
+  .             XMMMMM:  .MMMMW        k.
+ c;             :MMMMO   XMMMK          ,
+ Nc               ...   .MMMM       lkk; 
+.MX      ,cc,     cKX0c .MMMd     dWMMMMd
+:MM.   ;NMMMWWk.  MMMMM  MMM,   ,NMMMMMMM,
+cMMN:;OMMMK  ;MMc KMMMM. .MMc  xMMMMc.0MMk
+'MMMMMMMM.   .MMM. KMMMX   xNxWMMMx    WMO
+ kMMMMMO     ;MMM:  :MMMX.   .;l;      :Ml
+  lNM,       KMMM,    .oWMd            .M.
+ '          dMMMM                      .K
+ .X.      .OMMMM,                      . 
+  xMk:'':kMMMMMc                   
+   kMMMMMMMMMM.                          
+    :NMMMMMW,                            
+       ..                                
 EOF
         ;;
 

--- a/neofetch.1
+++ b/neofetch.1
@@ -304,7 +304,7 @@ Which Distro's ascii art to print
 NOTE: AIX, Hash, Alpine, AlterLinux, Amazon, Anarchy, Android, instantOS,
 Antergos, antiX, "AOSC OS", "AOSC OS/Retro", Apricity, ArchCraft,
 ArcoLinux, ArchBox, ARCHlabs, ArchStrike, XFerience, ArchMerge, Arch,
-Artix, Arya, Bedrock, Bitrig, BlackArch, BLAG, BlankOn, BlueLight,
+Artix, Arya, Bedrock, Bitrig, BigLinux, BlackArch, BLAG, BlankOn, BlueLight,
 bonsai, BSD, BunsenLabs, Calculate, Carbs, CentOS, Chakra, ChaletOS,
 Chapeau, Chrom*, Cleanjaro, ClearOS, Clear_Linux, Clover, Condres,
 Container_Linux, CRUX, Cucumber, dahlia, Debian, Deepin, DesaOS,

--- a/neofetch.1
+++ b/neofetch.1
@@ -304,7 +304,7 @@ Which Distro's ascii art to print
 NOTE: AIX, Hash, Alpine, AlterLinux, Amazon, Anarchy, Android, instantOS,
 Antergos, antiX, "AOSC OS", "AOSC OS/Retro", Apricity, ArchCraft,
 ArcoLinux, ArchBox, ARCHlabs, ArchStrike, XFerience, ArchMerge, Arch,
-Artix, Arya, Bedrock, Bitrig, BigLinux, BlackArch, BLAG, BlankOn, BlueLight,
+Artix, Arya, Bedrock, BigLinux, Bitrig, BlackArch, BLAG, BlankOn, BlueLight,
 bonsai, BSD, BunsenLabs, Calculate, Carbs, CentOS, Chakra, ChaletOS,
 Chapeau, Chrom*, Cleanjaro, ClearOS, Clear_Linux, Clover, Condres,
 Container_Linux, CRUX, Cucumber, dahlia, Debian, Deepin, DesaOS,


### PR DESCRIPTION
## Description

Add support for BigLinux, a Brazilian distribution developed since 2004 by Bruno Gonçalves that is now based on Manjaro. In search of the perfect system.

## Features
![ksnip_20220206-153741](https://user-images.githubusercontent.com/44807542/152698016-4b0ec8a0-13d8-4ac7-925a-fd9ec4775a53.png)
