### PR TITLE
Removed an prepended '=' sign from terminal font output for kitty

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3442,7 +3442,7 @@ END
         "kitty"*)
             term_font="from kitty.cli import *; o = create_default_opts(); \
                        print(f'{o.font_family} {o.font_size}')"
-            term_font="$(kitty +runpy ''"$term_font"'')"
+            term_font="$(kitty +runpy ''"$term_font"''|sed 's/=//')"
         ;;
 
         "konsole" | "yakuake")

--- a/neofetch
+++ b/neofetch
@@ -3442,7 +3442,9 @@ END
         "kitty"*)
             term_font="from kitty.cli import *; o = create_default_opts(); \
                        print(f'{o.font_family} {o.font_size}')"
-            term_font="$(kitty +runpy ''"$term_font"''|sed "s/=//"|sed "s/'//g")"
+            term_font="$(kitty +runpy ''"$term_font"'')"
+            term_font="${term_font//=}"
+            term_font="${term_font//\'}"
         ;;
 
         "konsole" | "yakuake")

--- a/neofetch
+++ b/neofetch
@@ -3442,7 +3442,7 @@ END
         "kitty"*)
             term_font="from kitty.cli import *; o = create_default_opts(); \
                        print(f'{o.font_family} {o.font_size}')"
-            term_font="$(kitty +runpy ''"$term_font"''|sed 's/=//')"
+            term_font="$(kitty +runpy ''"$term_font"''|sed "s/=//"|sed "s/'//g")"
         ;;
 
         "konsole" | "yakuake")


### PR DESCRIPTION
## Description

Terminal Font: = 'Hack Nerd Font Mono' 16.0

Is what I get in for terminal font detection on kitty, need to remove the '='


## Features


## Issues

Extra '=' sign in master for terminal-font 'kitty'

## TODO
