### PR TITLE
Fixes the broken progress bars that result from particular distro colors

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -4717,7 +4717,7 @@ set_text_colors() {
 
     case ${bar_color_total}${1} in
         distro[736]) bar_color_total=$(color "$1") ;;
-        distro[0-9]) bar_color_total=$(color "$2") ;;
+        distro*)     bar_color_total=$(color "$2") ;;
         *)           bar_color_total=$(color "$bar_color_total") ;;
     esac
 }


### PR DESCRIPTION
A distro like Feodra that uses a two–digit color wouldn’t match either of the first two patterns, and would end up trying to use the string “distro” as a color value.

Fixes #2226.