### PR TITLE
WIP: attempt to detect DE on remote sessions

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -1833,7 +1833,7 @@ get_de() {
             # the desktop variables are sometimes also set to the
             # window manager name. This checks to see if WM == DE
             # and discards the DE value.
-            [[ $de == "$wm" ]] && { unset -v de; return; }
+            [[ -n "$wm" && ( $de == "$wm" ) ]] && { unset -v de; return; }
         ;;
     esac
 
@@ -1841,9 +1841,19 @@ get_de() {
     [[ $DISPLAY && -z $de ]] && type -p xprop &>/dev/null && \
         de=$(xprop -root | awk '/KDE_SESSION_VERSION|^_MUFFIN|xfce4|xfce5/')
 
+    # Fallback to exploring displays with xprop for remote sessions.
+    if [[ -z $DISPLAY && -z $de ]]; then
+        for display in `seq 0 9`; do
+            type -p xprop &>/dev/null && \
+                de=$(xprop -display ":$display" -root | awk '/KDE_SESSION_VERSION|_KDE_NET_WM_|^_MUFFIN|xfce4|xfce5/')
+            [[ -n "$de" ]] && break
+        done
+    fi
+
     # Format strings.
     case $de in
         KDE_SESSION_VERSION*) de=KDE${de/* = } ;;
+        *_KDE_NET_WM_*) de=KDE ;;
         *xfce4*)  de=Xfce4 ;;
         *xfce5*)  de=Xfce5 ;;
         *xfce*)   de=Xfce ;;


### PR DESCRIPTION
## Description

When connecting with ssh to a machine that has an X11 session running, try to find which DISPLAY we can query.

## Features

It only detects the DE for now.

## Issues

The `KDE_SESSION_VERSION` property doesn't seem to exist on my session, so I had to check another one which doesn't mention the version.

## TODO

Reuse the found `DISPLAY` to detect other components?