### PR TITLE
Fixed GPU not displaying in Haiku

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2647,7 +2647,7 @@ get_gpu() {
 
         "Haiku")
             gpu="$(listdev | grep -A2 -F 'device Display controller' |\
-                   awk -F':' '/device beef/ {print $2}')"
+                   awk -F':' '/device [^D]/ {print $2}')"
         ;;
 
         *)


### PR DESCRIPTION
## Description

* Fixed an issue for Haiku where it was only searching for a gpu that matched the VirtualBox display adapter ID.
