### PR TITLE
Fix display of $XDG_SESSION_TYPE

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1883,8 +1883,8 @@ get_de() {
     # TODO:
     #  - New config option + flag: --de_display_server on/off ?
     #  - Add display of X11, Arcan and anything else relevant.
-    [[ $de && $WAYLAND_DISPLAY ]] &&
-        de+=" (Wayland)"
+    [[ $de ]] &&
+        de+=" (${XDG_SESSION_TYPE})"
 
     de_run=1
 }


### PR DESCRIPTION
## Description

- Fixed display `$XDG_SESSION_TYPE`


## Features

![Screenshot-from-2022-11-11-12-48-48-709x379](https://user-images.githubusercontent.com/1203834/201334460-3d286277-9e80-4691-a40d-fcb13c643685.png)


## Issues
Was not displaying `$XDG_SESSION_TYPE`
