### PR TITLE
Fixed unnecessary 'with Radeon Graphics' not removing properly

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2450,6 +2450,7 @@ get_cpu() {
     cpu="${cpu//Core / }"
     cpu="${cpu//(\"AuthenticAMD\"*)}"
     cpu="${cpu//with Radeon * Graphics}"
+    cpu="${cpu//with Radeon Graphics}"
     cpu="${cpu//, altivec supported}"
     cpu="${cpu//FPU*}"
     cpu="${cpu//Chip Revision*}"


### PR DESCRIPTION
## Description

Only fill in the fields below if relevant.


## Features
Added a line to remove unnecessary stuff in CPU name.
cpu="${cpu//with Radeon Graphics}"
Previously, this line didn't remove 'with Radeon Graphics' in the CPU name:
cpu="${cpu//with Radeon * Graphics}"

## Issues

## TODO
