### PR TITLE
Updated Ubuntu logo

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -11029,28 +11029,28 @@ EOF
         ;;
 
         "Ubuntu"* | "i3buntu"*)
-            set_colors 1 7 3
+            set_colors 9 7 3
             read -rd '' ascii_data <<'EOF'
-${c1}            .-/+oossssoo+\-.
-        ´:+ssssssssssssssssss+:`
-      -+ssssssssssssssssssyyssss+-
-    .ossssssssssssssssss${c2}dMMMNy${c1}sssso.
-   /sssssssssss${c2}hdmmNNmmyNMMMMh${c1}ssssss\
-  +sssssssss${c2}hm${c1}yd${c2}MMMMMMMNddddy${c1}ssssssss+
- /ssssssss${c2}hNMMM${c1}yh${c2}hyyyyhmNMMMNh${c1}ssssssss\
-.ssssssss${c2}dMMMNh${c1}ssssssssss${c2}hNMMMd${c1}ssssssss.
-+ssss${c2}hhhyNMMNy${c1}ssssssssssss${c2}yNMMMy${c1}sssssss+
-oss${c2}yNMMMNyMMh${c1}ssssssssssssss${c2}hmmmh${c1}ssssssso
-oss${c2}yNMMMNyMMh${c1}sssssssssssssshmmmh${c1}ssssssso
-+ssss${c2}hhhyNMMNy${c1}ssssssssssss${c2}yNMMMy${c1}sssssss+
-.ssssssss${c2}dMMMNh${c1}ssssssssss${c2}hNMMMd${c1}ssssssss.
- \ssssssss${c2}hNMMM${c1}yh${c2}hyyyyhdNMMMNh${c1}ssssssss/
-  +sssssssss${c2}dm${c1}yd${c2}MMMMMMMMddddy${c1}ssssssss+
-   \sssssssssss${c2}hdmNNNNmyNMMMMh${c1}ssssss/
-    .ossssssssssssssssss${c2}dMMMNy${c1}sssso.
-      -+sssssssssssssssss${c2}yyy${c1}ssss+-
-        `:+ssssssssssssssssss+:`
-            .-\+oossssoo+/-.
+${c1}llllllllllllllllllllllllllllllllllllllll
+${c1}llllllllllllllllllllllllllllllllllllllll
+${c1}llllllllllllllllllllllllllllllllllllllll
+${c1}llllllllllllllll${c2}odxkkd${c1}ll${c2}xO0Ox${c1}lllllllllll
+${c1}llllllllllll${c2}okKNMMMMX${c1}l${c2}dWMMMMMWx${c1}lllllllll
+${c1}llllllllll${c2}dKMMMWX0kko${c1}l${c2}KMMMMMMMK${c1}lllllllll
+${c1}lllllllll${c2}0MMMXx${c1}lllllll${c2}dNMMMMMWd${c1}l${c2}o${c1}lllllll
+${c1}lllllll${c2}odxdxd${c1}lllllllllll${c2}dkOkd${c1}l${c2}kNWd${c1}llllll
+${c1}lllll${c2}xXMMMMXx${c1}lllllllllllllllll${c2}KMMW${c1}llllll
+${c1}llll${c2}oMMMMMMMMo${c1}llllllllllllllll${c2}dMMMx${c1}lllll
+${c1}lllll${c2}NMMMMMMN${c1}lllllllllllllllll${c2}oMMMk${c1}lllll
+${c1}llllll${c2}OXNNXO${c1}llllllllllllllllll${c2}kMMMo${c1}lllll
+${c1}llllllll${c2}dxkk${c1}lllllllllllllllll${c2}oWMM0${c1}llllll
+${c1}llllllll${c2}dNMMNx${c1}llllllll${c2}kXWMWXO${c1}l${c2}xW0${c1}lllllll
+${c1}lllllllll${c2}o0MMMN0kd${c1}lll${c2}kMMMMMMMK${c1}l${c2}o${c1}llllllll
+${c1}lllllllllll${c2}oOXMMMMM0${c1}l${c2}kMMMMMMMK${c1}llllllllll
+${c1}llllllllllllll${c2}oxO0KXd${c1}l${c2}kXWMWXO${c1}lllllllllll
+${c1}lllllllllllllllllllllllll${c2}o${c1}llllllllllllll
+${c1}llllllllllllllllllllllllllllllllllllllll
+${c1}llllllllllllllllllllllllllllllllllllllll
 EOF
         ;;
 


### PR DESCRIPTION
## Description

This is an update of the Ubuntu logo to the new tag format and logo (https://design.ubuntu.com/brand/). Due to the resolution I used a square format instead of a real tag which would make the circle too small.

Here is the result with the default gnome-terminal profile:
![2022-05-12_09-14](https://user-images.githubusercontent.com/1928546/168013468-392e2199-bbf8-4a24-8d68-72fc33aa0118.png)

