### PR TITLE
Fix: Remove an unnecessary space in the manual page for the `--package_managers` parameter

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -4998,7 +4998,7 @@ INFO:
                                 NOTE: You can supply multiple args. eg. 'neofetch --disable cpu gpu'
 
     --title_fqdn on/off         Hide/Show Fully Qualified Domain Name in title.
-    --package_managers on/off   Hide/Show Package Manager names . (on, tiny, off)
+    --package_managers on/off   Hide/Show Package Manager names. (on, tiny, off)
     --os_arch on/off            Hide/Show OS architecture.
     --speed_type type           Change the type of cpu speed to display.
                                 Possible values: current, min, max, bios,


### PR DESCRIPTION
This removes a space between the final word in the sentence *(`Hide/Show Package Manager names`)* and the following period for the `--package_managers` parameter description.