### PR TITLE
Repair version for open-kernel NVIDIA version driver (LINUX)

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3940,8 +3940,7 @@ get_gpu_driver() {
             gpu_driver="${gpu_driver%, }"
 
             if [[ "$gpu_driver" == *"nvidia"* ]]; then
-                gpu_driver="$(< /proc/driver/nvidia/version)"
-                gpu_driver="${gpu_driver/*Module  }"
+                gpu_driver="$(< /sys/module/nvidia/version)"
                 gpu_driver="NVIDIA ${gpu_driver/  *}"
             fi
         ;;


### PR DESCRIPTION
## Description
This PR repairs how NVIDIA drivers should get their version.
The new NVIDIA open-kernel driver has the new word `Open` in `/proc/driver/nvidia/version`.
The way NVIDIA recommends to get the NVIDIA version is by getting it from `/sys/module/nvidia/version`.

By using the old method, neofetch would output the NVIDIA driver like this:
![image](https://user-images.githubusercontent.com/53640879/173181849-a86e68bc-4163-4db1-969d-0660ea3e641b.png)

This PR solves this problem:
![image](https://user-images.githubusercontent.com/53640879/173181866-46c4b7a8-85e2-4345-b1e0-46dac2c9baa8.png)

See https://github.com/NVIDIA/open-gpu-kernel-modules/discussions/297 for more information regarding the new open-kernel NVIDIA driver