### PR TITLE
Fix get_full_path for paths with complex filenames (e.g. files in the nix store)

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -4751,23 +4751,26 @@ get_full_path() {
     # If the file exists in the current directory, stop here.
     [[ -f "${PWD}/${1}" ]] && { printf '%s\n' "${PWD}/${1}"; return; }
 
-    ! cd "${1%/*}" && {
-        err "Error: Directory '${1%/*}' doesn't exist or is inaccessible"
+    # Extract the directory path and filename
+    local dir_path="${1%/*}"
+    local file_name="${1##*/}"
+
+    # Change directory to the path (if it exists)
+    ! cd "$dir_path" && {
+        err "Error: Directory '$dir_path' doesn't exist or is inaccessible"
         err "       Check that the directory exists or try another directory."
         exit 1
     }
 
-    local full_dir="${1##*/}"
-
     # Iterate down a (possible) chain of symlinks.
-    while [[ -L "$full_dir" ]]; do
-        full_dir="$(readlink "$full_dir")"
-        cd "${full_dir%/*}" || exit
-        full_dir="${full_dir##*/}"
+    while [[ -L "$file_name" ]]; do
+        file_name="$(readlink "$file_name")"
+        cd "${file_name%/*}" || exit
+        file_name="${file_name##*/}"
     done
 
     # Final directory.
-    full_dir="$(pwd -P)/${1/*\/}"
+    local full_dir="$(pwd -P)/$file_name"
 
     [[ -e "$full_dir" ]] && printf '%s\n' "$full_dir"
 }


### PR DESCRIPTION

## Description

I encountered a problem with neofetch on my NixOS system:
Images located in the nix store have the following path format: `/nix/store/1ayxpfhvvhq1c454acsgf4vb84m5mnr4-hm_image.png`.
The current implementation of the `get_full_path` method resolved this path incorrectly to `/nix/store/hm_image.png`.
On my system, I put the image in `/home/usersname/Pictures/image.png` which is a symlink pointing to the original file in the nix store.
So when I call `neofetch --kitty /home/usersname/Pictures/image.png` it would fall back to the default ASCII art (because it can't locate the non-existing path).
This PR fixes the incorrect path resolution -- tested on my system.
I assume this issue might also occur on other systems with complex filenames.

## Features

## Issues

## TODO
