### PR TITLE
Add Ubuntu version shortname in output by default

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1008,14 +1008,6 @@ get_distro() {
                         distro="Proxmox VE ${distro%/*}"
                 esac
 
-            elif type -p lsb_release >/dev/null; then
-                case $distro_shorthand in
-                    on)   lsb_flags=-si ;;
-                    tiny) lsb_flags=-si ;;
-                    *)    lsb_flags=-sd ;;
-                esac
-                distro=$(lsb_release "$lsb_flags")
-
             elif [[ -f /etc/os-release || \
                     -f /usr/lib/os-release || \
                     -f /etc/openwrt_release || \
@@ -1024,15 +1016,25 @@ get_distro() {
                 # Source the os-release file
                 for file in /etc/lsb-release /usr/lib/os-release \
                             /etc/os-release  /etc/openwrt_release; do
-                    source "$file" && break
+                    source "$file"
                 done
 
                 # Format the distro name.
                 case $distro_shorthand in
                     on)   distro="${NAME:-${DISTRIB_ID}} ${VERSION_ID:-${DISTRIB_RELEASE}}" ;;
                     tiny) distro="${NAME:-${DISTRIB_ID:-${TAILS_PRODUCT_NAME}}}" ;;
-                    off)  distro="${PRETTY_NAME:-${DISTRIB_DESCRIPTION}} ${UBUNTU_CODENAME}" ;;
+                    off)  distro="${PRETTY_NAME:-${DISTRIB_DESCRIPTION}} (${UBUNTU_CODENAME})" ;;
                 esac
+
+            elif type -p lsb_release >/dev/null; then
+                case $distro_shorthand in
+                    on)   lsb_flags=-si ;;
+                    tiny) lsb_flags=-si ;;
+                    *)    lsb_flags=-sd ;;
+                esac
+                distro=$(lsb_release "$lsb_flags")
+
+
 
             elif [[ -f /etc/GoboLinuxVersion ]]; then
                 case $distro_shorthand in


### PR DESCRIPTION
## Description

Print Ubuntu shortname in output, like `OS: Ubuntu 22.04 LTS (jammy) x86_64` instead of `OS: Ubuntu 22.04 LTS x86_64`

![image](https://user-images.githubusercontent.com/20600565/166164955-72b8dd61-39f6-4ec1-bfbf-8ff907e01797.png)

NOTE: I do not understand why this change alters the output on the `HOST` line. With the version on `master`, I see:

 ```
Host: X570 AORUS PRO WIFI -CF
```

_shrug_
