### PR TITLE
Fix LMDE ASCII art.

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -8349,7 +8349,7 @@ EOF
         "LMDE"*)
             set_colors 2 7
             read -rd '' ascii_data <<'EOF'
-         ${c2}`.-::---..
+${c2}          `${c1}.-::---..
 ${c1}      .:++++ooooosssoo:.
     .+o++::.      `.:oos+.
 ${c1}   :oo:.`             -+oo${c2}:


### PR DESCRIPTION
## Description

Fix the first line of the LMDE Ascii Art, which is not aligned with the rest of the logo.

## Features

## Issues

## TODO
