### PR TITLE
Slight glow around logo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h3 align="center"><img src="[https://media.discordapp.net/attachments/940740865129865219/980312819541106688/ZQI2EYz.png?width=1440&height=342](https://media.discordapp.net/attachments/940740865129865219/980314867561021530/ZQI2EYz.png?width=1440&height=342)" alt="logo" height="100px"></h3>
+<h3 align="center"><img src="https://media.discordapp.net/attachments/940740865129865219/980314867561021530/ZQI2EYz.png?width=1440&height=342" alt="logo" height="100px"></h3>
 <p align="center">A command-line system information tool written in bash 3.2+</p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h3 align="center"><img src="https://i.imgur.com/ZQI2EYz.png" alt="logo" height="100px"></h3>
+<h3 align="center"><img src="https://media.discordapp.net/attachments/940740865129865219/980312819541106688/ZQI2EYz.png?width=1440&height=342" alt="logo" height="100px"></h3>
 <p align="center">A command-line system information tool written in bash 3.2+</p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h3 align="center"><img src="https://media.discordapp.net/attachments/940740865129865219/980314867561021530/ZQI2EYz.png?width=1440&height=342" alt="logo" height="100px"></h3>
+<h3 align="center"><img src="https://user-images.githubusercontent.com/85663797/182021151-0ae9a9b0-bd5e-4d94-aa43-9ad5e36df7b8.png" alt="logo" height="100px"></h3>
 <p align="center">A command-line system information tool written in bash 3.2+</p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h3 align="center"><img src="https://media.discordapp.net/attachments/940740865129865219/980312819541106688/ZQI2EYz.png?width=1440&height=342" alt="logo" height="100px"></h3>
+<h3 align="center"><img src="[https://media.discordapp.net/attachments/940740865129865219/980312819541106688/ZQI2EYz.png?width=1440&height=342](https://media.discordapp.net/attachments/940740865129865219/980314867561021530/ZQI2EYz.png?width=1440&height=342)" alt="logo" height="100px"></h3>
 <p align="center">A command-line system information tool written in bash 3.2+</p>
 
 <p align="center">


### PR DESCRIPTION
## Description

Adds slight glow around neofetch logo on the README.md

## Features

makes logo more readable on dark themes of github

#### before change
![image](https://user-images.githubusercontent.com/85663797/170851193-07efe2a3-ce5f-4305-97c1-9d8e998e3bdd.png)
#### after change
![image](https://user-images.githubusercontent.com/85663797/170851203-0e20add8-d769-44a6-8d8c-2e9c9bc3b439.png)

## raw photo
![image](https://user-images.githubusercontent.com/85663797/170851235-9c48e599-1b49-4127-af90-d37fc95c3dec.png)


