### PR TITLE
Fix Chrome OS.

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1066,7 +1066,7 @@ get_distro() {
             # Chrome OS doesn't conform to the /etc/*-release standard.
             # While the file is a series of variables they can't be sourced
             # by the shell since the values aren't quoted.
-            elif [[ -f /etc/lsb-release && $(< /etc/lsb-release) == *CHROMEOS* ]]; then
+            elif grep -q CHROMEOS /etc/lsb-release; then
                 distro='Chrome OS'
 
             elif type -p guix >/dev/null; then
@@ -1112,11 +1112,14 @@ get_distro() {
                 esac
 
             elif [[ $(< /proc/version) == *chrome-bot* || -f /dev/cros_ec ]]; then
+                # gets chrome os version from /etc/lsb-release.
+                # totally not written by chatgpt :trolley:
+                cros_version=$(grep -oE 'CHROMEOS_RELEASE_BRANCH_NUMBER=([0-9]+)' /etc/lsb-release | cut -d= -f2)
                 [[ $distro != *Chrome* ]] &&
                     case $distro_shorthand in
-                        on)   distro+=" [Chrome OS]" ;;
-                        tiny) distro="Chrome OS" ;;
-                        *)    distro+=" on Chrome OS" ;;
+                        on)   distro+=" [Chrome OS $cros_version]" ;;
+                        tiny) distro="Chrome OS $cros_version" ;;
+                        *)    distro+="Chrome OS $cros_version" ;;
                     esac
                     distro=${distro## on }
             fi

--- a/neofetch
+++ b/neofetch
@@ -1114,7 +1114,7 @@ get_distro() {
             elif [[ $(< /proc/version) == *chrome-bot* || -f /dev/cros_ec ]]; then
                 # gets chrome os version from /etc/lsb-release.
                 # totally not written by chatgpt :trolley:
-                cros_version=$(grep -oE 'CHROMEOS_RELEASE_BRANCH_NUMBER=([0-9]+)' /etc/lsb-release | cut -d= -f2)
+                cros_version=$(grep -oE 'CHROMEOS_RELEASE_CHROME_MILESTONE=([0-9]+)' /etc/lsb-release | cut -d= -f2)
                 [[ $distro != *Chrome* ]] &&
                     case $distro_shorthand in
                         on)   distro+=" [Chrome OS $cros_version]" ;;


### PR DESCRIPTION
## Description
Adds proper Chrome OS support to neofetch. 

### Example output (Dell Chromebook 3100):
```


            .,:loool:,.               root@localhost 
        .,coooooooooooooc,.           -------------- 
     .,lllllllllllllllllllll,.        OS: Chrome OS 107 x86_64 
    ;ccccccccccccccccccccccccc;       Host: Google Fleex 
  'ccccccccccccccccccccccccccccc.     Kernel: 4.14.288-19299-gc573ee6f5c5f 
 ,ooc::::::::okO0000OOkkkkkkkkkkk:    Uptime: 42 mins 
.ooool;;;;:xK0kxxxxxk0XK0000000000.   Shell: bash 5.1.16 
:oooool;,;OKdddddddddddKX000000000d   Resolution: 1366x768 
lllllool;lNdllllllllllldNK000000000   Terminal: /dev/pts/1 
llllllllloMdcccccccccccoWK000000000   CPU: Intel Celeron N4020 (2) @ 2.800GHz 
;cllllllllXXc:::::::::c0X000000000d   GPU: Intel GeminiLake [UHD Graphics 600] 
.ccccllllllONkc;,,,;cxKK0000000000.   Memory: 2917MiB / 3805MiB 
 .cccccclllllxOOOOOOkxO0000000000;
  .:cccccccclllllllloO0000000OOO,                             
    ,:ccccccccclllcd0000OOOOOOl.                              
      '::cccccccccdOOOOOOOkx:.
        ..,::ccccxOOOkkko;.
            ..,:dOkxl:.


```


## Features

- Correct ASCII art
- Version number

## Issues

- None

## TODO

- Get proper model name (Dell Chromebook 3100) instead of board name (Fleex)?