### PR TITLE
Fix hostname detection for obscuring FQDN.

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1384,7 +1384,7 @@ get_title() {
 
     case $title_fqdn in
         on) hostname=$(hostname -f) ;;
-        *)  hostname=${HOSTNAME:-$(hostname)} ;;
+        *)  hostname=$(hostname | cut -d. -f1);;
     esac
 
     title=${title_color}${bold}${user}${at_color}@${title_color}${bold}${hostname}


### PR DESCRIPTION
## Description
POSIX or not, the current FQDN detection doesn't work on modern Linux systems.  This fixes it as tested on FC35.

## Features
Stops leaking my hostname information.

## Issues
resolves https://github.com/dylanaraps/neofetch/issues/2094
