### PR TITLE
neofetch: Priorize /etc/os-release

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1022,8 +1022,8 @@ get_distro() {
                     -f /etc/lsb-release ]]; then
 
                 # Source the os-release file
-                for file in /etc/lsb-release /usr/lib/os-release \
-                            /etc/os-release  /etc/openwrt_release; do
+                for file in /etc/lsb-release    /etc/os-release \
+                            /usr/lib/os-release /etc/openwrt_release; do
                     source "$file" && break
                 done
 


### PR DESCRIPTION
## Description

From os-release(5):
> The file /etc/os-release takes precedence over /usr/lib/os-release. Applications should check for the former, and exclusively use its data if it exists, and only fall back to /usr/lib/os-release if it is missing. Applications should not read data from both files at the same time.

This PR aligns the behavior with the specification.