### PR TITLE
Fix windows detection to match version

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1101,14 +1101,34 @@ get_distro() {
                 fi
             fi
 
+            # Gets the windows tag caption (ie `Microsoft Windows 11 Pro Insider Preview`)
+            #
+            # Then removes the `Microsoft` and `Windows` part and gets the current
+            # version of Windows (old code reported Windows 10 even if host runs Windows 11).
+            #
+            # Finally, we decline it in three versions :
+            #
+            # - The `on`   version (ie `[Windows 11.0.25330]`)
+            # - The `tiny` version (ie `Windows 11`)
+            # - The `any`  version (ie `on Windows 11 Pro Insider Preview`)
             if [[ $(< /proc/version) == *Microsoft* || $kernel_version == *Microsoft* ]]; then
-                windows_version=$(wmic.exe os get Version)
-                windows_version=$(trim "${windows_version/Version}")
+
+                windows_version_verbose=$(wmic.exe os get Caption)
+                windows_version_verbose=$(trim "${windows_version_verbose/Caption}")
+                windows_version_verbose=$(trim "${windows_version_verbose/Microsoft}")
+                windows_version_verbose=$(trim "${windows_version_verbose/Windows}")
+
+                windows_version_current=${windows_version_verbose//[^[:digit:]]/}
+
+                windows_version_number_long=$(wmic.exe os get Version)
+                windows_version_number_long=$(trim "${windows_version_number_long/Version}")
+                windows_version_number_long=$(trim "${windows_version_number_long}")
+                windows_version_number_long="${windows_version_current}${windows_version_number_long:2}"
 
                 case $distro_shorthand in
-                    on)   distro+=" [Windows $windows_version]" ;;
-                    tiny) distro="Windows ${windows_version::2}" ;;
-                    *)    distro+=" on Windows $windows_version" ;;
+                    on)   distro+=" [Windows $windows_version_number_long]" ;;
+                    tiny) distro=" Windows $windows_version_current" ;;
+                    *)    distro+=" on Windows $windows_version_verbose" ;;
                 esac
 
             elif [[ $(< /proc/version) == *chrome-bot* || -f /dev/cros_ec ]]; then


### PR DESCRIPTION
## Description

This PR fixes the wrong windows version displayed when host uses **Windows 11**.
>⚠️ Only tested in WSL2 using Debian, not in Windows itself ⚠️

Thanks to @Kwaay for issuing this bug to me and helping me fixing it.

### Reason
This bug was caused by neofetch using the command
```sh
wmic.exe os get Version
```
to get the OS version. But this prompt returns
```
Version
10.0.25330
```
even if I am using Windows 11. (my build version is `25330`, so it is fine).

You can see a comparison here :
![image](https://user-images.githubusercontent.com/22714562/229350869-afefbd02-547d-41bc-a814-e14481d1c6a6.png)

But if we use the command
```sh
wmic.exe os get Caption
```
to get the OS version, we get 
```
Caption
Microsoft Windows 11 Pro Insider Preview
```
So using this we lose the build number, but we get the correct OS version.

### Before (See OS section)
| `distro_shorthand` value | result                                                                                                          |
|--------------------------|-----------------------------------------------------------------------------------------------------------------|
| `on`                     | ![image](https://user-images.githubusercontent.com/22714562/229350534-8895941b-171e-4b6d-9b9b-19b8c6dab1d2.png) |
| `tiny`                   | ![image](https://user-images.githubusercontent.com/22714562/229350544-328ce8ec-4f11-450c-807e-b8a378868dfe.png) |
| `*`                      | ![image](https://user-images.githubusercontent.com/22714562/229350549-38ce0d02-bcb0-4ad9-836e-4531649feb87.png) |



### After (See OS section)
| `distro_shorthand` value | result                                                                                                          |
|--------------------------|-----------------------------------------------------------------------------------------------------------------|
| `on`                     | ![image](https://user-images.githubusercontent.com/22714562/229350631-58d19241-5861-4b60-b419-8682043c88b7.png) |
| `tiny`                   | ![image](https://user-images.githubusercontent.com/22714562/229350637-57abf22f-72ac-4fda-a3b5-9bdde2f39b20.png) |
| `*`                      | ![image](https://user-images.githubusercontent.com/22714562/229350645-8c644b5c-2e0f-450a-8223-b1df0cb580f5.png) |


## Features
- Add Windows 11 support

## Issues
- None

## TODO
- [X] Test those changes in WSL2 using Windows 11.
- [ ] Test those changes in WSL1 using Windows 11.
- [ ] Test those changes in Windows 11 itself (not inside a WSL machine).
- [x] Test those changes in WSL2 using Windows 10.
- [ ] Test those changes in WSL1 using Windows 10.
- [ ] Test those changes in Windows 10 itself (not inside a WSL machine).

Unfortunatly I cannot perform tests on other WSLs versions, nor in a Windows 10 machine, but I hope someone can ! 🤞 