### PR TITLE
Fix support for ARM, RISC-V, LoongArch detection

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2206,6 +2206,10 @@ get_cpu() {
                     [[ -z "$cpu" ]] && cpu="$(awk -F':' '/family/ {printf $2; exit}' "$cpu_file")"
                 ;;
 
+                "arm"* | "aarch64")
+                    cpu="$(lscpu | grep "Vendor ID" | sed "s/.*: *//g") $(lscpu | grep "Model name" | sed "s/.*: *//g")"
+                ;;
+		
                 *)
                     cpu="$(awk -F '\\s*: | @' \
                             '/model name|Hardware|Processor|^cpu model|chip type|^cpu type/ {

--- a/neofetch
+++ b/neofetch
@@ -2207,7 +2207,11 @@ get_cpu() {
                 ;;
 
                 "arm"* | "aarch64")
-                    cpu="$(lscpu | grep "Vendor ID" | sed "s/.*: *//g") $(lscpu | grep "Model name" | sed "s/.*: *//g")"
+                    cpu="$(lscpu | awk -F': ' '/Vendor ID/ {print $2; exit}' ) $(lscpu | awk -F': ' '/Model name/ {print $2; exit}')"
+                ;;
+                
+                "riscv"*)
+                    cpu="$(lscpu | awk -F': ' '/uarch/ {print $2; exit}' )"
                 ;;
 		
                 *)

--- a/neofetch
+++ b/neofetch
@@ -2207,13 +2207,24 @@ get_cpu() {
                 ;;
 
                 "arm"* | "aarch64")
-                    cpu="$(lscpu | awk -F': ' '/Vendor ID/ {print $2; exit}' ) $(lscpu | awk -F': ' '/Model name/ {print $2; exit}')"
+                    if [[ $(trim "$distro") == Android* ]]; then
+                    # Android roms have modified cpuinfo that shows CPU model as a string
+                        cpu="$(awk -F '\\s*: | @' \
+                            '/model name|Hardware|Processor|^cpu model|chip type|^cpu type/ {
+                            cpu=$2; if ($1 == "Hardware") exit } END { print cpu }' "$cpu_file")"
+                    else
+                        cpu="$(lscpu | awk -F': ' '/Vendor ID/ {print $2; exit}' ) $(lscpu | awk -F': ' '/Model name/ {print $2; exit}')"
+                    fi
                 ;;
-                
+
                 "riscv"*)
                     cpu="$(awk -F': ' '/uarch/ {print $2; exit}' "$cpu_file")"
                 ;;
-		
+
+                "loongarch"*)
+                    cpu="$(awk -F': ' '/Model/ {print $2; exit}' "$cpu_file")"
+                ;;
+
                 *)
                     cpu="$(awk -F '\\s*: | @' \
                             '/model name|Hardware|Processor|^cpu model|chip type|^cpu type/ {

--- a/neofetch
+++ b/neofetch
@@ -2449,7 +2449,7 @@ get_cpu() {
     cpu="${cpu//, * Compute Cores}"
     cpu="${cpu//Core / }"
     cpu="${cpu//(\"AuthenticAMD\"*)}"
-    cpu="${cpu//with Radeon * Graphics}"
+    cpu="${cpu//with Radeon*Graphics}"
     cpu="${cpu//, altivec supported}"
     cpu="${cpu//FPU*}"
     cpu="${cpu//Chip Revision*}"

--- a/neofetch
+++ b/neofetch
@@ -2209,25 +2209,15 @@ get_cpu() {
                 "arm"* | "aarch64")
                     if [[ $(trim "$distro") == Android* ]]; then
                     # Android roms have modified cpuinfo that shows CPU model as a string
-                        cpu="$(awk -F '\\s*: | @' \
-                            '/model name|Hardware|Processor|^cpu model|chip type|^cpu type/ {
-                            cpu=$2; if ($1 == "Hardware") exit } END { print cpu }' "$cpu_file")"
+                        cpu="$(awk -F':' '/Hardware/ {print $2; exit}' "$cpu_file")"
                     else
                         cpu="$(lscpu | awk -F': ' '/Vendor ID/ {print $2; exit}' ) $(lscpu | awk -F': ' '/Model name/ {print $2; exit}')"
                     fi
                 ;;
 
-                "riscv"*)
-                    cpu="$(awk -F': ' '/uarch/ {print $2; exit}' "$cpu_file")"
-                ;;
-
-                "loongarch"*)
-                    cpu="$(awk -F': ' '/Model/ {print $2; exit}' "$cpu_file")"
-                ;;
-
                 *)
                     cpu="$(awk -F '\\s*: | @' \
-                            '/model name|Hardware|Processor|^cpu model|chip type|^cpu type/ {
+                            '/model name|Model|uarch|Hardware|Processor|^cpu model|chip type|^cpu type/ {
                             cpu=$2; if ($1 == "Hardware") exit } END { print cpu }' "$cpu_file")"
                 ;;
             esac

--- a/neofetch
+++ b/neofetch
@@ -2211,7 +2211,7 @@ get_cpu() {
                 ;;
                 
                 "riscv"*)
-                    cpu="$(lscpu | awk -F': ' '/uarch/ {print $2; exit}' )"
+                    cpu="$(awk -F': ' '/uarch/ {print $2; exit}' "$cpu_file")"
                 ;;
 		
                 *)


### PR DESCRIPTION
## Description

Use lscpu to get name of ARM CPU, tested on HiSilicon and Phytium machines.

cpuinfo shows ARM CPU implementer and model as binary information stored at cpuid register, e.g. `0x48` means HiSilicon, lscpu uses a lookup table to decode that, utilising lscpu could avoid maintaining the lookup table ourselves.

![image](https://user-images.githubusercontent.com/26759054/175783580-364f71f4-f7fd-4556-87f2-07f895d07a29.png)

![image](https://user-images.githubusercontent.com/26759054/175783599-aba7eafc-0ddc-44c3-add8-6d9de8d4d587.png)

### Update 20220731

- added detection for Android, which shows CPU as string in cpuinfo.
- added Loongarch (tested on Loongson 3A5000), RISC-V (to show the uarch, tested on StarFive).

### Update 20220909

- Moved LoongArch and RISC-V to fallback detection, making it more universal.

P.S.:

small bugfix: fixed the bug of that the scripts deleting postfixes not matching those CPUs saying `with Radeon Graphics`