### PR TITLE
Improve wayland wm detection

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1899,9 +1899,9 @@ get_wm() {
     esac
 
     if [[ -O "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}" ]]; then
-        if tmp_pid="$(lsof -t "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}" 2>&1)" ||
-           tmp_pid="$(fuser   "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}" 2>&1)"; then
-            wm="$(ps -p "${tmp_pid}" -ho comm=)"
+        if tmp_pid="$(lsof -t "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}" 2>/dev/null)" ||
+           tmp_pid="$(fuser   "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}" 2>/dev/null)"; then
+            wm="$(ps -p ${tmp_pid} -ho comm=)"
         else
             # lsof may not exist, or may need root on some systems. Similarly fuser.
             # On those systems we search for a list of known window managers, this can mistakenly


### PR DESCRIPTION
## Description

On my arch system running the river wm, get_wm wasn't working.

First off, I'd had no reason to install lsof as yet, having only fuser.

Next up the output of fuser was way more than the expected "just a pid": it included a bunch of permission denied entries while enumerating all non-user procs, and also some extra whitespace around the output pid, which was interacting poorly with the defensive quoting inside the sub-shell expansion of $tmp_pid.

## TODO

- [ ] maybe add river to the guess branch when using neither lsof nor fuser?