### PR TITLE
Corrected spacing issue on LMDE logo

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -8349,7 +8349,7 @@ EOF
         "LMDE"*)
             set_colors 2 7
             read -rd '' ascii_data <<'EOF'
-         ${c2}`.-::---..
+${c2}          `.-::---..
 ${c1}      .:++++ooooosssoo:.
     .+o++::.      `.:oos+.
 ${c1}   :oo:.`             -+oo${c2}:


### PR DESCRIPTION
The top line of the LMDE logo was missing the correct spacing to properly align with the rest of the logo

## Description

Only fill in the fields below if relevant.


## Features

## Issues

## TODO
