### PR TITLE
add AmogOS

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -780,7 +780,7 @@ image_source="auto"
 # Default: 'auto'
 # Values:  'auto', 'distro_name'
 # Flag:    --ascii_distro
-# NOTE: AIX, Hash, Alpine, AlterLinux, Amazon, Anarchy, Android, instantOS,
+# NOTE: AIX, Hash, Alpine, AlterLinux, Amazon, AmogOS, Anarchy, Android, instantOS,
 #       Antergos, antiX, "AOSC OS", "AOSC OS/Retro", Apricity, ArchCraft,
 #       ArcoLinux, ArchBox, ARCHlabs, ArchStrike, XFerience, ArchMerge, Arch,
 #       Artix, Arya, Bedrock, Bitrig, BlackArch, BLAG, BlankOn, BlueLight,
@@ -5139,7 +5139,7 @@ ASCII:
     --ascii_colors x x x x x x  Colors to print the ascii art
     --ascii_distro distro       Which Distro's ascii art to print
 
-                                NOTE: AIX, Hash, Alpine, AlterLinux, Amazon, Anarchy, Android,
+                                NOTE: AIX, Hash, Alpine, AlterLinux, Amazon, AmogOS, Anarchy, Android,
                                 instantOS, Antergos, antiX, \"AOSC OS\", \"AOSC OS/Retro\",
                                 Apricity, ArchCraft, ArcoLinux, ArchBox, ARCHlabs, ArchStrike,
                                 XFerience, ArchMerge, Arch, Artix, Arya, Bedrock, Bitrig,
@@ -5696,6 +5696,21 @@ dMMMMMMMMMMMMMMMMh    yMMMMMMMMMMMMMMMMd
 .:+ydNMMMMMMMMMMMh    yMMMMMMMMMMMNdy+:.
      `.:+shNMMMMMh    yMMMMMNhs+:``
             `-+shy    shs+:`
+EOF
+        ;;
+
+        "AmogOS"*)
+            set_colors 7
+            read -rd '' ascii_data <<'EOF'
+${c1}     _______
+    /  ___  \
+   |  |___|  |
+   |         |
+   |         |
+   |         |
+ __|  _____  |
+|____|   __| | 
+        |____|
 EOF
         ;;
         "Anarchy"*)

--- a/neofetch.1
+++ b/neofetch.1
@@ -301,7 +301,7 @@ Colors to print the ascii art
 \fB\-\-ascii_distro\fR distro
 Which Distro's ascii art to print
 .TP
-NOTE: AIX, Hash, Alpine, AlterLinux, Amazon, Anarchy, Android, instantOS,
+NOTE: AIX, Hash, Alpine, AlterLinux, Amazon, AmogOS, Anarchy, Android, instantOS,
 Antergos, antiX, "AOSC OS", "AOSC OS/Retro", Apricity, ArchCraft,
 ArcoLinux, ArchBox, ARCHlabs, ArchStrike, XFerience, ArchMerge, Arch,
 Artix, Arya, Bedrock, Bitrig, BlackArch, BLAG, BlankOn, BlueLight,


### PR DESCRIPTION
## Description

I know this is going to be confusing but I am the OP of [this post on r/unixporn](https://www.reddit.com/r/unixporn/comments/nhomed/cinnamon_amogos_is_complete_icon_art_idea_by_u/) and was maintaining an private distro called AmogOS (not to be confused with [this version](https://github.com/Amog-OS/AmogOS) which went public way before mine). I was silently working on the full release of the operating system and wanted to add this logo, as elected by discord, to neofetch.

Project home: https://gitlab.com/Amog-OS/amogos