### PR TITLE
Fixed displaying song albums and titles with doublequotes in them

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2887,8 +2887,8 @@ get_song() {
             dbus-send --print-reply --dest=org.mpris.MediaPlayer2."${1}" /org/mpris/MediaPlayer2 \
             org.freedesktop.DBus.Properties.Get string:'org.mpris.MediaPlayer2.Player' \
             string:'Metadata' |\
-            awk -F '"' 'BEGIN {RS=" entry"}; /"xesam:artist"/ {a = $4} /"xesam:album"/ {b = $4}
-                        /"xesam:title"/ {t = $4} END {print a " \n" b " \n" t}'
+            awk -F '"' 'BEGIN {RS=" entry"}; /"xesam:artist"/ {a = $4} /"xesam:album"/ {split($0,b,"\""); for(i=5;i<length(b);i++)b[4]=b[4] "\"" b[i]}
+                        /"xesam:title"/ {split($0,t,"\""); for(i=5;i<length(t);i++)t[4]=t[4] "\"" t[i]} END {print a " \n" b[4] " \n" t[4]}'
         )"
     }
 


### PR DESCRIPTION
## Description
Changed how song album and title info from dbus is processed with awk.
Similiar modification can be applied to artist name but I've decided to not change it.

### Preview of a repaired example from the linked issue:
![image](https://user-images.githubusercontent.com/47438768/165869631-70a51dae-69e7-420d-8f3f-b74bcb16f488.png)

## Issues
Fixes #2106
