### PR TITLE
Add dwl to wayland window managers

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1911,6 +1911,7 @@ get_wm() {
                                -e asc \
                                -e clayland \
                                -e dwc \
+			       -e dwl \
                                -e fireplace \
                                -e gnome-shell \
                                -e greenfield \


### PR DESCRIPTION
## Description
dwl is now detected by neofetch

## Features
dwl Window Manager is now detected by neofetch

## Issues
without this patch, neofetch falsely detects the current WM as sway instead of dwl. due to the fact that most dwl users use `swaybg` to set their background which is grepped from the output of `ps`.