### PR TITLE
Add terminal `gnome-console`

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3327,6 +3327,7 @@ get_term() {
             ;;
 
             "gnome-terminal-") term="gnome-terminal" ;;
+            "kgx")             term="gnome-console" ;;
             "urxvtd")          term="urxvt" ;;
             *"nvim")           term="Neovim Terminal" ;;
             *"NeoVimServer"*)  term="VimR Terminal" ;;


### PR DESCRIPTION
Added terminal `gnome-console` for the term `kgx`.

**References:**
website: https://apps.gnome.org/app/org.gnome.Console/
git: https://gitlab.gnome.org/GNOME/console/