### PR TITLE
Resolution: don't display disabled resolutions

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -3107,9 +3107,10 @@ get_resolution() {
                 resolution="$(xdpyinfo | awk '/dimensions:/ {printf $2}')"
 
             elif [[ -d /sys/class/drm ]]; then
-                for dev in /sys/class/drm/*/modes; do
-                    read -r single_resolution _ < "$dev"
+                for dev in /sys/class/drm/*; do
+                    [[ $(<"$dev/enabled") != "enabled" ]] && continue
 
+                    read -r single_resolution _ < "$dev/modes"
                     [[ $single_resolution ]] && resolution="${single_resolution}, ${resolution}"
                 done
             fi


### PR DESCRIPTION
Before:

<img width="1437" alt="image" src="https://github.com/dylanaraps/neofetch/assets/6134068/b3e7b6b0-54ed-4178-898c-cd0eea329749">

After:

<img width="816" alt="image" src="https://github.com/dylanaraps/neofetch/assets/6134068/f94ec23f-171d-437e-b2c1-227d263954e5">

This issue affects both tty and wayland.

Note this method reports preferred / maximum resolution instead of current resolution as I said before. I highly recommand https://github.com/dylanaraps/neofetch/pull/2395 if you use wayland