### PR TITLE
Show macOS Ventura name

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1155,6 +1155,7 @@ get_distro() {
                 10.16*) codename="macOS Big Sur" ;;
                 11.*)  codename="macOS Big Sur" ;;
                 12.*)  codename="macOS Monterey" ;;
+		13.*)  codename="macOS Ventura" ;;
                 *)      codename=macOS ;;
             esac
 


### PR DESCRIPTION
## Description

Show the full name of macOS Ventura instead of just "macOS 13.0"
