### PR TITLE
Fedora immutable

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -820,6 +820,9 @@ image_source="auto"
 #       Slackware, SunOS, LinuxLite, OpenSUSE, Raspbian,
 #       postmarketOS, and Void have a smaller logo variant.
 #       Use '{distro name}_small' to use the small variants.
+# NOTE: Fedora has immutable spins with unique logos (except Onyx).
+#       Change this to Silverblue, Kinoite, Sericea, or CoreOS to use the spins.
+
 ascii_distro="auto"
 
 # Ascii Colors
@@ -1134,6 +1137,19 @@ get_distro() {
                     *"Lubuntu"*)  distro=${distro/Ubuntu/Lubuntu} ;;
                     *"budgie"*)   distro=${distro/Ubuntu/Ubuntu Budgie} ;;
                     *"cinnamon"*) distro=${distro/Ubuntu/Ubuntu Cinnamon} ;;
+                esac
+            fi
+
+            # Get Fedora immutable spin.
+            if [[ $distro == "Fedora"* ]]; then
+                case $VARIANT in
+                    "CoreOS" | "Kinoite" | "Sericea" | "Silverblue")
+                        case $distro_shorthand in
+                            on)   distro="Fedora $VARIANT $VERSION_ID" ;;
+                            tiny) distro="$VARIANT";;
+                            *)    distro="Fedora $VARIANT $OSTREE_VERSION" ;;
+                        esac
+                        ;;
                 esac
             fi
         ;;
@@ -5187,6 +5203,11 @@ ASCII:
 
                                 NOTE: Use '{distro name}_small' to use the small variants.
 
+                                NOTE: Fedora has immutable spins with unique logos (except Onyx).
+
+                                NOTE: Change this to Silverblue, Kinoite, Sericea, or CoreOS to use
+                                the spins.
+
     --ascii_bold on/off         Whether or not to bold the ascii logo.
     -L, --logo                  Hide the info text and only show the ascii logo.
 
@@ -7436,6 +7457,76 @@ ${c1}          /:-------------:\\
 :---${c2}:sdNMMMMNds:${c1}------------:
 :------${c2}:://:${c1}-------------::
 :---------------------://
+EOF
+        ;;
+
+        "Fedora Silverblue" | "Silverblue"*)
+            set_colors 4 7 12
+            read -rd '' ascii_data <<'EOF'
+${c1}    .;ooooooooooooooooooooooooooo.
+${c1}  ,dddddddddddddddddddddddddddddd'${c3};
+${c1} lddddddddddddddddddddddddddddd'${c3};;;
+${c1}ddddd${c2},XXX.${c1}ddddd${c2},XXX.${c1}dddd'${c2},XXX.${c3};;;;;
+${c1}ddddd${c2}XX${c1}x${c2}XX${c1}ddddd${c2}XX${c1}x${c2}XX${c1}ddd'${c2},XX${c3}x${c2}XX${c3};;;;;
+${c1}ddddd${c2}'XXX'${c1}ddddd${c2}'XXX'${c1}dd'${c2}XXXXXX'${c3};;;;;
+${c1}dddddd${c2};X;${c1}ddddddd${c2};X:${c1}d'${c2}XXX${c3};;;;;;;;;;;
+${c1}dddddd${c2};X;${c1}ddddddd${c2};X:${c2}XXX${c3};;;;;;;;;;;;;
+${c1}dddddd${c2};X;${c1}dddddd'${c2};XXX,,,,,,XXX.${c3};;;;;
+${c1}dddddd${c2};X;${c1}dddd'${c2}XXXX${c2}XXXXXXXXX${c3}x${c2}XX${c3};;;;;
+${c1}dddddd${c2};X;${c1}dd'${c2}XXX${c3};;;;;;;;;;;${c2}XXX${c3};;;;;;
+${c1}dddddd${c2};X;${c1}'${c2}XXX${c3};;;;;;;;;;;;;;;;;;;;;;
+${c1}dddddd${c2};XXXXX,,,,,,,,,,,,,;XXX:${c3};;;;;
+${c1}dddddd${c2}:XXXXXXXXXXXXXXXXXXXX${c3}x${c2}XX${c3};;;;;
+${c1}ddddd'${c3};;;;;;;;;;;;;;;;;;;${c2}'XXX'${c3};;;;'
+${c1}ddd'${c3};;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+${c1}o'${c3};;;;;;;;;;;;;;;;;;;;;;;;;;;;'
+EOF
+        ;;
+
+        "Fedora Kinoite"* | "Kinoite"*)
+            set_colors 12 7
+            read -rd '' ascii_data <<'EOF'
+${c1} ,clll:.${c2}          .,::::::::::::'
+${c1}:ooooooo${c2}        .;::::::::::::::
+${c1}looooooo${c2}       ,:::::::::::::::'
+${c1}looooooo${c2}      .::::::::::::::::
+${c1}looooooo${c2}      ;:::::::::::::::.
+${c1}looooooo${c2}     .::::::::::::::::
+${c1}looooool${c2};;;;,::::::::::::::::
+${c1}looool${c2}::,   .::::::::::::::
+${c1}looooc${c2}::     ;::
+${c1}looooc${c2}::;.  .::;
+${c1}loooool${c2}:::::::::::.
+${c1}looooooo${c2}.    .::::::'
+${c1}looooooo${c2}       .::::::,;,..
+${c1}looooooo${c2}          :::;' ';:;.
+${c1}looooooo${c2}          :::     :::
+${c1}cooooooo${c2}          .::'   '::.
+ ${c1}.ooooc ${c2}            ::, ,::
+                      ''''
+EOF
+        ;;
+
+        "Fedora Sericea"* | "Sericea"*)
+            set_colors 12 7
+            read -rd '' ascii_data <<'EOF'
+${c1}              :oooo,  .','
+      .';;;.;oooooooolooooo'
+     coooooooooooooooooooooooolc'
+  .':oooooooooooo${c2}ll${c1}ooooooooooooool
+.oooooooooooooooo${c2}ll${c1}oooooooooooo${c2}l${c1}ool
+ooooooooooooooooo${c2}ll${c1}ooooooooooo${c2}ll${c1}oo'
+ oooo${c2}l${c1}oooooooooo${c2}lll${c1}ooooooooo${c2}lll${c1}oo
+ .ooooo${c2}lll${c1}ooooo${c2}lll${c1}ooooooooo${c2}lll${c1}ool
+ .ooooooo${c2}lll${c1}oo${c2}llll${c1}oooo${c2}lllll${c1}ooooo:
+  'oooooooo${c2}llllllllllll${c1}oooooooo'
+     .c,.oo${c2}lllll${c1}oooooooo.${c2}
+           'll;
+           'll.
+           lll
+           lll
+          ;ll,
+          .l:
 EOF
         ;;
 

--- a/neofetch
+++ b/neofetch
@@ -5552,15 +5552,15 @@ h//NNNNh  ossss` +h  md- .hm/ `sNNNNN:+y
 EOF
         ;;
 
-	"Aperio GNU/Linux"*)
-	    set_colors 255
-	    read -rd '' ascii_data <<'EOF'
+    "Aperio GNU/Linux"*)
+        set_colors 255
+        read -rd '' ascii_data <<'EOF'
 ${c2}
  _.._  _ ._.. _
 (_][_)(/,[  |(_)
    |   GNU/Linux
 EOF
-	;;
+    ;;
 
         "Hash"*)
             set_colors 123

--- a/neofetch
+++ b/neofetch
@@ -786,7 +786,7 @@ image_source="auto"
 #       Artix, Arya, Bedrock, Bitrig, BlackArch, BLAG, BlankOn, BlueLight,
 #       Bodhi, bonsai, BSD, BunsenLabs, Calculate, Carbs, CentOS, Chakra, ChaletOS,
 #       Chapeau, Chrom*, Cleanjaro, ClearOS, Clear_Linux, Clover, Condres,
-#       Container_Linux, Crystal Linux, CRUX, Cucumber, dahlia, Debian, Deepin,
+#       CoreOS, Crystal Linux, CRUX, Cucumber, dahlia, Debian, Deepin,
 #       DesaOS, Devuan, DracOS, DarkOs, Itc, DragonFly, Drauger, Elementary,
 #       EndeavourOS, Endless, EuroLinux, Exherbo, Fedora, Feren, FreeBSD,
 #       FreeMiNT, Frugalware, Funtoo, GalliumOS, Garuda, Gentoo, Pentoo,
@@ -5145,8 +5145,6 @@ ASCII:
                                 XFerience, ArchMerge, Arch, Artix, Arya, Bedrock, Bitrig,
                                 BlackArch, BLAG, BlankOn, BlueLight, Bodhi, bonsai, BSD, BunsenLabs,
                                 Calculate, Carbs, CentOS, Chakra, ChaletOS, Chapeau, Chrom,
-                                Cleanjaro, ClearOS, Clear_Linux, Clover, Condres, Container_Linux,
-                                Crystal Linux, CRUX, Cucumber, dahlia, Debian, Deepin, DesaOS, Devuan,
                                 DracOS, DarkOs, Itc, DragonFly, Drauger, Elementary, EndeavourOS, Endless,
                                 EuroLinux, Exherbo, Fedora, Feren, FreeBSD, FreeMiNT, Frugalware,
                                 Funtoo, GalliumOS, Garuda, Gentoo, Pentoo, gNewSense, GNOME, GNU,
@@ -5165,6 +5163,8 @@ ASCII:
                                 SereneLinux, SharkLinux, Siduction, Slackware, SliTaz, SmartOS,
                                 Solus, Source_Mage, Sparky, Star, SteamOS, SunOS, openSUSE_Leap,
                                 t2, openSUSE_Tumbleweed, openSUSE, SwagArch, Tails, Trisquel,
+                                Cleanjaro, ClearOS, Clear_Linux, Clover, Condres, CoreOS, Crystal
+                                Linux, CRUX, Cucumber, dahlia, Debian, Deepin, DesaOS, Devuan,
                                 Ubuntu-Cinnamon, Ubuntu-Budgie, Ubuntu-GNOME, Ubuntu-MATE,
                                 Ubuntu-Studio, Ubuntu, Univention, Venom, Void, VNux, LangitKetujuh, semc,
                                 Obarun, windows10, Windows7, Xubuntu, Zorin, and IRIX have ascii logos.
@@ -6862,7 +6862,7 @@ ${c2}:sssssssssssso++${c1}${c3}`:/:--------.````````
 EOF
         ;;
 
-        "Container Linux by CoreOS"* | "Container_Linux"*)
+        "Container Linux by CoreOS"* | "Container_Linux"* | "Fedora CoreOS" | "CoreOS"*)
             set_colors 4 7 1
             read -rd '' ascii_data <<'EOF'
 ${c1}                .....

--- a/neofetch
+++ b/neofetch
@@ -791,7 +791,7 @@ image_source="auto"
 #       EndeavourOS, Endless, EuroLinux, Exherbo, Fedora, Feren, FreeBSD,
 #       FreeMiNT, Frugalware, Funtoo, GalliumOS, Garuda, Gentoo, Pentoo,
 #       gNewSense, GNOME, GNU, GoboLinux, Grombyang, Guix, Haiku, Huayra, HydroOS
-#       Hyperbola, iglunix, janus, Kali, KaOS, KDE_neon, Kibojoe, Kogaion, Korora,
+#       Hyperbola, iglunix, janus, Kali, KaOS, KDE_neon, Kibojoe, Kinoite, Kogaion, Korora,
 #       KSLinux, Kubuntu, LEDE, LaxerOS, LibreELEC, LFS, Linux_Lite, LMDE,
 #       Lubuntu, Lunar, macos, Mageia, MagpieOS, Mandriva, Manjaro, TeArch, Maui,
 #       Mer, Minix, LinuxMint, Live_Raizo, MX_Linux, Namib, Neptune, NetBSD,
@@ -802,9 +802,9 @@ image_source="auto"
 #       Proxmox, PuffOS, Puppy, PureOS, Qubes, Qubyt, Quibian, Radix, Raspbian,
 #       Reborn_OS, Redstar, Redcore, Redhat, Refracted_Devuan, Regata, Regolith,
 #       Rocky, Rosa, sabotage, Sabayon, Sailfish, SalentOS, Scientific, Septor,
-#       SereneLinux, SharkLinux, Siduction, SkiffOS, Slackware, SliTaz, SmartOS,
-#       Solus, Source_Mage, Sparky, Star, SteamOS, SunOS, openSUSE_Leap, t2,
-#       openSUSE_Tumbleweed, openSUSE, SwagArch, Tails, Trisquel,
+#       SereneLinux, Sericea, SharkLinux, Siduction, Silverblue,  SkiffOS, Slackware,
+#       SliTaz, SmartOS, Solus, Source_Mage, Sparky, Star, SteamOS, SunOS, openSUSE_Leap,
+#       t2, openSUSE_Tumbleweed, openSUSE, SwagArch, Tails, Trisquel,
 #       Ubuntu-Cinnamon, Ubuntu-Budgie, Ubuntu-GNOME, Ubuntu-MATE,
 #       Ubuntu-Studio, Ubuntu, Univention, Venom, Void, VNux, LangitKetujuh, semc,
 #       Obarun, windows10, Windows7, Xubuntu, Zorin, and IRIX have ascii logos.
@@ -5161,31 +5161,34 @@ ASCII:
                                 XFerience, ArchMerge, Arch, Artix, Arya, Bedrock, Bitrig,
                                 BlackArch, BLAG, BlankOn, BlueLight, Bodhi, bonsai, BSD, BunsenLabs,
                                 Calculate, Carbs, CentOS, Chakra, ChaletOS, Chapeau, Chrom,
-                                DracOS, DarkOs, Itc, DragonFly, Drauger, Elementary, EndeavourOS, Endless,
-                                EuroLinux, Exherbo, Fedora, Feren, FreeBSD, FreeMiNT, Frugalware,
-                                Funtoo, GalliumOS, Garuda, Gentoo, Pentoo, gNewSense, GNOME, GNU,
-                                GoboLinux, Grombyang, Guix, Haiku, Huayra, Hyperbola, iglunix, janus, Kali,
-                                KaOS, KDE_neon, Kibojoe, Kogaion, Korora, KSLinux, Kubuntu, LEDE,
-                                LaxerOS, LibreELEC, LFS, Linux_Lite, LMDE, Lubuntu, Lunar, macos,
-                                Mageia, MagpieOS, Mandriva, Manjaro, TeArch, Maui, Mer, Minix, LinuxMint,
-                                Live_Raizo, MX_Linux, Namib, Neptune, NetBSD, Netrunner, Nitrux,
-                                NixOS, Nurunner, NuTyX, OBRevenge, OpenBSD, openEuler, OpenIndiana,
-                                openmamba, OpenMandriva, OpenStage, OpenWrt, osmc, Oracle,
-                                OS Elbrus, PacBSD, Parabola, Pardus, Parrot, Parsix, TrueOS,
-                                PCLinuxOS, Pengwin, Peppermint, Pisi, popos, Porteus, PostMarketOS,
-                                Proxmox, PuffOS, Puppy, PureOS, Qubes, Qubyt, Quibian, Radix, Raspbian, Reborn_OS,
-                                Redstar, Redcore, Redhat, Refracted_Devuan, Regata, Regolith, Rosa,
-                                sabotage, Sabayon, Sailfish, SalentOS, Scientific, Septor,
-                                SereneLinux, SharkLinux, Siduction, Slackware, SliTaz, SmartOS,
-                                Solus, Source_Mage, Sparky, Star, SteamOS, SunOS, openSUSE_Leap,
-                                t2, openSUSE_Tumbleweed, openSUSE, SwagArch, Tails, Trisquel,
                                 Cleanjaro, ClearOS, Clear_Linux, Clover, Condres, CoreOS, Crystal
                                 Linux, CRUX, Cucumber, dahlia, Debian, Deepin, DesaOS, Devuan,
+                                DracOS, DarkOs, Itc, DragonFly, Drauger, Elementary, EndeavourOS,
+                                Endless, EuroLinux, Exherbo, Fedora, Feren, FreeBSD, FreeMiNT,
+                                Frugalware, Funtoo, GalliumOS, Garuda, Gentoo, Pentoo, gNewSense,
+                                GNOME, GNU, GoboLinux, Grombyang, Guix, Haiku, Huayra, Hyperbola,
+                                iglunix, janus, Kali, KaOS, KDE_neon, Kibojoe, Kinoite, Kogaion,
+                                Korora, KSLinux, Kubuntu, LEDE, LaxerOS, LibreELEC, LFS, Linux_Lite,
+                                LMDE, Lubuntu, Lunar, macos, Mageia, MagpieOS, Mandriva, Manjaro,
+                                TeArch, Maui, Mer, Minix, LinuxMint, Live_Raizo, MX_Linux, Namib,
+                                Neptune, NetBSD, Netrunner, Nitrux, NixOS, Nurunner, NuTyX,
+                                OBRevenge, OpenBSD, openEuler, OpenIndiana, openmamba, OpenMandriva,
+                                OpenStage, OpenWrt, osmc, Oracle, OS Elbrus, PacBSD, Parabola,
+                                Pardus, Parrot, Parsix, TrueOS, PCLinuxOS, Pengwin, Peppermint,
+                                Pisi, popos, Porteus, PostMarketOS, Proxmox, PuffOS, Puppy, PureOS,
+                                Qubes, Qubyt, Quibian, Radix, Raspbian, Reborn_OS, Redstar, Redcore,
+                                Redhat, Refracted_Devuan, Regata, Regolith, Rosa, sabotage, Sabayon,
+                                Sailfish, SalentOS, Scientific, Septor, SereneLinux, Sericea,
+                                SharkLinux, Siduction, Silverblue, Slackware, SliTaz,SmartOS,
+                                Solus, Source_Mage, Sparky, Star, SteamOS, SunOS, openSUSE_Leap, t2,
+                                openSUSE_Tumbleweed, openSUSE, SwagArch, Tails, Trisquel,
                                 Ubuntu-Cinnamon, Ubuntu-Budgie, Ubuntu-GNOME, Ubuntu-MATE,
-                                Ubuntu-Studio, Ubuntu, Univention, Venom, Void, VNux, LangitKetujuh, semc,
-                                Obarun, windows10, Windows7, Xubuntu, Zorin, and IRIX have ascii logos.
+                                Ubuntu-Studio, Ubuntu, Univention, Venom, Void, VNux, LangitKetujuh,
+                                semc, Obarun, windows10, Windows7, Xubuntu, Zorin, and IRIX have
+                                ascii logos.
 
-                                NOTE: Arch, Ubuntu, Redhat, Fedora and Dragonfly have 'old' logo variants.
+                                NOTE: Arch, Ubuntu, Redhat, Fedora and Dragonfly have 'old' logo
+                                variants.
 
                                 NOTE: Use '{distro name}_old' to use the old logos.
 


### PR DESCRIPTION
Add detection of Fedora Immutable spins (CoreOS, Kinoite, Sericea, and Silverblue) and relevant ASCII logos.

Also fixes small formatting issues.