### PR TITLE
Windows 11 Modifications

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1777,7 +1777,7 @@ get_de() {
 
         Windows)
             case $distro in
-                *"Windows 10"*)
+                *"Windows 10"*|*"Windows 11"*)
                     de=Fluent
                 ;;
 
@@ -11230,7 +11230,7 @@ EOF
 
         *"[Windows 11]"*|*"on Windows 11"*|\
         "Windows 11"* |"windows11")
-            set_colors 6 7
+            set_colors 4 6 
             read -rd '' ascii_data <<'EOF'
 ${c1}
 ################  ################


### PR DESCRIPTION
## Description

I added Windows 11 to the Fluent design and changed the Windows 11 logo to blue 6 7>4 6 
## Issues
According to the information I checked on the Internet, Windows 11 is designed with Fluent, not Aero. I thought the blue icon was better, so I changed it.
![neofetch](https://user-images.githubusercontent.com/53988221/165959704-7606e559-2a04-40a2-8329-8b9afdf067a5.png)

