### PR TITLE
Add support for MIRACLE LINUX

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -794,7 +794,7 @@ image_source="auto"
 #       Hyperbola, iglunix, janus, Kali, KaOS, KDE_neon, Kibojoe, Kogaion, Korora,
 #       KSLinux, Kubuntu, LEDE, LaxerOS, LibreELEC, LFS, Linux_Lite, LMDE,
 #       Lubuntu, Lunar, macos, Mageia, MagpieOS, Mandriva, Manjaro, TeArch, Maui,
-#       Mer, Minix, LinuxMint, Live_Raizo, MX_Linux, Namib, Neptune, NetBSD,
+#       Mer, Minix, MIRACLE_LINUX, LinuxMint, Live_Raizo, MX_Linux, Namib, Neptune, NetBSD,
 #       Netrunner, Nitrux, NixOS, Nurunner, NuTyX, OBRevenge, OpenBSD,
 #       openEuler, OpenIndiana, openmamba, OpenMandriva, OpenStage, OpenWrt,
 #       osmc, Oracle, OS Elbrus, PacBSD, Parabola, Pardus, Parrot, Parsix,
@@ -5153,21 +5153,22 @@ ASCII:
                                 GoboLinux, Grombyang, Guix, Haiku, Huayra, Hyperbola, iglunix, janus, Kali,
                                 KaOS, KDE_neon, Kibojoe, Kogaion, Korora, KSLinux, Kubuntu, LEDE,
                                 LaxerOS, LibreELEC, LFS, Linux_Lite, LMDE, Lubuntu, Lunar, macos,
-                                Mageia, MagpieOS, Mandriva, Manjaro, TeArch, Maui, Mer, Minix, LinuxMint,
-                                Live_Raizo, MX_Linux, Namib, Neptune, NetBSD, Netrunner, Nitrux,
-                                NixOS, Nurunner, NuTyX, OBRevenge, OpenBSD, openEuler, OpenIndiana,
-                                openmamba, OpenMandriva, OpenStage, OpenWrt, osmc, Oracle,
-                                OS Elbrus, PacBSD, Parabola, Pardus, Parrot, Parsix, TrueOS,
-                                PCLinuxOS, Pengwin, Peppermint, Pisi, popos, Porteus, PostMarketOS,
-                                Proxmox, PuffOS, Puppy, PureOS, Qubes, Qubyt, Quibian, Radix, Raspbian, Reborn_OS,
-                                Redstar, Redcore, Redhat, Refracted_Devuan, Regata, Regolith, Rosa,
-                                sabotage, Sabayon, Sailfish, SalentOS, Scientific, Septor,
-                                SereneLinux, SharkLinux, Siduction, Slackware, SliTaz, SmartOS,
-                                Solus, Source_Mage, Sparky, Star, SteamOS, SunOS, openSUSE_Leap,
-                                t2, openSUSE_Tumbleweed, openSUSE, SwagArch, Tails, Trisquel,
-                                Ubuntu-Cinnamon, Ubuntu-Budgie, Ubuntu-GNOME, Ubuntu-MATE,
-                                Ubuntu-Studio, Ubuntu, Univention, Venom, Void, VNux, LangitKetujuh, semc,
-                                Obarun, windows10, Windows7, Xubuntu, Zorin, and IRIX have ascii logos.
+                                Mageia, MagpieOS, Mandriva, Manjaro, TeArch, Maui, Mer, Minix,
+                                MIRACLE_LINUX, LinuxMint, Live_Raizo, MX_Linux, Namib, Neptune,
+                                NetBSD, Netrunner, Nitrux, NixOS, Nurunner, NuTyX, OBRevenge,
+                                OpenBSD, openEuler, OpenIndiana, openmamba, OpenMandriva, OpenStage,
+                                OpenWrt, osmc, Oracle, OS Elbrus, PacBSD, Parabola, Pardus, Parrot,
+                                Parsix, TrueOS, PCLinuxOS, Pengwin, Peppermint, Pisi, popos,
+                                Porteus, PostMarketOS, Proxmox, PuffOS, Puppy, PureOS, Qubes, Qubyt,
+                                Quibian, Radix, Raspbian, Reborn_OS, Redstar, Redcore, Redhat,
+                                Refracted_Devuan, Regata, Regolith, Rosa, sabotage, Sabayon,
+                                Sailfish, SalentOS, Scientific, Septor, SereneLinux, SharkLinux,
+                                Siduction, Slackware, SliTaz, SmartOS, Solus, Source_Mage, Sparky,
+                                Star, SteamOS, SunOS, openSUSE_Leap, t2, openSUSE_Tumbleweed,
+                                openSUSE, SwagArch, Tails, Trisquel, Ubuntu-Cinnamon, Ubuntu-Budgie,
+                                Ubuntu-GNOME, Ubuntu-MATE, Ubuntu-Studio, Ubuntu, Univention, Venom,
+                                Void, VNux, LangitKetujuh, semc, Obarun, windows10, Windows7,
+                                Xubuntu, Zorin, and IRIX have ascii logos.
 
                                 NOTE: Arch, Ubuntu, Redhat, Fedora and Dragonfly have 'old' logo variants.
 
@@ -8675,6 +8676,28 @@ ${c2}   -sdhyo+:-`                -/syymm:
        ../-yNMMy--/::/-.sMMmos+.`
            -+oyhNsooo+omy/```
               `::ohdmds-`
+EOF
+        ;;
+
+        "MIRACLE LINUX"* | "MIRACLE_LINUX"*)
+            set_colors 29
+            read -rd '' ascii_data <<'EOF'
+${c1}            ,A
+          .###
+     .#' .####   .#.
+   r##:  :####   ####.
+  +###;  :####  ######C
+  :####:  #### ,######".#.
+.# :####. :### #####'.#####.
+##: `####. ### ###'.########+.
+#### `####::## ##'.#######+'
+ ####+.`###i## #',####:'
+ `+###MI`##### 'l###:'
+   `+####+`### ;#E'
+      `+###:## #'
+         `:### '
+           '##
+            ';
 EOF
         ;;
 


### PR DESCRIPTION
## Description
Add support for MIRACLE LINUX

Logo URL: https://www.miraclelinux.com/++theme++cielo.stheme/stylesheets/++theme++cielo.stheme/images/logo.png
Product page: https://www.cybertrust.co.jp/miracle-linux/
Support page: https://www.miraclelinux.com/
Wikipedia: https://en.wikipedia.org/wiki/Miracle_Linux

About the ascii art:
- Original MIRACLE LINUX ascii art is contributed by Akio Tomita under MIT License (@tmya)
- Ascii art is brushed up by Haruka Kawahara under MIT License (@kawaharuka)

![neofetch_on_ML8](https://user-images.githubusercontent.com/210614/161057784-2439cae5-9537-44c0-9c33-387552a2ebf8.png)

