### PR TITLE
Local IP: fix detection on macOS

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3877,7 +3877,7 @@ get_local_ip() {
 
         "Mac OS X" | "macOS" | "iPhone OS")
             if [[ "${local_ip_interface[0]}" == "auto" ]]; then
-                interface="$(route get 1 | awk -F': ' '/interface/ {printf $2; exit}')"
+                interface="$(route get 0 | awk -F': ' '/interface/ {printf $2; exit}')"
                 local_ip="$(ipconfig getifaddr "$interface")"
             else
                 for interface in "${local_ip_interface[@]}"; do


### PR DESCRIPTION
`route get 0` reports `interface: utun3` on my machine

According to https://apple.stackexchange.com/a/310221, this is the default behavior on macOS Sierra and later

Use `0.0.0.0` instead

```
bash-5.2$ route get 1
   route to: 0.0.0.1
destination: default
       mask: 128.0.0.0
    gateway: 192.168.12.1
  interface: utun3
      flags: <UP,GATEWAY,DONE,STATIC,PRCLONING,GLOBAL>
 recvpipe  sendpipe  ssthresh  rtt,msec    rttvar  hopcount      mtu     expire
       0         0         0         0         0         0      1500         0
bash-5.2$ ipconfig getifaddr "utun3"
bash-5.2$ route get 0
   route to: default
destination: default
       mask: default
    gateway: 10.62.96.1
  interface: en0
      flags: <UP,GATEWAY,DONE,STATIC,PRCLONING,GLOBAL>
 recvpipe  sendpipe  ssthresh  rtt,msec    rttvar  hopcount      mtu     expire
       0         0         0         0         0         0      1500         0
bash-5.2$ ipconfig getifaddr "en0"
10.62.99.219
bash-5.2$```