### PR TITLE
Added support for Mac OS X 10.4 Tiger

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2731,6 +2731,11 @@ get_memory() {
                 mem_used="${mem_used/Pages active\: /}"
                 mem_used="${mem_used/\./}"
 
+		pages_inactive=$(vm_stat | grep "Pages inactive")
+		pages_inactive=${pages_inactive/Pages inactive\: /}
+		pages_inactive=${pages_inactive/\./}
+
+		mem_used=$((mem_used + pages_inactive))
                 mem_used=$((mem_used * 4096 / 1048576))
             else
                 hw_pagesize="$(sysctl -n hw.pagesize)"

--- a/neofetch
+++ b/neofetch
@@ -1260,7 +1260,14 @@ get_model() {
             if [[ $(kextstat | grep -F -e "FakeSMC" -e "VirtualSMC") != "" ]]; then
                 model="Hackintosh (SMBIOS: $(sysctl -n hw.model))"
             else
-                model=$(sysctl -n hw.model)
+                if [[ $osx_version =~ "10.4" ]]; then
+                    model="$(system_profiler SPHardwareDataType | grep Machine\ Name\:)"
+                    model=${model/Machine\ Name\:/}
+
+                    model="$model ($(sysctl -n hw.model))"
+                else
+                    model=$(sysctl -n hw.model)  
+                fi
             fi
         ;;
 
@@ -2282,7 +2289,12 @@ get_cpu() {
         ;;
 
         "Mac OS X"|"macOS")
-            cpu="$(sysctl -n machdep.cpu.brand_string)"
+            if [[ $osx_version =~ "10.4" ]]; then
+                cpu="$(system_profiler SPHardwareDataType | grep CPU\ Type)"
+                cpu="${cpu/CPU\ Type\:/}"
+            else
+                cpu="$(sysctl -n machdep.cpu.brand_string)"
+            fi
 
             # Get CPU cores.
             case $cpu_cores in
@@ -2704,13 +2716,25 @@ get_memory() {
         ;;
 
         "Mac OS X" | "macOS" | "iPhone OS")
-            hw_pagesize="$(sysctl -n hw.pagesize)"
-            mem_total="$(($(sysctl -n hw.memsize) / 1024 / 1024))"
-            pages_app="$(($(sysctl -n vm.page_pageable_internal_count) - $(sysctl -n vm.page_purgeable_count)))"
-            pages_wired="$(vm_stat | awk '/ wired/ { print $4 }')"
-            pages_compressed="$(vm_stat | awk '/ occupied/ { printf $5 }')"
-            pages_compressed="${pages_compressed:-0}"
-            mem_used="$(((${pages_app} + ${pages_wired//.} + ${pages_compressed//.}) * hw_pagesize / 1024 / 1024))"
+            if [[ $osx_version =~ "10.4" ]]; then
+                mem_total="$(system_profiler SPHardwareDataType | grep Memory:)"
+                mem_total="${mem_total/Memory\: /}"
+                mem_total="${mem_total/ MB/}"
+
+                mem_used="$(vm_stat | grep Pages\ active\:)"
+                mem_used="${mem_used/Pages active\: /}"
+                mem_used="${mem_used/\./}"
+
+                mem_used=$((mem_used * 4096 / 1048576))
+            else
+                hw_pagesize="$(sysctl -n hw.pagesize)"
+                mem_total="$(($(sysctl -n hw.memsize) / 1024 / 1024))"
+                pages_app="$(($(sysctl -n vm.page_pageable_internal_count) - $(sysctl -n vm.page_purgeable_count)))"
+                pages_wired="$(vm_stat | awk '/ wired/ { print $4 }')"
+                pages_compressed="$(vm_stat | awk '/ occupied/ { printf $5 }')"
+                pages_compressed="${pages_compressed:-0}"
+                mem_used="$(((${pages_app} + ${pages_wired//.} + ${pages_compressed//.}) * hw_pagesize / 1024 / 1024))"
+            fi
         ;;
 
         "BSD" | "MINIX")

--- a/neofetch
+++ b/neofetch
@@ -2292,6 +2292,12 @@ get_cpu() {
             if [[ $osx_version =~ "10.4" ]]; then
                 cpu="$(system_profiler SPHardwareDataType | grep CPU\ Type)"
                 cpu="${cpu/CPU\ Type\:/}"
+                
+                speed="$(system_profiler SPHardwareDataTypes | grep CPU\ Speed)"
+                speed="${speed/CPU\ Speed\:/}"
+
+                cores="$(system_profiler SPHardwareDataType | grep Number\ Of\ CPUs)"
+                cores="${cores/Number\ Of\ CPUs\:/}"
             else
                 cpu="$(sysctl -n machdep.cpu.brand_string)"
             fi

--- a/neofetch
+++ b/neofetch
@@ -1260,7 +1260,7 @@ get_model() {
             if [[ $(kextstat | grep -F -e "FakeSMC" -e "VirtualSMC") != "" ]]; then
                 model="Hackintosh (SMBIOS: $(sysctl -n hw.model))"
             else
-                if [[ $osx_version =~ "10.4" ]]; then
+                if [[ $osx_version =~ "10.4" || $osx_version =~ "10.5" ]]; then
                     model="$(system_profiler SPHardwareDataType | grep Machine\ Name\:)"
                     model=${model/Machine\ Name\:/}
 
@@ -2289,12 +2289,14 @@ get_cpu() {
         ;;
 
         "Mac OS X"|"macOS")
-            if [[ $osx_version =~ "10.4" ]]; then
+            if [[ $osx_version =~ "10.4" || $osx_version =~ "10.5" ]]; then
                 cpu="$(system_profiler SPHardwareDataType | grep CPU\ Type)"
                 cpu="${cpu/CPU\ Type\:/}"
                 
-                speed="$(system_profiler SPHardwareDataTypes | grep CPU\ Speed)"
+                speed="$(system_profiler SPHardwareDataType | grep CPU\ Speed)"
                 speed="${speed/CPU\ Speed\:/}"
+		speed="${speed/ MHz/}"
+		speed="${speed/ GHz/}"
 
                 cores="$(system_profiler SPHardwareDataType | grep Number\ Of\ CPUs)"
                 cores="${cores/Number\ Of\ CPUs\:/}"
@@ -2722,7 +2724,7 @@ get_memory() {
         ;;
 
         "Mac OS X" | "macOS" | "iPhone OS")
-            if [[ $osx_version =~ "10.4" ]]; then
+            if [[ $osx_version =~ "10.4" || $osx_version =~ "10.5" ]]; then
                 mem_total="$(system_profiler SPHardwareDataType | grep Memory:)"
                 mem_total="${mem_total/Memory\: /}"
                 mem_total="${mem_total/ MB/}"


### PR DESCRIPTION
## Description
Added support for Mac OS X 10.4 Tiger, but should work on other old versions of OS X, which I have not enabled as this is the only one I currently have to test with.

I changed it to parse data from the `system_profiler` and `vm_stat` for 10.4.x

Tested on iMac G4 running version 10.4.11

![1emsyx](https://user-images.githubusercontent.com/478279/177268952-da2f9693-d46a-4527-91db-f1ffbb4246e0.png)



## Features

## Issues
The current methods being used for OSX case in `get_cpu()` and `get_memory()` do not work on this version of OS X and causes neofetch to exit early.
## TODO
