### PR TITLE
Fix bug in Remove un-needed patterns from cpu output

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2206,6 +2206,10 @@ get_cpu() {
                     [[ -z "$cpu" ]] && cpu="$(awk -F':' '/family/ {printf $2; exit}' "$cpu_file")"
                 ;;
 
+                "arm"* | "aarch64")
+                    cpu="$(lscpu | grep "Vendor ID" | sed "s/.*: *//g") $(lscpu | grep "Model name" | sed "s/.*: *//g")"
+                ;;
+		
                 *)
                     cpu="$(awk -F '\\s*: | @' \
                             '/model name|Hardware|Processor|^cpu model|chip type|^cpu type/ {

--- a/neofetch
+++ b/neofetch
@@ -2449,7 +2449,7 @@ get_cpu() {
     cpu="${cpu//, * Compute Cores}"
     cpu="${cpu//Core / }"
     cpu="${cpu//(\"AuthenticAMD\"*)}"
-    cpu="${cpu//with Radeon * Graphics}"
+    cpu="${cpu//with Radeon*Graphics}"
     cpu="${cpu//, altivec supported}"
     cpu="${cpu//FPU*}"
     cpu="${cpu//Chip Revision*}"


### PR DESCRIPTION
`with Radeon * Graphics` will not match those CPUs saying `with Radeon Graphics`