### PR TITLE
simple improvements for Solaris

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1347,7 +1347,7 @@ get_model() {
         Solaris)
             model=$(prtconf -b | awk -F':' '/banner-name/ {printf $2}')
             virt=$(/usr/bin/uname -V)
-            if [ $? == 0 ] && [ "$virt" != "non-virtualized" ]; then
+            if virt=$(/usr/bin/uname -V) && [[ "$virt" != "non-virtualized" ]]; then
                 model="${model:-$(uname -i)} (${virt})"
             fi
         ;;

--- a/neofetch
+++ b/neofetch
@@ -1346,6 +1346,10 @@ get_model() {
 
         Solaris)
             model=$(prtconf -b | awk -F':' '/banner-name/ {printf $2}')
+            virt=$(/usr/bin/uname -V)
+            if [ $? == 0 ] && [ "$virt" != "non-virtualized" ]; then
+                model="${model:-$(uname -i)} (${virt})"
+            fi
         ;;
 
         AIX)
@@ -1407,6 +1411,15 @@ get_kernel() {
         kernel=${kernel/Version}
         return
     }
+
+    [[ $os == Solaris ]] && {
+        ver=$(uname -v)
+        case $ver in
+            11.[0123]) ;;
+            *) kernel=${ver} ;;
+        esac
+        return
+    }  
 
     case $kernel_shorthand in
         on)  kernel=$kernel_version ;;


### PR DESCRIPTION
## Description

I'm proposing 2 simple improvements for neofetch on Oracle Solaris:

1) current version always reports "Kernel" as 5.11 on Solaris 11 (and newer) which is not very useful. I'm proposing printing the full version string, including the SRU number. The Solaris Repository Update is a vehicle Oracle uses to deliver fixes and updates to Solaris.

2) adding information about the virtualization environment to the "Host" line - neofetch will display whether the system runs within a VirtualBox, Non-Global Zone, LDOM etc.
 
## Examples

(logos omitted because they break formatting)

### Solaris 11.4 SRU49 on an x86 running in VirtualBox

      foo@example.org
      --------------
      OS: Oracle Solaris 11.4 i386
      Host: i86pc (virtualbox)
      Kernel: 11.4.49.126.2
      Uptime: 3 mins
      Packages: 236 (pkginfo)
      Shell: bash 5.1.16
      Terminal: /dev/pts/2
      CPU: Intel Xeon E5-2690 v2 @ 2.992GHz
      Memory: 2958MiB / 4095MiB

### Solaris 11.4 SRU29 on a bare metal T5-2 SPARC system

      foo@example.org
      --------------------
      OS: Oracle Solaris 11.4 sparc
      Host: SPARC T5-2
      Kernel: 11.4.27.82.1
      Uptime: 9 days, 29 mins
      Packages: 219 (pkginfo)
      Shell: bash 5.0.17
      Terminal: /dev/pts/1
      CPU: SPARC-T5 (chipid 1, clock 3600 MHz) @ 3.600GHz
      Memory: 23448MiB / 523264MiB

### Solaris 11.4 SRU52 in a zone on an x86

      foo@example.org
      -------------
      OS: Oracle Solaris 11.4 i386
      Host: i86pc (non-global-zone)
      Kernel: 11.4.52.132.2
      Uptime: 2 days, 2 hours, 56 mins
      Packages: 107 (pkginfo)
      Shell: bash 5.1.16
      Terminal: /dev/pts/4
      CPU: Intel Celeron G1610T @ 2.295GHz
      Memory: 1345MiB / 2048MiB

### Solaris 10 Update 11 on a SPARC workstation

      foo@example.org
      ------------
      OS: Oracle Solaris 10 sparc
      Host: Sun Blade 1500
      Kernel: Generic_150400-48
      Uptime: 51 mins
      Packages: 2474 (pkginfo)
      Shell: bash 4.3.33
      Resolution: 1920x1200
      DE: GNOME
      Terminal: gnome-terminal
      CPU: UltraSPARC-IIIi (1) @ 1.503GHz
      Memory: 1723MiB / 3996MiB