### PR TITLE
Fall back to host name if model name is not found.

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1253,6 +1253,9 @@ get_model() {
 
             elif [[ -f /tmp/sysinfo/model ]]; then
                 model=$(< /tmp/sysinfo/model)
+
+            elif [[ -f /etc/hostname ]]; then
+                model="$(< /etc/hostname)"
             fi
         ;;
 


### PR DESCRIPTION
## Description
On Debian GNU/Linux 11 (bullseye) on WSL, the device model is not shown, since none of the files `get_model` searches for are present. One might consider falling back to the host name in that case.


## Features

## Issues

## TODO
