### PR TITLE
LocalIP (macOS): improve detection

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3878,10 +3878,10 @@ get_local_ip() {
         "Mac OS X" | "macOS" | "iPhone OS")
             if [[ "${local_ip_interface[0]}" == "auto" ]]; then
                 interface="$(route get 1 | awk -F': ' '/interface/ {printf $2; exit}')"
-                local_ip="$(ipconfig getifaddr "$interface")"
+                local_ip="$(ifconfig "$interface" | grep "inet " | awk '{print $2}')"
             else
                 for interface in "${local_ip_interface[@]}"; do
-                    local_ip="$(ipconfig getifaddr "$interface")"
+                    local_ip="$(ifconfig "$interface" | grep "inet " | awk '{print $2}')"
                     if [[ -n "$local_ip" ]]; then
                         prin "$interface" "$local_ip"
                     else


### PR DESCRIPTION
When a VPN session is enabled, the default route interface is changed to `utun*`, however `ipconfig` doesn't support it for some reason

Use `ifconfig` instead

---

![image](https://github.com/dylanaraps/neofetch/assets/6134068/a0a72e02-d9a6-422e-bfc7-63af4fe2444a)
