### PR TITLE
Add Ubuntu Touch support

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1549,6 +1549,7 @@ get_packages() {
             has kiss       && tot kiss l
             has cpt-list   && tot cpt-list
             has pacman-key && tot pacman -Qq --color never
+            has click      && tot click list
             has dpkg       && tot dpkg-query -f '.\n' -W
             has xbps-query && tot xbps-query -l
             has apk        && tot apk info

--- a/neofetch
+++ b/neofetch
@@ -1244,7 +1244,7 @@ get_distro() {
 get_model() {
     case $os in
         Linux)
-            if [[ -d /usr/bin/system-image-cli || -d /system/app/ ]]; then
+            if [[ -d /android/system/ || -d /system/app/ ]]; then
                 model="$(getprop ro.product.brand) $(getprop ro.product.model)"
 
             elif [[ -f /sys/devices/virtual/dmi/id/board_vendor ||

--- a/neofetch
+++ b/neofetch
@@ -1244,7 +1244,7 @@ get_distro() {
 get_model() {
     case $os in
         Linux)
-            if [[ -d /system/app/ && -d /system/priv-app ]]; then
+            if [[ -d /usr/bin/system-image-cli || -d /system/app/ ]]; then
                 model="$(getprop ro.product.brand) $(getprop ro.product.model)"
 
             elif [[ -f /sys/devices/virtual/dmi/id/board_vendor ||

--- a/neofetch
+++ b/neofetch
@@ -805,7 +805,7 @@ image_source="auto"
 #       SereneLinux, SharkLinux, Siduction, SkiffOS, Slackware, SliTaz, SmartOS,
 #       Solus, Source_Mage, Sparky, Star, SteamOS, SunOS, openSUSE_Leap, t2,
 #       openSUSE_Tumbleweed, openSUSE, SwagArch, Tails, Trisquel,
-#       Ubuntu-Cinnamon, Ubuntu-Budgie, Ubuntu-GNOME, Ubuntu-MATE,
+#       Ubuntu-Cinnamon, Ubuntu-Budgie, Ubuntu-GNOME, Ubuntu Touch, Ubuntu-MATE,
 #       Ubuntu-Studio, Ubuntu, Univention, Venom, Void, VNux, LangitKetujuh, semc,
 #       Obarun, windows10, Windows7, Xubuntu, Zorin, and IRIX have ascii logos.
 # NOTE: Arch, Ubuntu, Redhat, Fedora and Dragonfly have 'old' logo variants.
@@ -1123,6 +1123,14 @@ get_distro() {
 
             distro=$(trim_quotes "$distro")
             distro=${distro/NAME=}
+
+            if [[ -f /usr/bin/system-image-cli ]]; then
+                export ut_ota = $(system-image-cli -i | awk '/version tag:/ { print $3 }');
+                distro="Ubuntu Touch $ut_ota";
+
+                # There's a weird UT bug where the HOSTNAME is set to android.
+                export HOSTNAME=$(hostname);
+            fi
 
             # Get Ubuntu flavor.
             if [[ $distro == "Ubuntu"* ]]; then
@@ -10937,6 +10945,20 @@ ${c4}     `ooooo    ${c3}``    ${c4}.oooo
 ${c4}       `soooo.     .oooo`
          `\/oooooooooo`
             ``\/oo``
+EOF
+        ;;
+
+        "Ubuntu Touch"*)
+            set_colors 3 7
+            read -rd '' ascii_data <<'EOF'
+${c1}
+     ###############
+   ##               ##
+  ##  ${c2}##${c1}         ${c2}##${c1}  ##
+  ##  ${c2}##${c1}  ${c2}#${c1}   ${c2}#${c1}  ${c2}##${c1}  ##
+  ##       ${c2}###${c1}       ##
+   ##               ##
+     ###############
 EOF
         ;;
 

--- a/neofetch
+++ b/neofetch
@@ -1125,7 +1125,8 @@ get_distro() {
             distro=${distro/NAME=}
 
             if [[ -f /usr/bin/system-image-cli ]]; then
-                export ut_ota=$(system-image-cli -i | awk '/version tag:/ { print $3 }');
+            	local ut_ota
+                ut_ota=$(system-image-cli -i | awk '/version tag:/ { print $3 }');
                 distro="Ubuntu Touch $ut_ota";
 
                 # There's a weird UT bug where the HOSTNAME is set to android.

--- a/neofetch
+++ b/neofetch
@@ -1125,11 +1125,11 @@ get_distro() {
             distro=${distro/NAME=}
 
             if [[ -f /usr/bin/system-image-cli ]]; then
-                export ut_ota = $(system-image-cli -i | awk '/version tag:/ { print $3 }');
+                export ut_ota=$(system-image-cli -i | awk '/version tag:/ { print $3 }');
                 distro="Ubuntu Touch $ut_ota";
 
                 # There's a weird UT bug where the HOSTNAME is set to android.
-                export HOSTNAME=$(hostname);
+                HOSTNAME=$(hostname);
             fi
 
             # Get Ubuntu flavor.


### PR DESCRIPTION
## Description
Ubuntu Touch is an Ubuntu-based community-maintained mobile Linux distro. It has its own system of confined `click` packages and `system-image` for image-based OTA updates. This PR detects UT by the presence of `/usr/bin/system-image-cli`, uses `awk` to parse the current image version, and counts the user's `click` packages.

## Status (Todo):
 - [ ] Test the OTA version retrieval and add add release channel support