### PR TITLE
🔧 [fix] battery bar elapsed maths incorrect #2275

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3841,9 +3841,9 @@ get_battery() {
     [[ "$battery_state" ]] && battery+=" Charging"
 
     case $battery_display in
-        "bar")     battery="$(bar "${battery/\%*}" 100)" ;;
-        "infobar") battery="${battery} $(bar "${battery/\%*}" 100)" ;;
-        "barinfo") battery="$(bar "${battery/\%*}" 100)${info_color} ${battery}" ;;
+        "bar")     battery="$(bar "$((100-${battery/\%*}))" 100)" ;;
+        "infobar") battery="${battery} $(bar "$((100-${battery/\%*}))" 100)" ;;
+        "barinfo") battery="$(bar "$((100-${battery/\%*}))" 100)${info_color} ${battery}" ;;
     esac
 }
 


### PR DESCRIPTION
Description

Battery at 94% charged (so 6% used). barinfo shows 94% elapsed when it should show 6% elapsed. line 3844 to 3846 should say `$((100-${battery/\%*}))` instead of `${battery/\%*}`

incorrect actual behaviour:
![actual](https://user-images.githubusercontent.com/60593422/210526332-f9af1ca6-e63a-48fa-8153-8087beebb1be.png)

expected behaviour:
![expected](https://user-images.githubusercontent.com/60593422/210526367-af619b49-ae3f-4d9b-b3b4-919253d3b356.png)

## Features

## Issues
fixes: #2275 

## TODO
