### PR TITLE
No Hackintosh check on arm64

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1257,7 +1257,7 @@ get_model() {
         ;;
 
         "Mac OS X"|"macOS")
-            if [[ $(kextstat | grep -F -e "FakeSMC" -e "VirtualSMC") != "" ]]; then
+            if [ "$(arch)" != "arm64" ] && [[ $(kextstat | grep -F -e "FakeSMC" -e "VirtualSMC") != "" ]]; then
                 model="Hackintosh (SMBIOS: $(sysctl -n hw.model))"
             else
                 model=$(sysctl -n hw.model)

--- a/neofetch
+++ b/neofetch
@@ -3384,12 +3384,7 @@ END
             # See: https://groups.google.com/forum/#!topic/iterm2-discuss/0tO3xZ4Zlwg
             local current_profile_name profiles_count profile_name diff_font
 
-            current_profile_name="$(osascript <<END
-                                    tell application "iTerm2" to profile name \
-                                    of current session of current window
-END
-)"
-
+            current_profile_name=$ITERM_PROFILE
             # Warning: Dynamic profiles are not taken into account here!
             # https://www.iterm2.com/documentation-dynamic-profiles.html
             font_file="${HOME}/Library/Preferences/com.googlecode.iterm2.plist"


### PR DESCRIPTION
## Description

Only fill in the fields below if relevant.


## Features

## Issues

Hackintosh detection works by grepping a list of all loaded kexts, which takes a while to load. Skipping this check on ARM processors (on which Hackintoshing is currently impossible) noticeably improves performance (about 150ms on M2 Pro).

## TODO
