### PR TITLE
Improve detect NixOS version

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -999,6 +999,13 @@ get_distro() {
                     *) distro="OS Elbrus $(< /etc/mcst_version)"
                 esac
 
+            elif [[ -f /etc/NIXOS ]]; then
+                case $distro_shorthand in
+                    on) distro="NixOS $(nixos-version | awk '{print substr($1,0,5),$2}')" ;;
+                    tiny) distro="NixOS" ;;
+                    *) distro="NixOS $(nixos-version)" ;;
+                esac
+
             elif type -p pveversion >/dev/null; then
                 case $distro_shorthand in
                     on|tiny) distro="Proxmox VE" ;;


### PR DESCRIPTION
## Description
Improve detect NixOS version

Before PR:
```
neofetch --off --distro_shorthand on | grep OS
OS: nixos 22.11 x86_64

neofetch --off --distro_shorthand tiny | grep OS
OS: nixos x86_64

neofetch --off --distro_shorthand off | grep OS
OS: NixOS 22.11 (Raccoon) x86_64
```

After PR:
```
neofetch --off --distro_shorthand on | grep OS
OS: NixOS 22.11 (Raccoon) x86_64

neofetch --off --distro_shorthand tiny | grep OS
OS: NixOS x86_64

neofetch --off --distro_shorthand off | grep OS
OS: NixOS 22.11.git.31109649164 (Raccoon) x86_64
```