### PR TITLE
Enhancing --memory_unit functionality

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -172,7 +172,7 @@ memory_percent="off"
 # Change memory output unit.
 #
 # Default: 'mib'
-# Values:  'kib', 'mib', 'gib'
+# Values:  'kib', 'mib', 'gib', 'tib'
 # Flag:    --memory_unit
 #
 # Example:

--- a/neofetch
+++ b/neofetch
@@ -2812,22 +2812,22 @@ get_memory() {
             mem_label=TiB
             memory_unit_divider=$((1024 * 1024))
             printf -v mem_used "%'.*f" \
-                        ${mem_precision} \
-                        $(($mem_used / $memory_unit_divider)).$(($mem_used % $memory_unit_divider))
+                        "${mem_precision}" \
+                        $((mem_used / memory_unit_divider)).$((mem_used % memory_unit_divider))
             printf -v mem_total "%'.*f" \
-                        ${mem_precision} \
-                        $(($mem_total / $memory_unit_divider)).$(($mem_total % $memory_unit_divider))
+                        "${mem_precision}" \
+                        $((mem_total / memory_unit_divider)).$((mem_total % memory_unit_divider))
         ;;
 
         gib)
             mem_label=GiB
             memory_unit_divider=1024
             printf -v mem_used "%'.*f" \
-                        ${mem_precision} \
-                        $(($mem_used / $memory_unit_divider)).$(($mem_used % $memory_unit_divider))
+                        "${mem_precision}" \
+                        $((mem_used / memory_unit_divider)).$((mem_used % memory_unit_divider))
             printf -v mem_total "%'.*f" \
-                        ${mem_precision} \
-                        $(($mem_total / $memory_unit_divider)).$(($mem_total % $memory_unit_divider))
+                        "${mem_precision}" \
+                        $((mem_total / memory_unit_divider)).$((mem_total % memory_unit_divider))
         ;;
 
         kib)

--- a/neofetch
+++ b/neofetch
@@ -2810,6 +2810,11 @@ get_memory() {
     # Creates temp variables: memory_unit_divider, memory_unit_multiplier
     memory_unit_divider=1
     memory_unit_multiplier=1
+
+    # Keep a copy of the original megabyte values because progress bar need them
+    mu_mb="$mem_used"
+    mt_mb="$mem_total"
+
     case $memory_unit in
         tib)
             mem_label=TiB
@@ -2823,9 +2828,10 @@ get_memory() {
 
         kib)
             mem_label=KiB
-	    memory_unit_multiplier=1024
+            memory_unit_multiplier=1024
         ;;
     esac
+
     # Uses temp variables from above: memory_unit_divider, memory_unit_multiplier
     if test "$memory_unit_divider" -ge 1; then
             printf -v mem_used "%'.*f" \
@@ -2843,9 +2849,9 @@ get_memory() {
 
     # Bars.
     case $memory_display in
-        "bar")     memory="$(bar "${mem_used}" "${mem_total}")" ;;
-        "infobar") memory="${memory} $(bar "${mem_used}" "${mem_total}")" ;;
-        "barinfo") memory="$(bar "${mem_used}" "${mem_total}")${info_color} ${memory}" ;;
+        "bar")     memory="$(bar "${mu_mb}" "${mt_mb}")" ;;
+        "infobar") memory="${memory} $(bar "${mu_mb}" "${mt_mb}")" ;;
+        "barinfo") memory="$(bar "${mu_mb}" "${mt_mb}")${info_color} ${memory}" ;;
     esac
 }
 

--- a/neofetch
+++ b/neofetch
@@ -2807,6 +2807,9 @@ get_memory() {
 
     [[ "$memory_percent" == "on" ]] && ((mem_perc=mem_used * 100 / mem_total))
 
+    # Creates temp variables: memory_unit_divider, memory_unit_multiplier
+    memory_unit_divider=1
+    memory_unit_multiplier=1
     case $memory_unit in
         tib)
             mem_label=TiB
@@ -2820,24 +2823,21 @@ get_memory() {
 
         kib)
             mem_label=KiB
+	    memory_unit_multiplier=1024
         ;;
     esac
-
-    case $mem_label in
-        GiB|TiB)
+    # Uses temp variables from above: memory_unit_divider, memory_unit_multiplier
+    if test "$memory_unit_divider" -ge 1; then
             printf -v mem_used "%'.*f" \
                         "${mem_precision}" \
                         $((mem_used / memory_unit_divider)).$((mem_used % memory_unit_divider))
             printf -v mem_total "%'.*f" \
                         "${mem_precision}" \
                         $((mem_total / memory_unit_divider)).$((mem_total % memory_unit_divider))
-        ;;
-
-        KiB)
-            mem_used=$((mem_used * 1024))
-            mem_total=$((mem_total * 1024))
-	;;
-    esac
+    elif test "$memory_unit_multiplier" -ge 1; then
+            mem_used=$((mem_used * memory_unit_multiplier))
+            mem_total=$((mem_total * memory_unit_multiplier))
+    fi
 
     memory="${mem_used}${mem_label:-MiB} / ${mem_total}${mem_label:-MiB} ${mem_perc:+(${mem_perc}%)}"
 

--- a/neofetch
+++ b/neofetch
@@ -181,6 +181,12 @@ memory_percent="off"
 # gib: ' 0.98GiB / 6.79GiB'
 memory_unit="mib"
 
+# Change memory output precision.
+#
+# Default: '2'
+# Values: integer ≥ 0
+# Flag:    --memory_precision
+mem_precision=2
 
 # Packages
 
@@ -2806,10 +2812,10 @@ get_memory() {
             mem_label=TiB
             memory_unit_divider=$((1024 * 1024))
             printf -v mem_used "%'.*f" \
-                        ${mem_precision:-2} \
+                        ${mem_precision} \
                         $(($mem_used / $memory_unit_divider)).$(($mem_used % $memory_unit_divider))
             printf -v mem_total "%'.*f" \
-                        ${mem_precision:-2} \
+                        ${mem_precision} \
                         $(($mem_total / $memory_unit_divider)).$(($mem_total % $memory_unit_divider))
         ;;
 
@@ -2817,10 +2823,10 @@ get_memory() {
             mem_label=GiB
             memory_unit_divider=1024
             printf -v mem_used "%'.*f" \
-                        ${mem_precision:-2} \
+                        ${mem_precision} \
                         $(($mem_used / $memory_unit_divider)).$(($mem_used % $memory_unit_divider))
             printf -v mem_total "%'.*f" \
-                        ${mem_precision:-2} \
+                        ${mem_precision} \
                         $(($mem_total / $memory_unit_divider)).$(($mem_total % $memory_unit_divider))
         ;;
 
@@ -5088,6 +5094,7 @@ INFO:
     --song_shorthand on/off     Print the Artist/Album/Title on separate lines.
     --memory_percent on/off     Display memory percentage.
     --memory_unit (k/m/g/t)ib   Memory output unit.
+    --memory_precision integer  Change memory output precision. (≥0, default=2)
     --music_player player-name  Manually specify a player to use.
                                 Available values are listed in the config file
 
@@ -5297,6 +5304,7 @@ get_args() {
             "--music_player") music_player="$2" ;;
             "--memory_percent") memory_percent="$2" ;;
             "--memory_unit") memory_unit="$2" ;;
+	    "--memory_precision") mem_precision="$2" ;;
             "--cpu_temp")
                 cpu_temp="$2"
                 [[ "$cpu_temp" == "on" ]] && cpu_temp="C"

--- a/neofetch
+++ b/neofetch
@@ -2802,10 +2802,26 @@ get_memory() {
     [[ "$memory_percent" == "on" ]] && ((mem_perc=mem_used * 100 / mem_total))
 
     case $memory_unit in
+        tib)
+            mem_label=TiB
+            memory_unit_divider=$((1024 * 1024))
+            printf -v mem_used "%'.*f" \
+                        ${mem_precision:-2} \
+                        $(($mem_used / $memory_unit_divider)).$(($mem_used % $memory_unit_divider))
+            printf -v mem_total "%'.*f" \
+                        ${mem_precision:-2} \
+                        $(($mem_total / $memory_unit_divider)).$(($mem_total % $memory_unit_divider))
+        ;;
+
         gib)
-            mem_used=$(awk '{printf "%.2f", $1 / $2}' <<< "$mem_used 1024")
-            mem_total=$(awk '{printf "%.2f", $1 / $2}' <<< "$mem_total 1024")
             mem_label=GiB
+            memory_unit_divider=1024
+            printf -v mem_used "%'.*f" \
+                        ${mem_precision:-2} \
+                        $(($mem_used / $memory_unit_divider)).$(($mem_used % $memory_unit_divider))
+            printf -v mem_total "%'.*f" \
+                        ${mem_precision:-2} \
+                        $(($mem_total / $memory_unit_divider)).$(($mem_total % $memory_unit_divider))
         ;;
 
         kib)

--- a/neofetch
+++ b/neofetch
@@ -2716,7 +2716,7 @@ get_memory() {
             pages_wired="$(vm_stat | awk '/ wired/ { print $4 }')"
             pages_compressed="$(vm_stat | awk '/ occupied/ { printf $5 }')"
             pages_compressed="${pages_compressed:-0}"
-            mem_used="$(((${pages_app} + ${pages_wired//.} + ${pages_compressed//.}) * hw_pagesize / 1024 / 1024))"
+            mem_used="$(((pages_app + ${pages_wired//.} + ${pages_compressed//.}) * hw_pagesize / 1024 / 1024))"
         ;;
 
         "BSD" | "MINIX")

--- a/neofetch
+++ b/neofetch
@@ -2811,17 +2811,20 @@ get_memory() {
         tib)
             mem_label=TiB
             memory_unit_divider=$((1024 * 1024))
-            printf -v mem_used "%'.*f" \
-                        "${mem_precision}" \
-                        $((mem_used / memory_unit_divider)).$((mem_used % memory_unit_divider))
-            printf -v mem_total "%'.*f" \
-                        "${mem_precision}" \
-                        $((mem_total / memory_unit_divider)).$((mem_total % memory_unit_divider))
         ;;
 
         gib)
             mem_label=GiB
             memory_unit_divider=1024
+        ;;
+
+        kib)
+            mem_label=KiB
+        ;;
+    esac
+
+    case $mem_label in
+        GiB|TiB)
             printf -v mem_used "%'.*f" \
                         "${mem_precision}" \
                         $((mem_used / memory_unit_divider)).$((mem_used % memory_unit_divider))
@@ -2830,11 +2833,10 @@ get_memory() {
                         $((mem_total / memory_unit_divider)).$((mem_total % memory_unit_divider))
         ;;
 
-        kib)
+        KiB)
             mem_used=$((mem_used * 1024))
             mem_total=$((mem_total * 1024))
-            mem_label=KiB
-        ;;
+	;;
     esac
 
     memory="${mem_used}${mem_label:-MiB} / ${mem_total}${mem_label:-MiB} ${mem_perc:+(${mem_perc}%)}"

--- a/neofetch
+++ b/neofetch
@@ -5087,7 +5087,7 @@ INFO:
     --song_format format        Print the song data in a specific format (see config file).
     --song_shorthand on/off     Print the Artist/Album/Title on separate lines.
     --memory_percent on/off     Display memory percentage.
-    --memory_unit kib/mib/gib   Memory output unit.
+    --memory_unit (k/m/g/t)ib   Memory output unit.
     --music_player player-name  Manually specify a player to use.
                                 Available values are listed in the config file
 


### PR DESCRIPTION
## Description

Improving https://github.com/dylanaraps/neofetch/commit/0435dcd0cd44bb22afa9b986f15742cc05de7b20


## Features

- Implementing https://github.com/dylanaraps/neofetch/issues/1170#issuecomment-455576889 to avoid awk usage.
- Adding ability to configure precision of output using `mem_precision` which defaults to `2`.
- Added `tib` to accommodate TiB mentioned in https://github.com/dylanaraps/neofetch/issues/1170#issuecomment-894705941
