### PR TITLE
feat: display editor setting

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -62,6 +62,7 @@ print_info() {
     info "Uptime" uptime
     info "Packages" packages
     info "Shell" shell
+    info "Editor" editor
     info "Resolution" resolution
     info "DE" de
     info "WM" wm
@@ -222,6 +223,32 @@ shell_path="off"
 # on:  'bash 4.4.5'
 # off: 'bash'
 shell_version="on"
+
+
+# Editor
+
+
+# Show path to $EDITOR
+#
+# Default: 'off'
+# Values:  'on', 'off'
+# Flag:    --editor_path
+#
+# Example:
+# on:  '/opt/bin/vim'
+# off: 'vim'
+editor_path="off"
+
+# Show $EDITOR version
+#
+# Default:  'on'
+# Values:   'on', 'off'
+# Flag:     '--editor_version'
+#
+# Example:
+# on:  'vim 9.0'
+# off: 'vim'
+editor_version="on"
 
 
 # CPU
@@ -1766,6 +1793,38 @@ get_shell() {
     shell=${shell/xonsh\//xonsh }
     shell=${shell/options*}
     shell=${shell/\(*\)}
+}
+
+get_editor() {
+    local editor_full_path="${VISUAL:-$EDITOR}"
+
+    # in case neither is set just return
+    [[ -z "$editor_full_path" ]] && return
+
+    case $editor_path in
+        on)  editor="${editor_full_path} " ;;
+        off) editor="${editor_full_path##*/} " ;;
+    esac
+
+    # in case editor version is not demanded don't bother parsing it
+    [[ $editor_version != on ]] && return
+
+    case ${editor_name:=${editor_full_path##*/}} in
+        nano|vim)
+            editor+=$("$editor_full_path" --version 2>&1)
+            editor="${editor/$'\n'*}"
+            editor="${editor/$editor_name }"
+        ;;
+        *)
+            editor+=$("$editor_full_path" --version 2>&1)
+            editor="${editor/$'\n'*}"
+        ;;
+    esac
+
+    # remove some common unwanted info from version strings
+    editor=${editor/, version}
+    editor=${editor/options*}
+    editor=${editor/\(*\)}
 }
 
 get_de() {
@@ -5047,6 +5106,8 @@ INFO:
     --gtk3 on/off               Enable/Disable gtk3 theme/font/icons output
     --shell_path on/off         Enable/Disable showing \$SHELL path
     --shell_version on/off      Enable/Disable showing \$SHELL version
+    --editor_path on/off        Enable/Disable showing \$EDITOR path
+    --editor_version on/off     Enable/Disable showing \$EDITOR version
     --disk_show value           Which disks to display.
                                 Possible values: '/', '/dev/sdXX', '/path/to/mount point'
 
@@ -5263,6 +5324,8 @@ get_args() {
             "--gtk3") gtk3="$2" ;;
             "--shell_path") shell_path="$2" ;;
             "--shell_version") shell_version="$2" ;;
+            "--editor_path") editor_path="$2" ;;
+            "--editor_version") editor_version="$2" ;;
             "--ip_host") public_ip_host="$2" ;;
             "--ip_timeout") public_ip_timeout="$2" ;;
             "--ip_interface")

--- a/neofetch.1
+++ b/neofetch.1
@@ -125,6 +125,12 @@ Enable/Disable showing $SHELL path
 \fB\-\-shell_version\fR on/off
 Enable/Disable showing $SHELL version
 .TP
+\fB\-\-editor_path\fR on/off
+Enable/Disable showing $VISUAL or $EDITOR path
+.TP
+\fB\-\-editor_version\fR on/off
+Enable/Disable showing $VISUAL or $EDITOR version
+.TP
 \fB\-\-disk_show\fR value
 Which disks to display.
 Possible values: '/', '/dev/sdXX', '/path/to/mount point'


### PR DESCRIPTION
![Screenshot at 2022-12-28 17-31-19](https://user-images.githubusercontent.com/17141774/209843188-ddf121b4-f238-46ba-9205-20d9fec7103c.png)


Display the configured editor, version and path using the $EDITOR environment variable similar to the way the shell version is displayed from the $SHELL variable.

fixes: #2270

## TODO

- [x] Manpage
