### PR TITLE
Correct architecture detection on *BSD

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1218,7 +1218,7 @@ get_distro() {
 
     # Get OS architecture.
     case $os in
-        Solaris|AIX|Haiku|IRIX|FreeMiNT)
+        Solaris|AIX|Haiku|IRIX|FreeMiNT|BSD)
             machine_arch=$(uname -p)
         ;;
 


### PR DESCRIPTION
FreeBSD uses uname -p, NetBSD also according to https://www.pkgsrc.org/

## Description

Corrects architecture printing on *BSD.