### PR TITLE
Show commandline name instead of shortened command line

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -4943,7 +4943,7 @@ get_process_name() {
         ;;
 
         "Linux")
-            name="$(< "/proc/${1:-$PPID}/comm")"
+            name="$(< "/proc/${1:-$PPID}/cmdline")"
         ;;
 
         *)


### PR DESCRIPTION
/proc/pid/cmdline holds the complete command line for a process unlike /prod/pid/comm

The biggest difference when using cmdline vs comm is the following, when running an app via update-alternatives as done with Debian for example, you get the name x-terminal-emulator vs x-terminal-emul. Essentially, we want the full name of the process and not the shortened one.

This would allow for some more magic with which, readlink and basename that to get the actual name. However, readlink isn't available on all systems and some options aren't available on BSD systems. realpath might be used, but also that may not be available, which leaves us with implementing a bash only solution in case these do not exist. I've tried doing that with bash (via bats) in the past. Bats solved it doing it like this: https://github.com/bats-core/bats-core/pull/312

An alternative way is to ls the file /proc/id/exe and look at where this symlink is pointing to and basename that:

  $(basename ls -l /proc/2464281/exe | awk '{print $NF}')

