### PR TITLE
Fix "with Radeon Graphics" filter not working on some APUs

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2449,7 +2449,7 @@ get_cpu() {
     cpu="${cpu//, * Compute Cores}"
     cpu="${cpu//Core / }"
     cpu="${cpu//(\"AuthenticAMD\"*)}"
-    cpu="${cpu//with Radeon * Graphics}"
+    cpu="${cpu//with Radeon* Graphics}"
     cpu="${cpu//, altivec supported}"
     cpu="${cpu//FPU*}"
     cpu="${cpu//Chip Revision*}"


### PR DESCRIPTION
## Description

On my machine (Fedora 37; AMD Ryzen 5 4600G) the "with Radeon Graphics" bit is not properly filtered out since there is nothing between the words Radeon and Graphics in its cpuinfo


## Features

## Issues

## TODO
