### PR TITLE
Fix macOS Ventura and Montery not showing codenames

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1155,6 +1155,8 @@ get_distro() {
                 10.16*) codename="macOS Big Sur" ;;
                 11.*)  codename="macOS Big Sur" ;;
                 12.*)  codename="macOS Monterey" ;;
+                13.*)  codename="macOS Ventura" ;;
+                14.*)  codename="macOS Sonoma" ;;
                 *)      codename=macOS ;;
             esac
 


### PR DESCRIPTION
## Description

Only fill in the fields below if relevant.


## Features
Codenames for macOS vesions 13 and 14 added.

## Issues

## TODO
