### PR TITLE
Fixed distro detection on CentOS 6

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1082,7 +1082,8 @@ get_distro() {
 
             else
                 for release_file in /etc/*-release; do
-                    distro+=$(< "$release_file")
+                    distro=$(< "$release_file")
+                    break
                 done
 
                 if [[ -z $distro ]]; then


### PR DESCRIPTION
## Description

CentOS 6 has multiple symlinks back to /etc/centos-release

    $ ls /etc/*-release
    -rw-r--r-- 1 root root 28 Jun 26  2018 /etc/centos-release
    lrwxrwxrwx 1 root root 14 Jul  6  2018 /etc/redhat-release -> centos-release
    lrwxrwxrwx 1 root root 14 Jul  6  2018 /etc/system-release -> centos-release

which caused the distro information to be repeated 3 times. This change
will only take the first file available.